### PR TITLE
Update: added handler for AsExpression TS node.kind

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 npm-debug.log
 _test.js
 
+.idea

--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -1374,6 +1374,9 @@ module.exports = function(ast, extra) {
             case SyntaxKind.ParenthesizedExpression:
                 return convert(node.expression, parent);
 
+            case SyntaxKind.AsExpression:
+                return convert(node.expression, parent);
+
             default:
                 console.log(node.kind);
                 result = null;

--- a/tests/fixtures/ecma-features/typeHints/as-expression.result.js
+++ b/tests/fixtures/ecma-features/typeHints/as-expression.result.js
@@ -1,0 +1,174 @@
+module.exports = {
+    "type": "Program",
+    "range": [0, 51],
+    "loc": {
+        "start": {"line": 1, "column": 0},
+        "end": {"line": 1, "column": 51}
+    },
+    "body": [{
+        "type": "ExpressionStatement",
+        "range": [0, 7],
+        "loc": {
+            "start": {"line": 1, "column": 0},
+            "end": {"line": 1, "column": 7}
+        },
+        "expression": {
+            "type": "Identifier",
+            "range": [0, 1],
+            "loc": {
+                "start": {"line": 1, "column": 0},
+                "end": {"line": 1, "column": 1}
+            },
+            "name": "a"
+        }
+    }, {
+        "type": "ExpressionStatement",
+        "range": [7, 51],
+        "loc": {
+            "start": {"line": 1, "column": 7},
+            "end": {"line": 1, "column": 51}
+        },
+        "expression": {
+            "type": "MemberExpression",
+            "range": [7, 50],
+            "loc": {
+                "start": {"line": 1, "column": 7},
+                "end": {"line": 1, "column": 50}
+            },
+            "object": {
+                "type": "Identifier",
+                "range": [8, 12],
+                "loc": {
+                    "start": {"line": 1, "column": 8},
+                    "end": {"line": 1, "column": 12}
+                },
+                "name": "node"
+            },
+            "property": {
+                "type": "Identifier",
+                "range": [37, 50],
+                "loc": {
+                    "start": {"line": 1, "column": 37},
+                    "end": {"line": 1, "column": 50}
+                },
+                "name": "operatorToken"
+            },
+            "computed": false
+        }
+    }],
+    "sourceType": "script",
+    "tokens": [{
+        "type": "Identifier",
+        "value": "a",
+        "range": [0, 1],
+        "loc": {
+            "start": {"line": 1, "column": 0},
+            "end": {"line": 1, "column": 1}
+        }
+    }, {
+        "type": "Identifier",
+        "value": "as",
+        "range": [2, 4],
+        "loc": {
+            "start": {"line": 1, "column": 2},
+            "end": {"line": 1, "column": 4}
+        }
+    }, {
+        "type": "Identifier",
+        "value": "b",
+        "range": [5, 6],
+        "loc": {
+            "start": {"line": 1, "column": 5},
+            "end": {"line": 1, "column": 6}
+        }
+    }, {
+        "type": "Punctuator",
+        "value": ";",
+        "range": [6, 7],
+        "loc": {
+            "start": {"line": 1, "column": 6},
+            "end": {"line": 1, "column": 7}
+        }
+    }, {
+        "type": "Punctuator",
+        "value": "(",
+        "range": [7, 8],
+        "loc": {
+            "start": {"line": 1, "column": 7},
+            "end": {"line": 1, "column": 8}
+        }
+    }, {
+        "type": "Identifier",
+        "value": "node",
+        "range": [8, 12],
+        "loc": {
+            "start": {"line": 1, "column": 8},
+            "end": {"line": 1, "column": 12}
+        }
+    }, {
+        "type": "Identifier",
+        "value": "as",
+        "range": [13, 15],
+        "loc": {
+            "start": {"line": 1, "column": 13},
+            "end": {"line": 1, "column": 15}
+        }
+    }, {
+        "type": "Identifier",
+        "value": "ts",
+        "range": [16, 18],
+        "loc": {
+            "start": {"line": 1, "column": 16},
+            "end": {"line": 1, "column": 18}
+        }
+    }, {
+        "type": "Punctuator",
+        "value": ".",
+        "range": [18, 19],
+        "loc": {
+            "start": {"line": 1, "column": 18},
+            "end": {"line": 1, "column": 19}
+        }
+    }, {
+        "type": "Identifier",
+        "value": "BinaryExpression",
+        "range": [19, 35],
+        "loc": {
+            "start": {"line": 1, "column": 19},
+            "end": {"line": 1, "column": 35}
+        }
+    }, {
+        "type": "Punctuator",
+        "value": ")",
+        "range": [35, 36],
+        "loc": {
+            "start": {"line": 1, "column": 35},
+            "end": {"line": 1, "column": 36}
+        }
+    }, {
+        "type": "Punctuator",
+        "value": ".",
+        "range": [36, 37],
+        "loc": {
+            "start": {"line": 1, "column": 36},
+            "end": {"line": 1, "column": 37}
+        }
+    }, {
+        "type": "Identifier",
+        "value": "operatorToken",
+        "range": [37, 50],
+        "loc": {
+            "start": {"line": 1, "column": 37},
+            "end": {"line": 1, "column": 50}
+        }
+    }, {
+        "type": "Punctuator",
+        "value": ";",
+        "range": [50, 51],
+        "loc": {
+            "start": {"line": 1, "column": 50},
+            "end": {"line": 1, "column": 51}
+        }
+    }]
+}
+;

--- a/tests/fixtures/ecma-features/typeHints/as-expression.src.js
+++ b/tests/fixtures/ecma-features/typeHints/as-expression.src.js
@@ -1,0 +1,1 @@
+a as b;(node as ts.BinaryExpression).operatorToken;


### PR DESCRIPTION
In typescript you can give a hint to tsc about variable type
using keyword as

(node as ts.BinaryExpression).operatorToken;
currently it throws an exception