### PR TITLE
New: Implements JSX syntax (fixes #18)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "betarelease": "eslint-prerelease beta"
   },
   "dependencies": {
+    "lodash.unescape": "4.0.0",
     "object-assign": "^4.0.1"
   },
   "peerDependencies": {

--- a/parser.js
+++ b/parser.js
@@ -107,7 +107,14 @@ function parse(code, options) {
             commentAttachment.reset();
         }
 
-        var FILENAME = "eslint.ts";
+        if (options.ecmaFeatures && typeof options.ecmaFeatures === "object") {
+            // pass through jsx option
+            extra.ecmaFeatures.jsx = options.ecmaFeatures.jsx;
+        }
+
+        // Even if jsx option is set in typescript compiler, filename still has to
+        // contain .tsx file extension
+        var FILENAME = (extra.ecmaFeatures.jsx) ? "eslint.tsx" : "eslint.ts";
 
         var compilerHost = {
             fileExists: function() {

--- a/tests/lib/ecma-features.js
+++ b/tests/lib/ecma-features.js
@@ -43,12 +43,24 @@ var assert = require("chai").assert,
 var FIXTURES_DIR = "./tests/fixtures/ecma-features";
 // var FIXTURES_MIX_DIR = "./tests/fixtures/ecma-features-mix";
 
+var filesWithOutsandingTSIssues = [
+    "jsx/embedded-tags", // https://github.com/Microsoft/TypeScript/issues/7410
+    "jsx/namespaced-attribute-and-value-inserted", // https://github.com/Microsoft/TypeScript/issues/7411
+    "jsx/namespaced-name-and-attribute", // https://github.com/Microsoft/TypeScript/issues/7411
+    "jsx/test-content", // https://github.com/Microsoft/TypeScript/issues/7471
+    "jsx/multiple-blank-spaces"
+];
+
 var testFiles = shelljs.find(FIXTURES_DIR).filter(function(filename) {
     return filename.indexOf(".src.js") > -1;
+}).filter(function(filename) {
+    return filesWithOutsandingTSIssues.every(function(fileName) {
+        return filename.indexOf(fileName) === -1;
+    });
 }).map(function(filename) {
     return filename.substring(FIXTURES_DIR.length - 1, filename.length - 7);  // strip off ".src.js"
 }).filter(function(filename) {
-    return !(/jsx|error\-|invalid\-|globalReturn|experimental|newTarget/.test(filename));
+    return !(/error\-|invalid\-|globalReturn|experimental|newTarget/.test(filename));
 });
 
 // var moduleTestFiles = testFiles.filter(function(filename) {


### PR DESCRIPTION
@nzakas would be great to get your feedback on this!

**Note**: I added `lodash.unescape` as a dependency to ensure that HTML entities in JSX tags are decoded appropriately. Now that lodash is entirely modular, I felt that it was more prudent to include a micro-dependency than reinvent the wheel.