### PR TITLE
New: Add property decorators to AST (fixes #71)

### DIFF
--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -102,7 +102,7 @@ TOKEN_TO_TEXT[SyntaxKind.InKeyword] = "in";
  * @returns {boolean}      is valid ESTree class member
  */
 function isESTreeClassMember(node) {
-    return node.kind !== SyntaxKind.PropertyDeclaration && node.kind !== SyntaxKind.SemicolonClassElement;
+    return node.kind !== SyntaxKind.SemicolonClassElement;
 }
 
 /**
@@ -944,6 +944,19 @@ module.exports = function(ast, extra) {
                 } else {
                     return convertChild(node.expression);
                 }
+                break;
+
+            case SyntaxKind.PropertyDeclaration:
+                assign(result, {
+                    type: "ClassProperty",
+                    key: convertChild(node.name),
+                    value: convertChild(node.initializer),
+                    computed: (node.name.kind === SyntaxKind.ComputedPropertyName),
+                    static: Boolean(node.flags & ts.NodeFlags.Static),
+                    decorators: (node.decorators) ? node.decorators.map(function(d) {
+                        return convertChild(d.expression);
+                    }) : []
+                });
                 break;
 
             case SyntaxKind.GetAccessor:

--- a/tests/fixtures/typescript/decorators/property-decorators/property-decorator-factory-instance-member.result.js
+++ b/tests/fixtures/typescript/decorators/property-decorators/property-decorator-factory-instance-member.result.js
@@ -1,0 +1,644 @@
+module.exports = {
+    "type": "Program",
+    "range": [
+        0,
+        88
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 5,
+            "column": 1
+        }
+    },
+    "body": [
+        {
+            "type": "ClassDeclaration",
+            "range": [
+                0,
+                88
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 5,
+                    "column": 1
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    6,
+                    19
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 19
+                    }
+                },
+                "name": "SomeComponent"
+            },
+            "body": {
+                "type": "ClassBody",
+                "body": [
+                    {
+                        "computed": false,
+                        "decorators": [
+                            {
+                                "arguments": [],
+                                "callee": {
+                                    "loc": {
+                                        "end": {
+                                            "column": 10,
+                                            "line": 2
+                                        },
+                                        "start": {
+                                            "column": 5,
+                                            "line": 2
+                                        }
+                                    },
+                                    "name": "Input",
+                                    "range": [
+                                        27,
+                                        32
+                                    ],
+                                    "type": "Identifier"
+                                },
+                                "loc": {
+                                    "end": {
+                                        "column": 12,
+                                        "line": 2
+                                    },
+                                    "start": {
+                                        "column": 5,
+                                        "line": 2
+                                    }
+                                },
+                                "range": [
+                                    27,
+                                    34
+                                ],
+                                "type": "CallExpression"
+                            }
+                        ],
+                        "key": {
+                            "loc": {
+                                "end": {
+                                    "column": 17,
+                                    "line": 2
+                                },
+                                "start": {
+                                    "column": 13,
+                                    "line": 2
+                                }
+                            },
+                            "name": "data",
+                            "range": [
+                                35,
+                                39
+                            ],
+                            "type": "Identifier"
+                        },
+                        "loc": {
+                            "end": {
+                                "column": 18,
+                                "line": 2
+                            },
+                            "start": {
+                                "column": 4,
+                                "line": 2
+                            }
+                        },
+                        "range": [
+                            26,
+                            40
+                        ],
+                        "static": false,
+                        "type": "ClassProperty",
+                        "value": null
+                    },
+                    {
+                        "computed": false,
+                        "decorators": [
+                            {
+                                "arguments": [],
+                                "callee": {
+                                    "loc": {
+                                        "end": {
+                                            "column": 11,
+                                            "line": 3
+                                        },
+                                        "start": {
+                                            "column": 5,
+                                            "line": 3
+                                        }
+                                    },
+                                    "name": "Output",
+                                    "range": [
+                                        46,
+                                        52
+                                    ],
+                                    "type": "Identifier"
+                                },
+                                "loc": {
+                                    "end": {
+                                        "column": 13,
+                                        "line": 3
+                                    },
+                                    "start": {
+                                        "column": 5,
+                                        "line": 3
+                                    }
+                                },
+                                "range": [
+                                    46,
+                                    54
+                                ],
+                                "type": "CallExpression"
+                            }
+                        ],
+                        "key": {
+                            "loc": {
+                                "end": {
+                                    "column": 9,
+                                    "line": 4
+                                },
+                                "start": {
+                                    "column": 4,
+                                    "line": 4
+                                }
+                            },
+                            "name": "click",
+                            "range": [
+                                59,
+                                64
+                            ],
+                            "type": "Identifier"
+                        },
+                        "loc": {
+                            "end": {
+                                "column": 31,
+                                "line": 4
+                            },
+                            "start": {
+                                "column": 4,
+                                "line": 3
+                            }
+                        },
+                        "range": [
+                            45,
+                            86
+                        ],
+                        "static": false,
+                        "type": "ClassProperty",
+                        "value": {
+                            "arguments": [],
+                            "callee": {
+                                "loc": {
+                                    "end": {
+                                        "column": 28,
+                                        "line": 4
+                                    },
+                                    "start": {
+                                        "column": 16,
+                                        "line": 4
+                                    }
+                                },
+                                "name": "EventEmitter",
+                                "range": [
+                                    71,
+                                    83
+                                ],
+                                "type": "Identifier"
+                            },
+                            "loc": {
+                                "end": {
+                                    "column": 30,
+                                    "line": 4
+                                },
+                                "start": {
+                                    "column": 12,
+                                    "line": 4
+                                }
+                            },
+                            "range": [
+                                67,
+                                85
+                            ],
+                            "type": "NewExpression"
+                        }
+                    }
+                ],
+                "range": [
+                    20,
+                    88
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 20
+                    },
+                    "end": {
+                        "line": 5,
+                        "column": 1
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "class",
+            "range": [
+                0,
+                5
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "SomeComponent",
+            "range": [
+                6,
+                19
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 6
+                },
+                "end": {
+                    "line": 1,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                20,
+                21
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 20
+                },
+                "end": {
+                    "line": 1,
+                    "column": 21
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "@",
+            "range": [
+                26,
+                27
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Input",
+            "range": [
+                27,
+                32
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 5
+                },
+                "end": {
+                    "line": 2,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                32,
+                33
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 10
+                },
+                "end": {
+                    "line": 2,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                33,
+                34
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 11
+                },
+                "end": {
+                    "line": 2,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "data",
+            "range": [
+                35,
+                39
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 13
+                },
+                "end": {
+                    "line": 2,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                39,
+                40
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 17
+                },
+                "end": {
+                    "line": 2,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "@",
+            "range": [
+                45,
+                46
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 4
+                },
+                "end": {
+                    "line": 3,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Output",
+            "range": [
+                46,
+                52
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 5
+                },
+                "end": {
+                    "line": 3,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                52,
+                53
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 11
+                },
+                "end": {
+                    "line": 3,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                53,
+                54
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 12
+                },
+                "end": {
+                    "line": 3,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "click",
+            "range": [
+                59,
+                64
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 4
+                },
+                "end": {
+                    "line": 4,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "range": [
+                65,
+                66
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 10
+                },
+                "end": {
+                    "line": 4,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "new",
+            "range": [
+                67,
+                70
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 12
+                },
+                "end": {
+                    "line": 4,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "EventEmitter",
+            "range": [
+                71,
+                83
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 16
+                },
+                "end": {
+                    "line": 4,
+                    "column": 28
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                83,
+                84
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 28
+                },
+                "end": {
+                    "line": 4,
+                    "column": 29
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                84,
+                85
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 29
+                },
+                "end": {
+                    "line": 4,
+                    "column": 30
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                85,
+                86
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 30
+                },
+                "end": {
+                    "line": 4,
+                    "column": 31
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                87,
+                88
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 0
+                },
+                "end": {
+                    "line": 5,
+                    "column": 1
+                }
+            }
+        }
+    ]
+};

--- a/tests/fixtures/typescript/decorators/property-decorators/property-decorator-factory-instance-member.src.ts
+++ b/tests/fixtures/typescript/decorators/property-decorators/property-decorator-factory-instance-member.src.ts
@@ -1,0 +1,5 @@
+class SomeComponent {
+    @Input() data;
+    @Output()
+    click = new EventEmitter();
+}

--- a/tests/fixtures/typescript/decorators/property-decorators/property-decorator-factory-static-member.result.js
+++ b/tests/fixtures/typescript/decorators/property-decorators/property-decorator-factory-static-member.result.js
@@ -1,0 +1,631 @@
+module.exports = {
+    "type": "Program",
+    "range": [
+        0,
+        93
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 6,
+            "column": 1
+        }
+    },
+    "body": [
+        {
+            "type": "ClassDeclaration",
+            "range": [
+                0,
+                93
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 6,
+                    "column": 1
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    6,
+                    7
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 7
+                    }
+                },
+                "name": "A"
+            },
+            "body": {
+                "type": "ClassBody",
+                "body": [
+                    {
+                        "type": "ClassProperty",
+                        "range": [
+                            14,
+                            47
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 37
+                            }
+                        },
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                41,
+                                46
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 31
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 36
+                                }
+                            },
+                            "name": "prop1"
+                        },
+                        "value": null,
+                        "computed": false,
+                        "static": true,
+                        "decorators": [
+                            {
+                                "type": "CallExpression",
+                                "range": [
+                                    15,
+                                    33
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 5
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 23
+                                    }
+                                },
+                                "callee": {
+                                    "type": "Identifier",
+                                    "range": [
+                                        15,
+                                        27
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 5
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 17
+                                        }
+                                    },
+                                    "name": "configurable"
+                                },
+                                "arguments": [
+                                    {
+                                        "type": "Literal",
+                                        "range": [
+                                            28,
+                                            32
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 2,
+                                                "column": 18
+                                            },
+                                            "end": {
+                                                "line": 2,
+                                                "column": 22
+                                            }
+                                        },
+                                        "value": true,
+                                        "raw": "true"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "type": "ClassProperty",
+                        "range": [
+                            53,
+                            91
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 4,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 17
+                            }
+                        },
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                85,
+                                90
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 11
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 16
+                                }
+                            },
+                            "name": "prop2"
+                        },
+                        "value": null,
+                        "computed": false,
+                        "static": true,
+                        "decorators": [
+                            {
+                                "type": "CallExpression",
+                                "range": [
+                                    54,
+                                    73
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 4,
+                                        "column": 5
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 24
+                                    }
+                                },
+                                "callee": {
+                                    "type": "Identifier",
+                                    "range": [
+                                        54,
+                                        66
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 4,
+                                            "column": 5
+                                        },
+                                        "end": {
+                                            "line": 4,
+                                            "column": 17
+                                        }
+                                    },
+                                    "name": "configurable"
+                                },
+                                "arguments": [
+                                    {
+                                        "type": "Literal",
+                                        "range": [
+                                            67,
+                                            72
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 4,
+                                                "column": 18
+                                            },
+                                            "end": {
+                                                "line": 4,
+                                                "column": 23
+                                            }
+                                        },
+                                        "value": false,
+                                        "raw": "false"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "range": [
+                    8,
+                    93
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 6,
+                        "column": 1
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "class",
+            "range": [
+                0,
+                5
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "A",
+            "range": [
+                6,
+                7
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 6
+                },
+                "end": {
+                    "line": 1,
+                    "column": 7
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                8,
+                9
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 8
+                },
+                "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "@",
+            "range": [
+                14,
+                15
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "configurable",
+            "range": [
+                15,
+                27
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 5
+                },
+                "end": {
+                    "line": 2,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                27,
+                28
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 17
+                },
+                "end": {
+                    "line": 2,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Boolean",
+            "value": "true",
+            "range": [
+                28,
+                32
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 18
+                },
+                "end": {
+                    "line": 2,
+                    "column": 22
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                32,
+                33
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 22
+                },
+                "end": {
+                    "line": 2,
+                    "column": 23
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "range": [
+                34,
+                40
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 24
+                },
+                "end": {
+                    "line": 2,
+                    "column": 30
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "prop1",
+            "range": [
+                41,
+                46
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 31
+                },
+                "end": {
+                    "line": 2,
+                    "column": 36
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                46,
+                47
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 36
+                },
+                "end": {
+                    "line": 2,
+                    "column": 37
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "@",
+            "range": [
+                53,
+                54
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 4
+                },
+                "end": {
+                    "line": 4,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "configurable",
+            "range": [
+                54,
+                66
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 5
+                },
+                "end": {
+                    "line": 4,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                66,
+                67
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 17
+                },
+                "end": {
+                    "line": 4,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Boolean",
+            "value": "false",
+            "range": [
+                67,
+                72
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 18
+                },
+                "end": {
+                    "line": 4,
+                    "column": 23
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                72,
+                73
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 23
+                },
+                "end": {
+                    "line": 4,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "range": [
+                78,
+                84
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 4
+                },
+                "end": {
+                    "line": 5,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "prop2",
+            "range": [
+                85,
+                90
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 11
+                },
+                "end": {
+                    "line": 5,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                90,
+                91
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 16
+                },
+                "end": {
+                    "line": 5,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                92,
+                93
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 0
+                },
+                "end": {
+                    "line": 6,
+                    "column": 1
+                }
+            }
+        }
+    ]
+};

--- a/tests/fixtures/typescript/decorators/property-decorators/property-decorator-factory-static-member.src.ts
+++ b/tests/fixtures/typescript/decorators/property-decorators/property-decorator-factory-static-member.src.ts
@@ -1,0 +1,6 @@
+class A {
+    @configurable(true) static prop1;
+
+    @configurable(false)
+    static prop2;
+}

--- a/tests/fixtures/typescript/decorators/property-decorators/property-decorator-instance-member.result.js
+++ b/tests/fixtures/typescript/decorators/property-decorators/property-decorator-instance-member.result.js
@@ -1,0 +1,411 @@
+module.exports = {
+    "type": "Program",
+    "range": [
+        0,
+        39
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 5,
+            "column": 1
+        }
+    },
+    "body": [
+        {
+            "type": "ClassDeclaration",
+            "range": [
+                0,
+                39
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 5,
+                    "column": 1
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    6,
+                    7
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 7
+                    }
+                },
+                "name": "B"
+            },
+            "body": {
+                "type": "ClassBody",
+                "body": [
+                    {
+                        "type": "ClassProperty",
+                        "range": [
+                            14,
+                            21
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 11
+                            }
+                        },
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                19,
+                                20
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 9
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 10
+                                }
+                            },
+                            "name": "x"
+                        },
+                        "value": null,
+                        "computed": false,
+                        "static": false,
+                        "decorators": [
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    15,
+                                    18
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 5
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 8
+                                    }
+                                },
+                                "name": "foo"
+                            }
+                        ]
+                    },
+                    {
+                        "type": "ClassProperty",
+                        "range": [
+                            26,
+                            37
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 3,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 6
+                            }
+                        },
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                35,
+                                36
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 4,
+                                    "column": 4
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 5
+                                }
+                            },
+                            "name": "y"
+                        },
+                        "value": null,
+                        "computed": false,
+                        "static": false,
+                        "decorators": [
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    27,
+                                    30
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 3,
+                                        "column": 5
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 8
+                                    }
+                                },
+                                "name": "bar"
+                            }
+                        ]
+                    }
+                ],
+                "range": [
+                    8,
+                    39
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 5,
+                        "column": 1
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "class",
+            "range": [
+                0,
+                5
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "B",
+            "range": [
+                6,
+                7
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 6
+                },
+                "end": {
+                    "line": 1,
+                    "column": 7
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                8,
+                9
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 8
+                },
+                "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "@",
+            "range": [
+                14,
+                15
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "range": [
+                15,
+                18
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 5
+                },
+                "end": {
+                    "line": 2,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "x",
+            "range": [
+                19,
+                20
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 9
+                },
+                "end": {
+                    "line": 2,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                20,
+                21
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 10
+                },
+                "end": {
+                    "line": 2,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "@",
+            "range": [
+                26,
+                27
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 4
+                },
+                "end": {
+                    "line": 3,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "range": [
+                27,
+                30
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 5
+                },
+                "end": {
+                    "line": 3,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "y",
+            "range": [
+                35,
+                36
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 4
+                },
+                "end": {
+                    "line": 4,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                36,
+                37
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 5
+                },
+                "end": {
+                    "line": 4,
+                    "column": 6
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                38,
+                39
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 0
+                },
+                "end": {
+                    "line": 5,
+                    "column": 1
+                }
+            }
+        }
+    ]
+};

--- a/tests/fixtures/typescript/decorators/property-decorators/property-decorator-instance-member.src.ts
+++ b/tests/fixtures/typescript/decorators/property-decorators/property-decorator-instance-member.src.ts
@@ -1,0 +1,5 @@
+class B {
+    @foo x;
+    @bar
+    y;
+}

--- a/tests/fixtures/typescript/decorators/property-decorators/property-decorator-static-member.result.js
+++ b/tests/fixtures/typescript/decorators/property-decorators/property-decorator-static-member.result.js
@@ -1,0 +1,447 @@
+module.exports = {
+    "type": "Program",
+    "range": [
+        0,
+        53
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 5,
+            "column": 1
+        }
+    },
+    "body": [
+        {
+            "type": "ClassDeclaration",
+            "range": [
+                0,
+                53
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 5,
+                    "column": 1
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    6,
+                    7
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 7
+                    }
+                },
+                "name": "C"
+            },
+            "body": {
+                "type": "ClassBody",
+                "body": [
+                    {
+                        "type": "ClassProperty",
+                        "range": [
+                            14,
+                            28
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 18
+                            }
+                        },
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                26,
+                                27
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 16
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 17
+                                }
+                            },
+                            "name": "a"
+                        },
+                        "value": null,
+                        "computed": false,
+                        "static": true,
+                        "decorators": [
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    15,
+                                    18
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 5
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 8
+                                    }
+                                },
+                                "name": "baz"
+                            }
+                        ]
+                    },
+                    {
+                        "type": "ClassProperty",
+                        "range": [
+                            33,
+                            51
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 3,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 13
+                            }
+                        },
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                49,
+                                50
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 4,
+                                    "column": 11
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 12
+                                }
+                            },
+                            "name": "b"
+                        },
+                        "value": null,
+                        "computed": false,
+                        "static": true,
+                        "decorators": [
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    34,
+                                    37
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 3,
+                                        "column": 5
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 8
+                                    }
+                                },
+                                "name": "qux"
+                            }
+                        ]
+                    }
+                ],
+                "range": [
+                    8,
+                    53
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 5,
+                        "column": 1
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "class",
+            "range": [
+                0,
+                5
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "C",
+            "range": [
+                6,
+                7
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 6
+                },
+                "end": {
+                    "line": 1,
+                    "column": 7
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                8,
+                9
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 8
+                },
+                "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "@",
+            "range": [
+                14,
+                15
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "baz",
+            "range": [
+                15,
+                18
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 5
+                },
+                "end": {
+                    "line": 2,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "range": [
+                19,
+                25
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 9
+                },
+                "end": {
+                    "line": 2,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "a",
+            "range": [
+                26,
+                27
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 16
+                },
+                "end": {
+                    "line": 2,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                27,
+                28
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 17
+                },
+                "end": {
+                    "line": 2,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "@",
+            "range": [
+                33,
+                34
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 4
+                },
+                "end": {
+                    "line": 3,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "qux",
+            "range": [
+                34,
+                37
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 5
+                },
+                "end": {
+                    "line": 3,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "range": [
+                42,
+                48
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 4
+                },
+                "end": {
+                    "line": 4,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "b",
+            "range": [
+                49,
+                50
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 11
+                },
+                "end": {
+                    "line": 4,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                50,
+                51
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 12
+                },
+                "end": {
+                    "line": 4,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                52,
+                53
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 0
+                },
+                "end": {
+                    "line": 5,
+                    "column": 1
+                }
+            }
+        }
+    ]
+};

--- a/tests/fixtures/typescript/decorators/property-decorators/property-decorator-static-member.src.ts
+++ b/tests/fixtures/typescript/decorators/property-decorators/property-decorator-static-member.src.ts
@@ -1,0 +1,5 @@
+class C {
+    @baz static a;
+    @qux
+    static b;
+}


### PR DESCRIPTION
We were previously just stripping `ClassProperty` nodes entirely. This PR adds support for them, and their decorators