### PR TITLE
Fix: Remove console logging of node.kind (fixes #29)

### DIFF
--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -1552,7 +1552,6 @@ module.exports = function(ast, extra) {
                 return convert(node.expression, parent);
 
             default:
-                console.log("unsupported node.kind:", node.kind);
                 result = null;
         }
 


### PR DESCRIPTION
This was probably left behind during development as per discussion in
issue #29.