### PR TITLE
New: Accessibility Modifiers (fixes #87)

### DIFF
--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -499,6 +499,32 @@ module.exports = function(ast, extra) {
         }
 
         /**
+         * Gets a TSNode's accessibility level
+         * @param {TSNode} tsNode The TSNode
+         * @returns {string | null} accessibility "public", "protected", "private", or null
+         */
+        function getTSNodeAccessibility(tsNode) {
+            var modifiers = tsNode.modifiers;
+            if (!modifiers) {
+                return null;
+            }
+            for (var i = 0; i < modifiers.length; i++) {
+                var modifier = modifiers[i];
+                switch (modifier.kind) {
+                    case SyntaxKind.PublicKeyword:
+                        return "public";
+                    case SyntaxKind.ProtectedKeyword:
+                        return "protected";
+                    case SyntaxKind.PrivateKeyword:
+                        return "private";
+                    default:
+                        continue;
+                }
+            }
+            return null;
+        }
+
+        /**
          * Converts a TSNode's typeParameters array to a flow-like TypeParameterDeclaration node
          * @param {TSNode[]} typeParameters TSNode typeParameters
          * @returns {TypeParameterDeclaration} TypeParameterDeclaration node
@@ -984,6 +1010,7 @@ module.exports = function(ast, extra) {
                     value: convertChild(node.initializer),
                     computed: (node.name.kind === SyntaxKind.ComputedPropertyName),
                     static: Boolean(node.flags & ts.NodeFlags.Static),
+                    accessibility: getTSNodeAccessibility(node),
                     decorators: (node.decorators) ? node.decorators.map(function(d) {
                         return convertChild(d.expression);
                     }) : []
@@ -1066,6 +1093,7 @@ module.exports = function(ast, extra) {
                         computed: isMethodNameComputed,
                         static: Boolean(node.flags & ts.NodeFlags.Static),
                         kind: "method",
+                        accessibility: getTSNodeAccessibility(node),
                         decorators: (node.decorators) ? node.decorators.map(function(d) {
                             return convertChild(d.expression);
                         }) : []
@@ -1157,6 +1185,7 @@ module.exports = function(ast, extra) {
                     key: constructorKey,
                     value: constructor,
                     computed: constructorIsComputed,
+                    accessibility: getTSNodeAccessibility(node),
                     static: constructorIsStatic,
                     kind: (constructorIsStatic || constructorIsComputed) ? "method" : "constructor"
                 });

--- a/tests/fixtures/attach-comments/export-default-anonymous-class.result.js
+++ b/tests/fixtures/attach-comments/export-default-anonymous-class.result.js
@@ -73,6 +73,7 @@ module.exports = {
                             },
                             "kind": "method",
                             "computed": false,
+                            "accessibility": null,
                             "decorators": [],
                             "range": [
                                 103,

--- a/tests/fixtures/ecma-features/classes/class-accessor-properties.result.js
+++ b/tests/fixtures/ecma-features/classes/class-accessor-properties.result.js
@@ -1,5 +1,9 @@
 module.exports = {
     "type": "Program",
+    "range": [
+        0,
+        32
+    ],
     "loc": {
         "start": {
             "line": 1,
@@ -10,14 +14,13 @@ module.exports = {
             "column": 32
         }
     },
-    "range": [
-        0,
-        32
-    ],
     "body": [
         {
             "type": "ClassDeclaration",
-            "decorators": [],
+            "range": [
+                0,
+                31
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -28,12 +31,12 @@ module.exports = {
                     "column": 31
                 }
             },
-            "range": [
-                0,
-                31
-            ],
             "id": {
                 "type": "Identifier",
+                "range": [
+                    6,
+                    7
+                ],
                 "loc": {
                     "start": {
                         "line": 1,
@@ -44,33 +47,17 @@ module.exports = {
                         "column": 7
                     }
                 },
-                "range": [
-                    6,
-                    7
-                ],
                 "name": "A"
             },
-            "superClass": null,
-            "implements": [],
             "body": {
                 "type": "ClassBody",
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 8
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 31
-                    }
-                },
-                "range": [
-                    8,
-                    31
-                ],
                 "body": [
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            9,
+                            18
+                        ],
                         "loc": {
                             "start": {
                                 "line": 1,
@@ -81,14 +68,12 @@ module.exports = {
                                 "column": 18
                             }
                         },
-                        "range": [
-                            9,
-                            18
-                        ],
-                        "computed": false,
-                        "decorators": [],
                         "key": {
                             "type": "Identifier",
+                            "range": [
+                                13,
+                                14
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -99,36 +84,19 @@ module.exports = {
                                     "column": 14
                                 }
                             },
-                            "range": [
-                                13,
-                                14
-                            ],
                             "name": "a"
                         },
-                        "static": false,
-                        "kind": "get",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 14
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 18
-                                }
-                            },
-                            "range": [
-                                14,
-                                18
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    16,
+                                    18
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 1,
@@ -139,16 +107,36 @@ module.exports = {
                                         "column": 18
                                     }
                                 },
-                                "range": [
-                                    16,
-                                    18
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                14,
+                                18
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 14
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 18
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": false,
+                        "kind": "get",
+                        "accessibility": null,
+                        "decorators": []
                     },
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            19,
+                            29
+                        ],
                         "loc": {
                             "start": {
                                 "line": 1,
@@ -159,14 +147,12 @@ module.exports = {
                                 "column": 29
                             }
                         },
-                        "range": [
-                            19,
-                            29
-                        ],
-                        "computed": false,
-                        "decorators": [],
                         "key": {
                             "type": "Identifier",
+                            "range": [
+                                23,
+                                24
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -177,56 +163,19 @@ module.exports = {
                                     "column": 24
                                 }
                             },
-                            "range": [
-                                23,
-                                24
-                            ],
                             "name": "b"
                         },
-                        "static": false,
-                        "kind": "set",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 24
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 29
-                                }
-                            },
-                            "range": [
-                                24,
-                                29
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [
-                                {
-                                    "type": "Identifier",
-                                    "loc": {
-                                        "start": {
-                                            "line": 1,
-                                            "column": 25
-                                        },
-                                        "end": {
-                                            "line": 1,
-                                            "column": 26
-                                        }
-                                    },
-                                    "range": [
-                                        25,
-                                        26
-                                    ],
-                                    "name": "c",
-                                    "decorators": []
-                                }
-                            ],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    27,
+                                    29
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 1,
@@ -237,19 +186,76 @@ module.exports = {
                                         "column": 29
                                     }
                                 },
-                                "range": [
-                                    27,
-                                    29
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                24,
+                                29
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 24
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 29
+                                }
+                            },
+                            "params": [
+                                {
+                                    "type": "Identifier",
+                                    "range": [
+                                        25,
+                                        26
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 1,
+                                            "column": 25
+                                        },
+                                        "end": {
+                                            "line": 1,
+                                            "column": 26
+                                        }
+                                    },
+                                    "name": "c",
+                                    "decorators": []
+                                }
+                            ]
+                        },
+                        "computed": false,
+                        "static": false,
+                        "kind": "set",
+                        "accessibility": null,
+                        "decorators": []
                     }
-                ]
-            }
+                ],
+                "range": [
+                    8,
+                    31
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 31
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
         },
         {
             "type": "EmptyStatement",
+            "range": [
+                31,
+                32
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -259,11 +265,7 @@ module.exports = {
                     "line": 1,
                     "column": 32
                 }
-            },
-            "range": [
-                31,
-                32
-            ]
+            }
         }
     ],
     "sourceType": "script",
@@ -271,6 +273,10 @@ module.exports = {
         {
             "type": "Keyword",
             "value": "class",
+            "range": [
+                0,
+                5
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -280,15 +286,15 @@ module.exports = {
                     "line": 1,
                     "column": 5
                 }
-            },
-            "range": [
-                0,
-                5
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "A",
+            "range": [
+                6,
+                7
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -298,15 +304,15 @@ module.exports = {
                     "line": 1,
                     "column": 7
                 }
-            },
-            "range": [
-                6,
-                7
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                8,
+                9
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -316,15 +322,15 @@ module.exports = {
                     "line": 1,
                     "column": 9
                 }
-            },
-            "range": [
-                8,
-                9
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "get",
+            "range": [
+                9,
+                12
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -334,15 +340,15 @@ module.exports = {
                     "line": 1,
                     "column": 12
                 }
-            },
-            "range": [
-                9,
-                12
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "a",
+            "range": [
+                13,
+                14
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -352,15 +358,15 @@ module.exports = {
                     "line": 1,
                     "column": 14
                 }
-            },
-            "range": [
-                13,
-                14
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                14,
+                15
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -370,15 +376,15 @@ module.exports = {
                     "line": 1,
                     "column": 15
                 }
-            },
-            "range": [
-                14,
-                15
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                15,
+                16
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -388,15 +394,15 @@ module.exports = {
                     "line": 1,
                     "column": 16
                 }
-            },
-            "range": [
-                15,
-                16
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                16,
+                17
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -406,15 +412,15 @@ module.exports = {
                     "line": 1,
                     "column": 17
                 }
-            },
-            "range": [
-                16,
-                17
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                17,
+                18
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -424,15 +430,15 @@ module.exports = {
                     "line": 1,
                     "column": 18
                 }
-            },
-            "range": [
-                17,
-                18
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "set",
+            "range": [
+                19,
+                22
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -442,15 +448,15 @@ module.exports = {
                     "line": 1,
                     "column": 22
                 }
-            },
-            "range": [
-                19,
-                22
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "b",
+            "range": [
+                23,
+                24
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -460,15 +466,15 @@ module.exports = {
                     "line": 1,
                     "column": 24
                 }
-            },
-            "range": [
-                23,
-                24
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                24,
+                25
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -478,15 +484,15 @@ module.exports = {
                     "line": 1,
                     "column": 25
                 }
-            },
-            "range": [
-                24,
-                25
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "c",
+            "range": [
+                25,
+                26
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -496,15 +502,15 @@ module.exports = {
                     "line": 1,
                     "column": 26
                 }
-            },
-            "range": [
-                25,
-                26
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                26,
+                27
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -514,15 +520,15 @@ module.exports = {
                     "line": 1,
                     "column": 27
                 }
-            },
-            "range": [
-                26,
-                27
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                27,
+                28
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -532,15 +538,15 @@ module.exports = {
                     "line": 1,
                     "column": 28
                 }
-            },
-            "range": [
-                27,
-                28
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                28,
+                29
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -550,15 +556,15 @@ module.exports = {
                     "line": 1,
                     "column": 29
                 }
-            },
-            "range": [
-                28,
-                29
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                29,
+                30
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -568,15 +574,15 @@ module.exports = {
                     "line": 1,
                     "column": 30
                 }
-            },
-            "range": [
-                29,
-                30
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                30,
+                31
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -586,15 +592,15 @@ module.exports = {
                     "line": 1,
                     "column": 31
                 }
-            },
-            "range": [
-                30,
-                31
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                31,
+                32
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -604,11 +610,7 @@ module.exports = {
                     "line": 1,
                     "column": 32
                 }
-            },
-            "range": [
-                31,
-                32
-            ]
+            }
         }
     ]
 };

--- a/tests/fixtures/ecma-features/classes/class-computed-static-method.result.js
+++ b/tests/fixtures/ecma-features/classes/class-computed-static-method.result.js
@@ -1,5 +1,9 @@
 module.exports = {
     "type": "Program",
+    "range": [
+        0,
+        26
+    ],
     "loc": {
         "start": {
             "line": 1,
@@ -10,14 +14,13 @@ module.exports = {
             "column": 26
         }
     },
-    "range": [
-        0,
-        26
-    ],
     "body": [
         {
             "type": "ClassDeclaration",
-            "decorators": [],
+            "range": [
+                0,
+                25
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -28,12 +31,12 @@ module.exports = {
                     "column": 25
                 }
             },
-            "range": [
-                0,
-                25
-            ],
             "id": {
                 "type": "Identifier",
+                "range": [
+                    6,
+                    7
+                ],
                 "loc": {
                     "start": {
                         "line": 1,
@@ -44,33 +47,17 @@ module.exports = {
                         "column": 7
                     }
                 },
-                "range": [
-                    6,
-                    7
-                ],
                 "name": "A"
             },
-            "superClass": null,
-            "implements": [],
             "body": {
                 "type": "ClassBody",
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 8
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 25
-                    }
-                },
-                "range": [
-                    8,
-                    25
-                ],
                 "body": [
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            9,
+                            23
+                        ],
                         "loc": {
                             "start": {
                                 "line": 1,
@@ -81,14 +68,12 @@ module.exports = {
                                 "column": 23
                             }
                         },
-                        "range": [
-                            9,
-                            23
-                        ],
-                        "computed": true,
-                        "decorators": [],
                         "key": {
                             "type": "Identifier",
+                            "range": [
+                                17,
+                                18
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -99,36 +84,19 @@ module.exports = {
                                     "column": 18
                                 }
                             },
-                            "range": [
-                                17,
-                                18
-                            ],
                             "name": "a"
                         },
-                        "static": true,
-                        "kind": "method",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 19
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 23
-                                }
-                            },
-                            "range": [
-                                19,
-                                23
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    21,
+                                    23
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 1,
@@ -139,19 +107,56 @@ module.exports = {
                                         "column": 23
                                     }
                                 },
-                                "range": [
-                                    21,
-                                    23
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                19,
+                                23
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 19
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 23
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": true,
+                        "static": true,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": []
                     }
-                ]
-            }
+                ],
+                "range": [
+                    8,
+                    25
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 25
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
         },
         {
             "type": "EmptyStatement",
+            "range": [
+                25,
+                26
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -161,11 +166,7 @@ module.exports = {
                     "line": 1,
                     "column": 26
                 }
-            },
-            "range": [
-                25,
-                26
-            ]
+            }
         }
     ],
     "sourceType": "script",
@@ -173,6 +174,10 @@ module.exports = {
         {
             "type": "Keyword",
             "value": "class",
+            "range": [
+                0,
+                5
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -182,15 +187,15 @@ module.exports = {
                     "line": 1,
                     "column": 5
                 }
-            },
-            "range": [
-                0,
-                5
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "A",
+            "range": [
+                6,
+                7
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -200,15 +205,15 @@ module.exports = {
                     "line": 1,
                     "column": 7
                 }
-            },
-            "range": [
-                6,
-                7
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                8,
+                9
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -218,15 +223,15 @@ module.exports = {
                     "line": 1,
                     "column": 9
                 }
-            },
-            "range": [
-                8,
-                9
-            ]
+            }
         },
         {
             "type": "Keyword",
             "value": "static",
+            "range": [
+                9,
+                15
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -236,15 +241,15 @@ module.exports = {
                     "line": 1,
                     "column": 15
                 }
-            },
-            "range": [
-                9,
-                15
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "[",
+            "range": [
+                16,
+                17
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -254,15 +259,15 @@ module.exports = {
                     "line": 1,
                     "column": 17
                 }
-            },
-            "range": [
-                16,
-                17
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "a",
+            "range": [
+                17,
+                18
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -272,15 +277,15 @@ module.exports = {
                     "line": 1,
                     "column": 18
                 }
-            },
-            "range": [
-                17,
-                18
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "]",
+            "range": [
+                18,
+                19
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -290,15 +295,15 @@ module.exports = {
                     "line": 1,
                     "column": 19
                 }
-            },
-            "range": [
-                18,
-                19
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                19,
+                20
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -308,15 +313,15 @@ module.exports = {
                     "line": 1,
                     "column": 20
                 }
-            },
-            "range": [
-                19,
-                20
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                20,
+                21
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -326,15 +331,15 @@ module.exports = {
                     "line": 1,
                     "column": 21
                 }
-            },
-            "range": [
-                20,
-                21
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                21,
+                22
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -344,15 +349,15 @@ module.exports = {
                     "line": 1,
                     "column": 22
                 }
-            },
-            "range": [
-                21,
-                22
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                22,
+                23
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -362,15 +367,15 @@ module.exports = {
                     "line": 1,
                     "column": 23
                 }
-            },
-            "range": [
-                22,
-                23
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                23,
+                24
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -380,15 +385,15 @@ module.exports = {
                     "line": 1,
                     "column": 24
                 }
-            },
-            "range": [
-                23,
-                24
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                24,
+                25
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -398,15 +403,15 @@ module.exports = {
                     "line": 1,
                     "column": 25
                 }
-            },
-            "range": [
-                24,
-                25
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                25,
+                26
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -416,11 +421,7 @@ module.exports = {
                     "line": 1,
                     "column": 26
                 }
-            },
-            "range": [
-                25,
-                26
-            ]
+            }
         }
     ]
 };

--- a/tests/fixtures/ecma-features/classes/class-method-named-prototype.result.js
+++ b/tests/fixtures/ecma-features/classes/class-method-named-prototype.result.js
@@ -1,5 +1,9 @@
 module.exports = {
     "type": "Program",
+    "range": [
+        0,
+        24
+    ],
     "loc": {
         "start": {
             "line": 1,
@@ -10,14 +14,13 @@ module.exports = {
             "column": 24
         }
     },
-    "range": [
-        0,
-        24
-    ],
     "body": [
         {
             "type": "ClassDeclaration",
-            "decorators": [],
+            "range": [
+                0,
+                23
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -28,12 +31,12 @@ module.exports = {
                     "column": 23
                 }
             },
-            "range": [
-                0,
-                23
-            ],
             "id": {
                 "type": "Identifier",
+                "range": [
+                    6,
+                    7
+                ],
                 "loc": {
                     "start": {
                         "line": 1,
@@ -44,33 +47,17 @@ module.exports = {
                         "column": 7
                     }
                 },
-                "range": [
-                    6,
-                    7
-                ],
                 "name": "A"
             },
-            "superClass": null,
-            "implements": [],
             "body": {
                 "type": "ClassBody",
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 8
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 23
-                    }
-                },
-                "range": [
-                    8,
-                    23
-                ],
                 "body": [
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            9,
+                            22
+                        ],
                         "loc": {
                             "start": {
                                 "line": 1,
@@ -81,14 +68,12 @@ module.exports = {
                                 "column": 22
                             }
                         },
-                        "range": [
-                            9,
-                            22
-                        ],
-                        "computed": false,
-                        "decorators": [],
                         "key": {
                             "type": "Identifier",
+                            "range": [
+                                9,
+                                18
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -99,36 +84,19 @@ module.exports = {
                                     "column": 18
                                 }
                             },
-                            "range": [
-                                9,
-                                18
-                            ],
                             "name": "prototype"
                         },
-                        "static": false,
-                        "kind": "method",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 18
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 22
-                                }
-                            },
-                            "range": [
-                                18,
-                                22
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    20,
+                                    22
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 1,
@@ -139,19 +107,56 @@ module.exports = {
                                         "column": 22
                                     }
                                 },
-                                "range": [
-                                    20,
-                                    22
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                18,
+                                22
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 18
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 22
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": false,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": []
                     }
-                ]
-            }
+                ],
+                "range": [
+                    8,
+                    23
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 23
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
         },
         {
             "type": "EmptyStatement",
+            "range": [
+                23,
+                24
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -161,11 +166,7 @@ module.exports = {
                     "line": 1,
                     "column": 24
                 }
-            },
-            "range": [
-                23,
-                24
-            ]
+            }
         }
     ],
     "sourceType": "script",
@@ -173,6 +174,10 @@ module.exports = {
         {
             "type": "Keyword",
             "value": "class",
+            "range": [
+                0,
+                5
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -182,15 +187,15 @@ module.exports = {
                     "line": 1,
                     "column": 5
                 }
-            },
-            "range": [
-                0,
-                5
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "A",
+            "range": [
+                6,
+                7
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -200,15 +205,15 @@ module.exports = {
                     "line": 1,
                     "column": 7
                 }
-            },
-            "range": [
-                6,
-                7
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                8,
+                9
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -218,15 +223,15 @@ module.exports = {
                     "line": 1,
                     "column": 9
                 }
-            },
-            "range": [
-                8,
-                9
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "prototype",
+            "range": [
+                9,
+                18
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -236,15 +241,15 @@ module.exports = {
                     "line": 1,
                     "column": 18
                 }
-            },
-            "range": [
-                9,
-                18
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                18,
+                19
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -254,15 +259,15 @@ module.exports = {
                     "line": 1,
                     "column": 19
                 }
-            },
-            "range": [
-                18,
-                19
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                19,
+                20
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -272,15 +277,15 @@ module.exports = {
                     "line": 1,
                     "column": 20
                 }
-            },
-            "range": [
-                19,
-                20
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                20,
+                21
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -290,15 +295,15 @@ module.exports = {
                     "line": 1,
                     "column": 21
                 }
-            },
-            "range": [
-                20,
-                21
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                21,
+                22
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -308,15 +313,15 @@ module.exports = {
                     "line": 1,
                     "column": 22
                 }
-            },
-            "range": [
-                21,
-                22
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                22,
+                23
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -326,15 +331,15 @@ module.exports = {
                     "line": 1,
                     "column": 23
                 }
-            },
-            "range": [
-                22,
-                23
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                23,
+                24
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -344,11 +349,7 @@ module.exports = {
                     "line": 1,
                     "column": 24
                 }
-            },
-            "range": [
-                23,
-                24
-            ]
+            }
         }
     ]
 };

--- a/tests/fixtures/ecma-features/classes/class-method-named-static.result.js
+++ b/tests/fixtures/ecma-features/classes/class-method-named-static.result.js
@@ -1,5 +1,9 @@
 module.exports = {
     "type": "Program",
+    "range": [
+        0,
+        22
+    ],
     "loc": {
         "start": {
             "line": 1,
@@ -10,14 +14,13 @@ module.exports = {
             "column": 22
         }
     },
-    "range": [
-        0,
-        22
-    ],
     "body": [
         {
             "type": "ClassDeclaration",
-            "decorators": [],
+            "range": [
+                0,
+                21
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -28,12 +31,12 @@ module.exports = {
                     "column": 21
                 }
             },
-            "range": [
-                0,
-                21
-            ],
             "id": {
                 "type": "Identifier",
+                "range": [
+                    6,
+                    7
+                ],
                 "loc": {
                     "start": {
                         "line": 1,
@@ -44,33 +47,17 @@ module.exports = {
                         "column": 7
                     }
                 },
-                "range": [
-                    6,
-                    7
-                ],
                 "name": "A"
             },
-            "superClass": null,
-            "implements": [],
             "body": {
                 "type": "ClassBody",
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 8
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 21
-                    }
-                },
-                "range": [
-                    8,
-                    21
-                ],
                 "body": [
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            9,
+                            19
+                        ],
                         "loc": {
                             "start": {
                                 "line": 1,
@@ -81,14 +68,12 @@ module.exports = {
                                 "column": 19
                             }
                         },
-                        "range": [
-                            9,
-                            19
-                        ],
-                        "computed": false,
-                        "decorators": [],
                         "key": {
                             "type": "Identifier",
+                            "range": [
+                                9,
+                                15
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -99,36 +84,19 @@ module.exports = {
                                     "column": 15
                                 }
                             },
-                            "range": [
-                                9,
-                                15
-                            ],
                             "name": "static"
                         },
-                        "static": false,
-                        "kind": "method",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 15
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 19
-                                }
-                            },
-                            "range": [
-                                15,
-                                19
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    17,
+                                    19
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 1,
@@ -139,19 +107,56 @@ module.exports = {
                                         "column": 19
                                     }
                                 },
-                                "range": [
-                                    17,
-                                    19
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                15,
+                                19
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 15
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 19
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": false,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": []
                     }
-                ]
-            }
+                ],
+                "range": [
+                    8,
+                    21
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 21
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
         },
         {
             "type": "EmptyStatement",
+            "range": [
+                21,
+                22
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -161,11 +166,7 @@ module.exports = {
                     "line": 1,
                     "column": 22
                 }
-            },
-            "range": [
-                21,
-                22
-            ]
+            }
         }
     ],
     "sourceType": "script",
@@ -173,6 +174,10 @@ module.exports = {
         {
             "type": "Keyword",
             "value": "class",
+            "range": [
+                0,
+                5
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -182,15 +187,15 @@ module.exports = {
                     "line": 1,
                     "column": 5
                 }
-            },
-            "range": [
-                0,
-                5
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "A",
+            "range": [
+                6,
+                7
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -200,15 +205,15 @@ module.exports = {
                     "line": 1,
                     "column": 7
                 }
-            },
-            "range": [
-                6,
-                7
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                8,
+                9
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -218,15 +223,15 @@ module.exports = {
                     "line": 1,
                     "column": 9
                 }
-            },
-            "range": [
-                8,
-                9
-            ]
+            }
         },
         {
             "type": "Keyword",
             "value": "static",
+            "range": [
+                9,
+                15
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -236,15 +241,15 @@ module.exports = {
                     "line": 1,
                     "column": 15
                 }
-            },
-            "range": [
-                9,
-                15
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                15,
+                16
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -254,15 +259,15 @@ module.exports = {
                     "line": 1,
                     "column": 16
                 }
-            },
-            "range": [
-                15,
-                16
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                16,
+                17
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -272,15 +277,15 @@ module.exports = {
                     "line": 1,
                     "column": 17
                 }
-            },
-            "range": [
-                16,
-                17
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                17,
+                18
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -290,15 +295,15 @@ module.exports = {
                     "line": 1,
                     "column": 18
                 }
-            },
-            "range": [
-                17,
-                18
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                18,
+                19
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -308,15 +313,15 @@ module.exports = {
                     "line": 1,
                     "column": 19
                 }
-            },
-            "range": [
-                18,
-                19
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                19,
+                20
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -326,15 +331,15 @@ module.exports = {
                     "line": 1,
                     "column": 20
                 }
-            },
-            "range": [
-                19,
-                20
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                20,
+                21
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -344,15 +349,15 @@ module.exports = {
                     "line": 1,
                     "column": 21
                 }
-            },
-            "range": [
-                20,
-                21
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                21,
+                22
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -362,11 +367,7 @@ module.exports = {
                     "line": 1,
                     "column": 22
                 }
-            },
-            "range": [
-                21,
-                22
-            ]
+            }
         }
     ]
 };

--- a/tests/fixtures/ecma-features/classes/class-one-method-super.result.js
+++ b/tests/fixtures/ecma-features/classes/class-one-method-super.result.js
@@ -1,5 +1,9 @@
 module.exports = {
     "type": "Program",
+    "range": [
+        0,
+        44
+    ],
     "loc": {
         "start": {
             "line": 1,
@@ -10,14 +14,13 @@ module.exports = {
             "column": 2
         }
     },
-    "range": [
-        0,
-        44
-    ],
     "body": [
         {
             "type": "ClassDeclaration",
-            "decorators": [],
+            "range": [
+                0,
+                43
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -28,12 +31,12 @@ module.exports = {
                     "column": 1
                 }
             },
-            "range": [
-                0,
-                43
-            ],
             "id": {
                 "type": "Identifier",
+                "range": [
+                    6,
+                    7
+                ],
                 "loc": {
                     "start": {
                         "line": 1,
@@ -44,33 +47,17 @@ module.exports = {
                         "column": 7
                     }
                 },
-                "range": [
-                    6,
-                    7
-                ],
                 "name": "A"
             },
-            "superClass": null,
-            "implements": [],
             "body": {
                 "type": "ClassBody",
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 8
-                    },
-                    "end": {
-                        "line": 5,
-                        "column": 1
-                    }
-                },
-                "range": [
-                    8,
-                    43
-                ],
                 "body": [
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            14,
+                            41
+                        ],
                         "loc": {
                             "start": {
                                 "line": 2,
@@ -81,14 +68,12 @@ module.exports = {
                                 "column": 5
                             }
                         },
-                        "range": [
-                            14,
-                            41
-                        ],
-                        "computed": false,
-                        "decorators": [],
                         "key": {
                             "type": "Identifier",
+                            "range": [
+                                14,
+                                15
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 2,
@@ -99,36 +84,19 @@ module.exports = {
                                     "column": 5
                                 }
                             },
-                            "range": [
-                                14,
-                                15
-                            ],
                             "name": "a"
                         },
-                        "static": false,
-                        "kind": "method",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 2,
-                                    "column": 5
-                                },
-                                "end": {
-                                    "line": 4,
-                                    "column": 5
-                                }
-                            },
-                            "range": [
-                                15,
-                                41
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    17,
+                                    41
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 2,
@@ -139,13 +107,13 @@ module.exports = {
                                         "column": 5
                                     }
                                 },
-                                "range": [
-                                    17,
-                                    41
-                                ],
                                 "body": [
                                     {
                                         "type": "ExpressionStatement",
+                                        "range": [
+                                            27,
+                                            35
+                                        ],
                                         "loc": {
                                             "start": {
                                                 "line": 3,
@@ -156,12 +124,12 @@ module.exports = {
                                                 "column": 16
                                             }
                                         },
-                                        "range": [
-                                            27,
-                                            35
-                                        ],
                                         "expression": {
                                             "type": "CallExpression",
+                                            "range": [
+                                                27,
+                                                34
+                                            ],
                                             "loc": {
                                                 "start": {
                                                     "line": 3,
@@ -172,12 +140,12 @@ module.exports = {
                                                     "column": 15
                                                 }
                                             },
-                                            "range": [
-                                                27,
-                                                34
-                                            ],
                                             "callee": {
                                                 "type": "Super",
+                                                "range": [
+                                                    27,
+                                                    32
+                                                ],
                                                 "loc": {
                                                     "start": {
                                                         "line": 3,
@@ -187,24 +155,61 @@ module.exports = {
                                                         "line": 3,
                                                         "column": 13
                                                     }
-                                                },
-                                                "range": [
-                                                    27,
-                                                    32
-                                                ]
+                                                }
                                             },
                                             "arguments": []
                                         }
                                     }
                                 ]
-                            }
-                        }
+                            },
+                            "range": [
+                                15,
+                                41
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 5
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 5
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": false,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": []
                     }
-                ]
-            }
+                ],
+                "range": [
+                    8,
+                    43
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 5,
+                        "column": 1
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
         },
         {
             "type": "EmptyStatement",
+            "range": [
+                43,
+                44
+            ],
             "loc": {
                 "start": {
                     "line": 5,
@@ -214,11 +219,7 @@ module.exports = {
                     "line": 5,
                     "column": 2
                 }
-            },
-            "range": [
-                43,
-                44
-            ]
+            }
         }
     ],
     "sourceType": "script",
@@ -226,6 +227,10 @@ module.exports = {
         {
             "type": "Keyword",
             "value": "class",
+            "range": [
+                0,
+                5
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -235,15 +240,15 @@ module.exports = {
                     "line": 1,
                     "column": 5
                 }
-            },
-            "range": [
-                0,
-                5
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "A",
+            "range": [
+                6,
+                7
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -253,15 +258,15 @@ module.exports = {
                     "line": 1,
                     "column": 7
                 }
-            },
-            "range": [
-                6,
-                7
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                8,
+                9
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -271,15 +276,15 @@ module.exports = {
                     "line": 1,
                     "column": 9
                 }
-            },
-            "range": [
-                8,
-                9
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "a",
+            "range": [
+                14,
+                15
+            ],
             "loc": {
                 "start": {
                     "line": 2,
@@ -289,15 +294,15 @@ module.exports = {
                     "line": 2,
                     "column": 5
                 }
-            },
-            "range": [
-                14,
-                15
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                15,
+                16
+            ],
             "loc": {
                 "start": {
                     "line": 2,
@@ -307,15 +312,15 @@ module.exports = {
                     "line": 2,
                     "column": 6
                 }
-            },
-            "range": [
-                15,
-                16
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                16,
+                17
+            ],
             "loc": {
                 "start": {
                     "line": 2,
@@ -325,15 +330,15 @@ module.exports = {
                     "line": 2,
                     "column": 7
                 }
-            },
-            "range": [
-                16,
-                17
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                17,
+                18
+            ],
             "loc": {
                 "start": {
                     "line": 2,
@@ -343,15 +348,15 @@ module.exports = {
                     "line": 2,
                     "column": 8
                 }
-            },
-            "range": [
-                17,
-                18
-            ]
+            }
         },
         {
             "type": "Keyword",
             "value": "super",
+            "range": [
+                27,
+                32
+            ],
             "loc": {
                 "start": {
                     "line": 3,
@@ -361,15 +366,15 @@ module.exports = {
                     "line": 3,
                     "column": 13
                 }
-            },
-            "range": [
-                27,
-                32
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                32,
+                33
+            ],
             "loc": {
                 "start": {
                     "line": 3,
@@ -379,15 +384,15 @@ module.exports = {
                     "line": 3,
                     "column": 14
                 }
-            },
-            "range": [
-                32,
-                33
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                33,
+                34
+            ],
             "loc": {
                 "start": {
                     "line": 3,
@@ -397,15 +402,15 @@ module.exports = {
                     "line": 3,
                     "column": 15
                 }
-            },
-            "range": [
-                33,
-                34
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                34,
+                35
+            ],
             "loc": {
                 "start": {
                     "line": 3,
@@ -415,15 +420,15 @@ module.exports = {
                     "line": 3,
                     "column": 16
                 }
-            },
-            "range": [
-                34,
-                35
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                40,
+                41
+            ],
             "loc": {
                 "start": {
                     "line": 4,
@@ -433,15 +438,15 @@ module.exports = {
                     "line": 4,
                     "column": 5
                 }
-            },
-            "range": [
-                40,
-                41
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                42,
+                43
+            ],
             "loc": {
                 "start": {
                     "line": 5,
@@ -451,15 +456,15 @@ module.exports = {
                     "line": 5,
                     "column": 1
                 }
-            },
-            "range": [
-                42,
-                43
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                43,
+                44
+            ],
             "loc": {
                 "start": {
                     "line": 5,
@@ -469,11 +474,7 @@ module.exports = {
                     "line": 5,
                     "column": 2
                 }
-            },
-            "range": [
-                43,
-                44
-            ]
+            }
         }
     ]
 };

--- a/tests/fixtures/ecma-features/classes/class-one-method.result.js
+++ b/tests/fixtures/ecma-features/classes/class-one-method.result.js
@@ -1,5 +1,9 @@
 module.exports = {
     "type": "Program",
+    "range": [
+        0,
+        22
+    ],
     "loc": {
         "start": {
             "line": 1,
@@ -10,14 +14,13 @@ module.exports = {
             "column": 2
         }
     },
-    "range": [
-        0,
-        22
-    ],
     "body": [
         {
             "type": "ClassDeclaration",
-            "decorators": [],
+            "range": [
+                0,
+                21
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -28,12 +31,12 @@ module.exports = {
                     "column": 1
                 }
             },
-            "range": [
-                0,
-                21
-            ],
             "id": {
                 "type": "Identifier",
+                "range": [
+                    6,
+                    7
+                ],
                 "loc": {
                     "start": {
                         "line": 1,
@@ -44,33 +47,17 @@ module.exports = {
                         "column": 7
                     }
                 },
-                "range": [
-                    6,
-                    7
-                ],
                 "name": "A"
             },
-            "superClass": null,
-            "implements": [],
             "body": {
                 "type": "ClassBody",
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 8
-                    },
-                    "end": {
-                        "line": 3,
-                        "column": 1
-                    }
-                },
-                "range": [
-                    8,
-                    21
-                ],
                 "body": [
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            14,
+                            19
+                        ],
                         "loc": {
                             "start": {
                                 "line": 2,
@@ -81,14 +68,12 @@ module.exports = {
                                 "column": 9
                             }
                         },
-                        "range": [
-                            14,
-                            19
-                        ],
-                        "computed": false,
-                        "decorators": [],
                         "key": {
                             "type": "Identifier",
+                            "range": [
+                                14,
+                                15
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 2,
@@ -99,36 +84,19 @@ module.exports = {
                                     "column": 5
                                 }
                             },
-                            "range": [
-                                14,
-                                15
-                            ],
                             "name": "a"
                         },
-                        "static": false,
-                        "kind": "method",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 2,
-                                    "column": 5
-                                },
-                                "end": {
-                                    "line": 2,
-                                    "column": 9
-                                }
-                            },
-                            "range": [
-                                15,
-                                19
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    17,
+                                    19
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 2,
@@ -139,19 +107,56 @@ module.exports = {
                                         "column": 9
                                     }
                                 },
-                                "range": [
-                                    17,
-                                    19
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                15,
+                                19
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 5
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 9
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": false,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": []
                     }
-                ]
-            }
+                ],
+                "range": [
+                    8,
+                    21
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 1
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
         },
         {
             "type": "EmptyStatement",
+            "range": [
+                21,
+                22
+            ],
             "loc": {
                 "start": {
                     "line": 3,
@@ -161,11 +166,7 @@ module.exports = {
                     "line": 3,
                     "column": 2
                 }
-            },
-            "range": [
-                21,
-                22
-            ]
+            }
         }
     ],
     "sourceType": "script",
@@ -173,6 +174,10 @@ module.exports = {
         {
             "type": "Keyword",
             "value": "class",
+            "range": [
+                0,
+                5
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -182,15 +187,15 @@ module.exports = {
                     "line": 1,
                     "column": 5
                 }
-            },
-            "range": [
-                0,
-                5
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "A",
+            "range": [
+                6,
+                7
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -200,15 +205,15 @@ module.exports = {
                     "line": 1,
                     "column": 7
                 }
-            },
-            "range": [
-                6,
-                7
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                8,
+                9
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -218,15 +223,15 @@ module.exports = {
                     "line": 1,
                     "column": 9
                 }
-            },
-            "range": [
-                8,
-                9
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "a",
+            "range": [
+                14,
+                15
+            ],
             "loc": {
                 "start": {
                     "line": 2,
@@ -236,15 +241,15 @@ module.exports = {
                     "line": 2,
                     "column": 5
                 }
-            },
-            "range": [
-                14,
-                15
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                15,
+                16
+            ],
             "loc": {
                 "start": {
                     "line": 2,
@@ -254,15 +259,15 @@ module.exports = {
                     "line": 2,
                     "column": 6
                 }
-            },
-            "range": [
-                15,
-                16
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                16,
+                17
+            ],
             "loc": {
                 "start": {
                     "line": 2,
@@ -272,15 +277,15 @@ module.exports = {
                     "line": 2,
                     "column": 7
                 }
-            },
-            "range": [
-                16,
-                17
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                17,
+                18
+            ],
             "loc": {
                 "start": {
                     "line": 2,
@@ -290,15 +295,15 @@ module.exports = {
                     "line": 2,
                     "column": 8
                 }
-            },
-            "range": [
-                17,
-                18
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                18,
+                19
+            ],
             "loc": {
                 "start": {
                     "line": 2,
@@ -308,15 +313,15 @@ module.exports = {
                     "line": 2,
                     "column": 9
                 }
-            },
-            "range": [
-                18,
-                19
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                20,
+                21
+            ],
             "loc": {
                 "start": {
                     "line": 3,
@@ -326,15 +331,15 @@ module.exports = {
                     "line": 3,
                     "column": 1
                 }
-            },
-            "range": [
-                20,
-                21
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                21,
+                22
+            ],
             "loc": {
                 "start": {
                     "line": 3,
@@ -344,11 +349,7 @@ module.exports = {
                     "line": 3,
                     "column": 2
                 }
-            },
-            "range": [
-                21,
-                22
-            ]
+            }
         }
     ]
 };

--- a/tests/fixtures/ecma-features/classes/class-static-method-named-prototype.result.js
+++ b/tests/fixtures/ecma-features/classes/class-static-method-named-prototype.result.js
@@ -1,5 +1,9 @@
 module.exports = {
     "type": "Program",
+    "range": [
+        0,
+        35
+    ],
     "loc": {
         "start": {
             "line": 1,
@@ -10,14 +14,13 @@ module.exports = {
             "column": 35
         }
     },
-    "range": [
-        0,
-        35
-    ],
     "body": [
         {
             "type": "ClassDeclaration",
-            "decorators": [],
+            "range": [
+                0,
+                34
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -28,12 +31,12 @@ module.exports = {
                     "column": 34
                 }
             },
-            "range": [
-                0,
-                34
-            ],
             "id": {
                 "type": "Identifier",
+                "range": [
+                    6,
+                    7
+                ],
                 "loc": {
                     "start": {
                         "line": 1,
@@ -44,33 +47,17 @@ module.exports = {
                         "column": 7
                     }
                 },
-                "range": [
-                    6,
-                    7
-                ],
                 "name": "A"
             },
-            "superClass": null,
-            "implements": [],
             "body": {
                 "type": "ClassBody",
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 8
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 34
-                    }
-                },
-                "range": [
-                    8,
-                    34
-                ],
                 "body": [
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            9,
+                            33
+                        ],
                         "loc": {
                             "start": {
                                 "line": 1,
@@ -81,14 +68,12 @@ module.exports = {
                                 "column": 33
                             }
                         },
-                        "range": [
-                            9,
-                            33
-                        ],
-                        "computed": true,
-                        "decorators": [],
                         "key": {
                             "type": "Literal",
+                            "range": [
+                                17,
+                                28
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -99,37 +84,20 @@ module.exports = {
                                     "column": 28
                                 }
                             },
-                            "range": [
-                                17,
-                                28
-                            ],
                             "value": "prototype",
                             "raw": "\"prototype\""
                         },
-                        "static": true,
-                        "kind": "method",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 29
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 33
-                                }
-                            },
-                            "range": [
-                                29,
-                                33
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    31,
+                                    33
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 1,
@@ -140,19 +108,56 @@ module.exports = {
                                         "column": 33
                                     }
                                 },
-                                "range": [
-                                    31,
-                                    33
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                29,
+                                33
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 29
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 33
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": true,
+                        "static": true,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": []
                     }
-                ]
-            }
+                ],
+                "range": [
+                    8,
+                    34
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 34
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
         },
         {
             "type": "EmptyStatement",
+            "range": [
+                34,
+                35
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -162,11 +167,7 @@ module.exports = {
                     "line": 1,
                     "column": 35
                 }
-            },
-            "range": [
-                34,
-                35
-            ]
+            }
         }
     ],
     "sourceType": "script",
@@ -174,6 +175,10 @@ module.exports = {
         {
             "type": "Keyword",
             "value": "class",
+            "range": [
+                0,
+                5
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -183,15 +188,15 @@ module.exports = {
                     "line": 1,
                     "column": 5
                 }
-            },
-            "range": [
-                0,
-                5
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "A",
+            "range": [
+                6,
+                7
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -201,15 +206,15 @@ module.exports = {
                     "line": 1,
                     "column": 7
                 }
-            },
-            "range": [
-                6,
-                7
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                8,
+                9
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -219,15 +224,15 @@ module.exports = {
                     "line": 1,
                     "column": 9
                 }
-            },
-            "range": [
-                8,
-                9
-            ]
+            }
         },
         {
             "type": "Keyword",
             "value": "static",
+            "range": [
+                9,
+                15
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -237,15 +242,15 @@ module.exports = {
                     "line": 1,
                     "column": 15
                 }
-            },
-            "range": [
-                9,
-                15
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "[",
+            "range": [
+                16,
+                17
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -255,15 +260,15 @@ module.exports = {
                     "line": 1,
                     "column": 17
                 }
-            },
-            "range": [
-                16,
-                17
-            ]
+            }
         },
         {
             "type": "String",
             "value": "\"prototype\"",
+            "range": [
+                17,
+                28
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -273,15 +278,15 @@ module.exports = {
                     "line": 1,
                     "column": 28
                 }
-            },
-            "range": [
-                17,
-                28
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "]",
+            "range": [
+                28,
+                29
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -291,15 +296,15 @@ module.exports = {
                     "line": 1,
                     "column": 29
                 }
-            },
-            "range": [
-                28,
-                29
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                29,
+                30
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -309,15 +314,15 @@ module.exports = {
                     "line": 1,
                     "column": 30
                 }
-            },
-            "range": [
-                29,
-                30
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                30,
+                31
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -327,15 +332,15 @@ module.exports = {
                     "line": 1,
                     "column": 31
                 }
-            },
-            "range": [
-                30,
-                31
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                31,
+                32
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -345,15 +350,15 @@ module.exports = {
                     "line": 1,
                     "column": 32
                 }
-            },
-            "range": [
-                31,
-                32
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                32,
+                33
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -363,15 +368,15 @@ module.exports = {
                     "line": 1,
                     "column": 33
                 }
-            },
-            "range": [
-                32,
-                33
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                33,
+                34
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -381,15 +386,15 @@ module.exports = {
                     "line": 1,
                     "column": 34
                 }
-            },
-            "range": [
-                33,
-                34
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                34,
+                35
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -399,11 +404,7 @@ module.exports = {
                     "line": 1,
                     "column": 35
                 }
-            },
-            "range": [
-                34,
-                35
-            ]
+            }
         }
     ]
 };

--- a/tests/fixtures/ecma-features/classes/class-static-method-named-static.result.js
+++ b/tests/fixtures/ecma-features/classes/class-static-method-named-static.result.js
@@ -1,5 +1,9 @@
 module.exports = {
     "type": "Program",
+    "range": [
+        0,
+        29
+    ],
     "loc": {
         "start": {
             "line": 1,
@@ -10,14 +14,13 @@ module.exports = {
             "column": 29
         }
     },
-    "range": [
-        0,
-        29
-    ],
     "body": [
         {
             "type": "ClassDeclaration",
-            "decorators": [],
+            "range": [
+                0,
+                28
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -28,12 +31,12 @@ module.exports = {
                     "column": 28
                 }
             },
-            "range": [
-                0,
-                28
-            ],
             "id": {
                 "type": "Identifier",
+                "range": [
+                    6,
+                    7
+                ],
                 "loc": {
                     "start": {
                         "line": 1,
@@ -44,33 +47,17 @@ module.exports = {
                         "column": 7
                     }
                 },
-                "range": [
-                    6,
-                    7
-                ],
                 "name": "A"
             },
-            "superClass": null,
-            "implements": [],
             "body": {
                 "type": "ClassBody",
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 8
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 28
-                    }
-                },
-                "range": [
-                    8,
-                    28
-                ],
                 "body": [
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            9,
+                            26
+                        ],
                         "loc": {
                             "start": {
                                 "line": 1,
@@ -81,14 +68,12 @@ module.exports = {
                                 "column": 26
                             }
                         },
-                        "range": [
-                            9,
-                            26
-                        ],
-                        "computed": false,
-                        "decorators": [],
                         "key": {
                             "type": "Identifier",
+                            "range": [
+                                16,
+                                22
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -99,36 +84,19 @@ module.exports = {
                                     "column": 22
                                 }
                             },
-                            "range": [
-                                16,
-                                22
-                            ],
                             "name": "static"
                         },
-                        "static": true,
-                        "kind": "method",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 22
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 26
-                                }
-                            },
-                            "range": [
-                                22,
-                                26
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    24,
+                                    26
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 1,
@@ -139,19 +107,56 @@ module.exports = {
                                         "column": 26
                                     }
                                 },
-                                "range": [
-                                    24,
-                                    26
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                22,
+                                26
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 22
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 26
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": true,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": []
                     }
-                ]
-            }
+                ],
+                "range": [
+                    8,
+                    28
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 28
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
         },
         {
             "type": "EmptyStatement",
+            "range": [
+                28,
+                29
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -161,11 +166,7 @@ module.exports = {
                     "line": 1,
                     "column": 29
                 }
-            },
-            "range": [
-                28,
-                29
-            ]
+            }
         }
     ],
     "sourceType": "script",
@@ -173,6 +174,10 @@ module.exports = {
         {
             "type": "Keyword",
             "value": "class",
+            "range": [
+                0,
+                5
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -182,15 +187,15 @@ module.exports = {
                     "line": 1,
                     "column": 5
                 }
-            },
-            "range": [
-                0,
-                5
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "A",
+            "range": [
+                6,
+                7
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -200,15 +205,15 @@ module.exports = {
                     "line": 1,
                     "column": 7
                 }
-            },
-            "range": [
-                6,
-                7
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                8,
+                9
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -218,15 +223,15 @@ module.exports = {
                     "line": 1,
                     "column": 9
                 }
-            },
-            "range": [
-                8,
-                9
-            ]
+            }
         },
         {
             "type": "Keyword",
             "value": "static",
+            "range": [
+                9,
+                15
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -236,15 +241,15 @@ module.exports = {
                     "line": 1,
                     "column": 15
                 }
-            },
-            "range": [
-                9,
-                15
-            ]
+            }
         },
         {
             "type": "Keyword",
             "value": "static",
+            "range": [
+                16,
+                22
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -254,15 +259,15 @@ module.exports = {
                     "line": 1,
                     "column": 22
                 }
-            },
-            "range": [
-                16,
-                22
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                22,
+                23
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -272,15 +277,15 @@ module.exports = {
                     "line": 1,
                     "column": 23
                 }
-            },
-            "range": [
-                22,
-                23
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                23,
+                24
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -290,15 +295,15 @@ module.exports = {
                     "line": 1,
                     "column": 24
                 }
-            },
-            "range": [
-                23,
-                24
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                24,
+                25
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -308,15 +313,15 @@ module.exports = {
                     "line": 1,
                     "column": 25
                 }
-            },
-            "range": [
-                24,
-                25
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                25,
+                26
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -326,15 +331,15 @@ module.exports = {
                     "line": 1,
                     "column": 26
                 }
-            },
-            "range": [
-                25,
-                26
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                26,
+                27
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -344,15 +349,15 @@ module.exports = {
                     "line": 1,
                     "column": 27
                 }
-            },
-            "range": [
-                26,
-                27
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                27,
+                28
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -362,15 +367,15 @@ module.exports = {
                     "line": 1,
                     "column": 28
                 }
-            },
-            "range": [
-                27,
-                28
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                28,
+                29
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -380,11 +385,7 @@ module.exports = {
                     "line": 1,
                     "column": 29
                 }
-            },
-            "range": [
-                28,
-                29
-            ]
+            }
         }
     ]
 };

--- a/tests/fixtures/ecma-features/classes/class-static-method.result.js
+++ b/tests/fixtures/ecma-features/classes/class-static-method.result.js
@@ -1,5 +1,9 @@
 module.exports = {
     "type": "Program",
+    "range": [
+        0,
+        24
+    ],
     "loc": {
         "start": {
             "line": 1,
@@ -10,14 +14,13 @@ module.exports = {
             "column": 24
         }
     },
-    "range": [
-        0,
-        24
-    ],
     "body": [
         {
             "type": "ClassDeclaration",
-            "decorators": [],
+            "range": [
+                0,
+                23
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -28,12 +31,12 @@ module.exports = {
                     "column": 23
                 }
             },
-            "range": [
-                0,
-                23
-            ],
             "id": {
                 "type": "Identifier",
+                "range": [
+                    6,
+                    7
+                ],
                 "loc": {
                     "start": {
                         "line": 1,
@@ -44,33 +47,17 @@ module.exports = {
                         "column": 7
                     }
                 },
-                "range": [
-                    6,
-                    7
-                ],
                 "name": "A"
             },
-            "superClass": null,
-            "implements": [],
             "body": {
                 "type": "ClassBody",
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 8
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 23
-                    }
-                },
-                "range": [
-                    8,
-                    23
-                ],
                 "body": [
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            9,
+                            21
+                        ],
                         "loc": {
                             "start": {
                                 "line": 1,
@@ -81,14 +68,12 @@ module.exports = {
                                 "column": 21
                             }
                         },
-                        "range": [
-                            9,
-                            21
-                        ],
-                        "computed": false,
-                        "decorators": [],
                         "key": {
                             "type": "Identifier",
+                            "range": [
+                                16,
+                                17
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -99,36 +84,19 @@ module.exports = {
                                     "column": 17
                                 }
                             },
-                            "range": [
-                                16,
-                                17
-                            ],
                             "name": "a"
                         },
-                        "static": true,
-                        "kind": "method",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 17
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 21
-                                }
-                            },
-                            "range": [
-                                17,
-                                21
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    19,
+                                    21
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 1,
@@ -139,19 +107,56 @@ module.exports = {
                                         "column": 21
                                     }
                                 },
-                                "range": [
-                                    19,
-                                    21
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                17,
+                                21
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 17
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 21
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": true,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": []
                     }
-                ]
-            }
+                ],
+                "range": [
+                    8,
+                    23
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 23
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
         },
         {
             "type": "EmptyStatement",
+            "range": [
+                23,
+                24
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -161,11 +166,7 @@ module.exports = {
                     "line": 1,
                     "column": 24
                 }
-            },
-            "range": [
-                23,
-                24
-            ]
+            }
         }
     ],
     "sourceType": "script",
@@ -173,6 +174,10 @@ module.exports = {
         {
             "type": "Keyword",
             "value": "class",
+            "range": [
+                0,
+                5
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -182,15 +187,15 @@ module.exports = {
                     "line": 1,
                     "column": 5
                 }
-            },
-            "range": [
-                0,
-                5
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "A",
+            "range": [
+                6,
+                7
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -200,15 +205,15 @@ module.exports = {
                     "line": 1,
                     "column": 7
                 }
-            },
-            "range": [
-                6,
-                7
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                8,
+                9
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -218,15 +223,15 @@ module.exports = {
                     "line": 1,
                     "column": 9
                 }
-            },
-            "range": [
-                8,
-                9
-            ]
+            }
         },
         {
             "type": "Keyword",
             "value": "static",
+            "range": [
+                9,
+                15
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -236,15 +241,15 @@ module.exports = {
                     "line": 1,
                     "column": 15
                 }
-            },
-            "range": [
-                9,
-                15
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "a",
+            "range": [
+                16,
+                17
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -254,15 +259,15 @@ module.exports = {
                     "line": 1,
                     "column": 17
                 }
-            },
-            "range": [
-                16,
-                17
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                17,
+                18
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -272,15 +277,15 @@ module.exports = {
                     "line": 1,
                     "column": 18
                 }
-            },
-            "range": [
-                17,
-                18
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                18,
+                19
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -290,15 +295,15 @@ module.exports = {
                     "line": 1,
                     "column": 19
                 }
-            },
-            "range": [
-                18,
-                19
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                19,
+                20
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -308,15 +313,15 @@ module.exports = {
                     "line": 1,
                     "column": 20
                 }
-            },
-            "range": [
-                19,
-                20
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                20,
+                21
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -326,15 +331,15 @@ module.exports = {
                     "line": 1,
                     "column": 21
                 }
-            },
-            "range": [
-                20,
-                21
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                21,
+                22
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -344,15 +349,15 @@ module.exports = {
                     "line": 1,
                     "column": 22
                 }
-            },
-            "range": [
-                21,
-                22
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                22,
+                23
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -362,15 +367,15 @@ module.exports = {
                     "line": 1,
                     "column": 23
                 }
-            },
-            "range": [
-                22,
-                23
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                23,
+                24
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -380,11 +385,7 @@ module.exports = {
                     "line": 1,
                     "column": 24
                 }
-            },
-            "range": [
-                23,
-                24
-            ]
+            }
         }
     ]
 };

--- a/tests/fixtures/ecma-features/classes/class-static-methods-and-accessor-properties.result.js
+++ b/tests/fixtures/ecma-features/classes/class-static-methods-and-accessor-properties.result.js
@@ -1,5 +1,9 @@
 module.exports = {
     "type": "Program",
+    "range": [
+        0,
+        59
+    ],
     "loc": {
         "start": {
             "line": 1,
@@ -10,14 +14,13 @@ module.exports = {
             "column": 59
         }
     },
-    "range": [
-        0,
-        59
-    ],
     "body": [
         {
             "type": "ClassDeclaration",
-            "decorators": [],
+            "range": [
+                0,
+                58
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -28,12 +31,12 @@ module.exports = {
                     "column": 58
                 }
             },
-            "range": [
-                0,
-                58
-            ],
             "id": {
                 "type": "Identifier",
+                "range": [
+                    6,
+                    7
+                ],
                 "loc": {
                     "start": {
                         "line": 1,
@@ -44,33 +47,17 @@ module.exports = {
                         "column": 7
                     }
                 },
-                "range": [
-                    6,
-                    7
-                ],
                 "name": "A"
             },
-            "superClass": null,
-            "implements": [],
             "body": {
                 "type": "ClassBody",
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 8
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 58
-                    }
-                },
-                "range": [
-                    8,
-                    58
-                ],
                 "body": [
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            9,
+                            21
+                        ],
                         "loc": {
                             "start": {
                                 "line": 1,
@@ -81,14 +68,12 @@ module.exports = {
                                 "column": 21
                             }
                         },
-                        "range": [
-                            9,
-                            21
-                        ],
-                        "computed": false,
-                        "decorators": [],
                         "key": {
                             "type": "Identifier",
+                            "range": [
+                                16,
+                                17
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -99,36 +84,19 @@ module.exports = {
                                     "column": 17
                                 }
                             },
-                            "range": [
-                                16,
-                                17
-                            ],
                             "name": "a"
                         },
-                        "static": true,
-                        "kind": "method",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 17
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 21
-                                }
-                            },
-                            "range": [
-                                17,
-                                21
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    19,
+                                    21
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 1,
@@ -139,16 +107,36 @@ module.exports = {
                                         "column": 21
                                     }
                                 },
-                                "range": [
-                                    19,
-                                    21
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                17,
+                                21
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 17
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 21
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": true,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": []
                     },
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            22,
+                            38
+                        ],
                         "loc": {
                             "start": {
                                 "line": 1,
@@ -159,14 +147,12 @@ module.exports = {
                                 "column": 38
                             }
                         },
-                        "range": [
-                            22,
-                            38
-                        ],
-                        "computed": false,
-                        "decorators": [],
                         "key": {
                             "type": "Identifier",
+                            "range": [
+                                33,
+                                34
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -177,36 +163,19 @@ module.exports = {
                                     "column": 34
                                 }
                             },
-                            "range": [
-                                33,
-                                34
-                            ],
                             "name": "a"
                         },
-                        "static": true,
-                        "kind": "get",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 34
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 38
-                                }
-                            },
-                            "range": [
-                                34,
-                                38
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    36,
+                                    38
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 1,
@@ -217,16 +186,36 @@ module.exports = {
                                         "column": 38
                                     }
                                 },
-                                "range": [
-                                    36,
-                                    38
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                34,
+                                38
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 34
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 38
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": true,
+                        "kind": "get",
+                        "accessibility": null,
+                        "decorators": []
                     },
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            39,
+                            56
+                        ],
                         "loc": {
                             "start": {
                                 "line": 1,
@@ -237,14 +226,12 @@ module.exports = {
                                 "column": 56
                             }
                         },
-                        "range": [
-                            39,
-                            56
-                        ],
-                        "computed": false,
-                        "decorators": [],
                         "key": {
                             "type": "Identifier",
+                            "range": [
+                                50,
+                                51
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -255,56 +242,19 @@ module.exports = {
                                     "column": 51
                                 }
                             },
-                            "range": [
-                                50,
-                                51
-                            ],
                             "name": "a"
                         },
-                        "static": true,
-                        "kind": "set",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 51
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 56
-                                }
-                            },
-                            "range": [
-                                51,
-                                56
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [
-                                {
-                                    "type": "Identifier",
-                                    "loc": {
-                                        "start": {
-                                            "line": 1,
-                                            "column": 52
-                                        },
-                                        "end": {
-                                            "line": 1,
-                                            "column": 53
-                                        }
-                                    },
-                                    "range": [
-                                        52,
-                                        53
-                                    ],
-                                    "name": "b",
-                                    "decorators": []
-                                }
-                            ],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    54,
+                                    56
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 1,
@@ -315,19 +265,76 @@ module.exports = {
                                         "column": 56
                                     }
                                 },
-                                "range": [
-                                    54,
-                                    56
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                51,
+                                56
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 51
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 56
+                                }
+                            },
+                            "params": [
+                                {
+                                    "type": "Identifier",
+                                    "range": [
+                                        52,
+                                        53
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 1,
+                                            "column": 52
+                                        },
+                                        "end": {
+                                            "line": 1,
+                                            "column": 53
+                                        }
+                                    },
+                                    "name": "b",
+                                    "decorators": []
+                                }
+                            ]
+                        },
+                        "computed": false,
+                        "static": true,
+                        "kind": "set",
+                        "accessibility": null,
+                        "decorators": []
                     }
-                ]
-            }
+                ],
+                "range": [
+                    8,
+                    58
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 58
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
         },
         {
             "type": "EmptyStatement",
+            "range": [
+                58,
+                59
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -337,11 +344,7 @@ module.exports = {
                     "line": 1,
                     "column": 59
                 }
-            },
-            "range": [
-                58,
-                59
-            ]
+            }
         }
     ],
     "sourceType": "script",
@@ -349,6 +352,10 @@ module.exports = {
         {
             "type": "Keyword",
             "value": "class",
+            "range": [
+                0,
+                5
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -358,15 +365,15 @@ module.exports = {
                     "line": 1,
                     "column": 5
                 }
-            },
-            "range": [
-                0,
-                5
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "A",
+            "range": [
+                6,
+                7
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -376,15 +383,15 @@ module.exports = {
                     "line": 1,
                     "column": 7
                 }
-            },
-            "range": [
-                6,
-                7
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                8,
+                9
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -394,15 +401,15 @@ module.exports = {
                     "line": 1,
                     "column": 9
                 }
-            },
-            "range": [
-                8,
-                9
-            ]
+            }
         },
         {
             "type": "Keyword",
             "value": "static",
+            "range": [
+                9,
+                15
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -412,15 +419,15 @@ module.exports = {
                     "line": 1,
                     "column": 15
                 }
-            },
-            "range": [
-                9,
-                15
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "a",
+            "range": [
+                16,
+                17
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -430,15 +437,15 @@ module.exports = {
                     "line": 1,
                     "column": 17
                 }
-            },
-            "range": [
-                16,
-                17
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                17,
+                18
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -448,15 +455,15 @@ module.exports = {
                     "line": 1,
                     "column": 18
                 }
-            },
-            "range": [
-                17,
-                18
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                18,
+                19
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -466,15 +473,15 @@ module.exports = {
                     "line": 1,
                     "column": 19
                 }
-            },
-            "range": [
-                18,
-                19
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                19,
+                20
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -484,15 +491,15 @@ module.exports = {
                     "line": 1,
                     "column": 20
                 }
-            },
-            "range": [
-                19,
-                20
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                20,
+                21
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -502,15 +509,15 @@ module.exports = {
                     "line": 1,
                     "column": 21
                 }
-            },
-            "range": [
-                20,
-                21
-            ]
+            }
         },
         {
             "type": "Keyword",
             "value": "static",
+            "range": [
+                22,
+                28
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -520,15 +527,15 @@ module.exports = {
                     "line": 1,
                     "column": 28
                 }
-            },
-            "range": [
-                22,
-                28
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "get",
+            "range": [
+                29,
+                32
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -538,15 +545,15 @@ module.exports = {
                     "line": 1,
                     "column": 32
                 }
-            },
-            "range": [
-                29,
-                32
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "a",
+            "range": [
+                33,
+                34
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -556,15 +563,15 @@ module.exports = {
                     "line": 1,
                     "column": 34
                 }
-            },
-            "range": [
-                33,
-                34
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                34,
+                35
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -574,15 +581,15 @@ module.exports = {
                     "line": 1,
                     "column": 35
                 }
-            },
-            "range": [
-                34,
-                35
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                35,
+                36
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -592,15 +599,15 @@ module.exports = {
                     "line": 1,
                     "column": 36
                 }
-            },
-            "range": [
-                35,
-                36
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                36,
+                37
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -610,15 +617,15 @@ module.exports = {
                     "line": 1,
                     "column": 37
                 }
-            },
-            "range": [
-                36,
-                37
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                37,
+                38
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -628,15 +635,15 @@ module.exports = {
                     "line": 1,
                     "column": 38
                 }
-            },
-            "range": [
-                37,
-                38
-            ]
+            }
         },
         {
             "type": "Keyword",
             "value": "static",
+            "range": [
+                39,
+                45
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -646,15 +653,15 @@ module.exports = {
                     "line": 1,
                     "column": 45
                 }
-            },
-            "range": [
-                39,
-                45
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "set",
+            "range": [
+                46,
+                49
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -664,15 +671,15 @@ module.exports = {
                     "line": 1,
                     "column": 49
                 }
-            },
-            "range": [
-                46,
-                49
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "a",
+            "range": [
+                50,
+                51
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -682,15 +689,15 @@ module.exports = {
                     "line": 1,
                     "column": 51
                 }
-            },
-            "range": [
-                50,
-                51
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                51,
+                52
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -700,15 +707,15 @@ module.exports = {
                     "line": 1,
                     "column": 52
                 }
-            },
-            "range": [
-                51,
-                52
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "b",
+            "range": [
+                52,
+                53
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -718,15 +725,15 @@ module.exports = {
                     "line": 1,
                     "column": 53
                 }
-            },
-            "range": [
-                52,
-                53
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                53,
+                54
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -736,15 +743,15 @@ module.exports = {
                     "line": 1,
                     "column": 54
                 }
-            },
-            "range": [
-                53,
-                54
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                54,
+                55
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -754,15 +761,15 @@ module.exports = {
                     "line": 1,
                     "column": 55
                 }
-            },
-            "range": [
-                54,
-                55
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                55,
+                56
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -772,15 +779,15 @@ module.exports = {
                     "line": 1,
                     "column": 56
                 }
-            },
-            "range": [
-                55,
-                56
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                57,
+                58
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -790,15 +797,15 @@ module.exports = {
                     "line": 1,
                     "column": 58
                 }
-            },
-            "range": [
-                57,
-                58
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                58,
+                59
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -808,11 +815,7 @@ module.exports = {
                     "line": 1,
                     "column": 59
                 }
-            },
-            "range": [
-                58,
-                59
-            ]
+            }
         }
     ]
 };

--- a/tests/fixtures/ecma-features/classes/class-two-computed-static-methods.result.js
+++ b/tests/fixtures/ecma-features/classes/class-two-computed-static-methods.result.js
@@ -1,5 +1,9 @@
 module.exports = {
     "type": "Program",
+    "range": [
+        0,
+        39
+    ],
     "loc": {
         "start": {
             "line": 1,
@@ -10,14 +14,13 @@ module.exports = {
             "column": 39
         }
     },
-    "range": [
-        0,
-        39
-    ],
     "body": [
         {
             "type": "ClassDeclaration",
-            "decorators": [],
+            "range": [
+                0,
+                38
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -28,12 +31,12 @@ module.exports = {
                     "column": 38
                 }
             },
-            "range": [
-                0,
-                38
-            ],
             "id": {
                 "type": "Identifier",
+                "range": [
+                    6,
+                    7
+                ],
                 "loc": {
                     "start": {
                         "line": 1,
@@ -44,33 +47,17 @@ module.exports = {
                         "column": 7
                     }
                 },
-                "range": [
-                    6,
-                    7
-                ],
                 "name": "A"
             },
-            "superClass": null,
-            "implements": [],
             "body": {
                 "type": "ClassBody",
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 8
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 38
-                    }
-                },
-                "range": [
-                    8,
-                    38
-                ],
                 "body": [
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            9,
+                            22
+                        ],
                         "loc": {
                             "start": {
                                 "line": 1,
@@ -81,14 +68,12 @@ module.exports = {
                                 "column": 22
                             }
                         },
-                        "range": [
-                            9,
-                            22
-                        ],
-                        "computed": true,
-                        "decorators": [],
                         "key": {
                             "type": "Identifier",
+                            "range": [
+                                16,
+                                17
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -99,36 +84,19 @@ module.exports = {
                                     "column": 17
                                 }
                             },
-                            "range": [
-                                16,
-                                17
-                            ],
                             "name": "a"
                         },
-                        "static": true,
-                        "kind": "method",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 18
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 22
-                                }
-                            },
-                            "range": [
-                                18,
-                                22
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    20,
+                                    22
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 1,
@@ -139,16 +107,36 @@ module.exports = {
                                         "column": 22
                                     }
                                 },
-                                "range": [
-                                    20,
-                                    22
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                18,
+                                22
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 18
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 22
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": true,
+                        "static": true,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": []
                     },
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            24,
+                            37
+                        ],
                         "loc": {
                             "start": {
                                 "line": 1,
@@ -159,14 +147,12 @@ module.exports = {
                                 "column": 37
                             }
                         },
-                        "range": [
-                            24,
-                            37
-                        ],
-                        "computed": true,
-                        "decorators": [],
                         "key": {
                             "type": "Identifier",
+                            "range": [
+                                31,
+                                32
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -177,36 +163,19 @@ module.exports = {
                                     "column": 32
                                 }
                             },
-                            "range": [
-                                31,
-                                32
-                            ],
                             "name": "b"
                         },
-                        "static": true,
-                        "kind": "method",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 33
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 37
-                                }
-                            },
-                            "range": [
-                                33,
-                                37
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    35,
+                                    37
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 1,
@@ -217,19 +186,56 @@ module.exports = {
                                         "column": 37
                                     }
                                 },
-                                "range": [
-                                    35,
-                                    37
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                33,
+                                37
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 33
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 37
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": true,
+                        "static": true,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": []
                     }
-                ]
-            }
+                ],
+                "range": [
+                    8,
+                    38
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 38
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
         },
         {
             "type": "EmptyStatement",
+            "range": [
+                38,
+                39
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -239,11 +245,7 @@ module.exports = {
                     "line": 1,
                     "column": 39
                 }
-            },
-            "range": [
-                38,
-                39
-            ]
+            }
         }
     ],
     "sourceType": "script",
@@ -251,6 +253,10 @@ module.exports = {
         {
             "type": "Keyword",
             "value": "class",
+            "range": [
+                0,
+                5
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -260,15 +266,15 @@ module.exports = {
                     "line": 1,
                     "column": 5
                 }
-            },
-            "range": [
-                0,
-                5
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "A",
+            "range": [
+                6,
+                7
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -278,15 +284,15 @@ module.exports = {
                     "line": 1,
                     "column": 7
                 }
-            },
-            "range": [
-                6,
-                7
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                8,
+                9
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -296,15 +302,15 @@ module.exports = {
                     "line": 1,
                     "column": 9
                 }
-            },
-            "range": [
-                8,
-                9
-            ]
+            }
         },
         {
             "type": "Keyword",
             "value": "static",
+            "range": [
+                9,
+                15
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -314,15 +320,15 @@ module.exports = {
                     "line": 1,
                     "column": 15
                 }
-            },
-            "range": [
-                9,
-                15
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "[",
+            "range": [
+                15,
+                16
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -332,15 +338,15 @@ module.exports = {
                     "line": 1,
                     "column": 16
                 }
-            },
-            "range": [
-                15,
-                16
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "a",
+            "range": [
+                16,
+                17
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -350,15 +356,15 @@ module.exports = {
                     "line": 1,
                     "column": 17
                 }
-            },
-            "range": [
-                16,
-                17
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "]",
+            "range": [
+                17,
+                18
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -368,15 +374,15 @@ module.exports = {
                     "line": 1,
                     "column": 18
                 }
-            },
-            "range": [
-                17,
-                18
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                18,
+                19
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -386,15 +392,15 @@ module.exports = {
                     "line": 1,
                     "column": 19
                 }
-            },
-            "range": [
-                18,
-                19
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                19,
+                20
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -404,15 +410,15 @@ module.exports = {
                     "line": 1,
                     "column": 20
                 }
-            },
-            "range": [
-                19,
-                20
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                20,
+                21
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -422,15 +428,15 @@ module.exports = {
                     "line": 1,
                     "column": 21
                 }
-            },
-            "range": [
-                20,
-                21
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                21,
+                22
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -440,15 +446,15 @@ module.exports = {
                     "line": 1,
                     "column": 22
                 }
-            },
-            "range": [
-                21,
-                22
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                22,
+                23
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -458,15 +464,15 @@ module.exports = {
                     "line": 1,
                     "column": 23
                 }
-            },
-            "range": [
-                22,
-                23
-            ]
+            }
         },
         {
             "type": "Keyword",
             "value": "static",
+            "range": [
+                24,
+                30
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -476,15 +482,15 @@ module.exports = {
                     "line": 1,
                     "column": 30
                 }
-            },
-            "range": [
-                24,
-                30
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "[",
+            "range": [
+                30,
+                31
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -494,15 +500,15 @@ module.exports = {
                     "line": 1,
                     "column": 31
                 }
-            },
-            "range": [
-                30,
-                31
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "b",
+            "range": [
+                31,
+                32
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -512,15 +518,15 @@ module.exports = {
                     "line": 1,
                     "column": 32
                 }
-            },
-            "range": [
-                31,
-                32
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "]",
+            "range": [
+                32,
+                33
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -530,15 +536,15 @@ module.exports = {
                     "line": 1,
                     "column": 33
                 }
-            },
-            "range": [
-                32,
-                33
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                33,
+                34
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -548,15 +554,15 @@ module.exports = {
                     "line": 1,
                     "column": 34
                 }
-            },
-            "range": [
-                33,
-                34
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                34,
+                35
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -566,15 +572,15 @@ module.exports = {
                     "line": 1,
                     "column": 35
                 }
-            },
-            "range": [
-                34,
-                35
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                35,
+                36
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -584,15 +590,15 @@ module.exports = {
                     "line": 1,
                     "column": 36
                 }
-            },
-            "range": [
-                35,
-                36
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                36,
+                37
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -602,15 +608,15 @@ module.exports = {
                     "line": 1,
                     "column": 37
                 }
-            },
-            "range": [
-                36,
-                37
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                37,
+                38
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -620,15 +626,15 @@ module.exports = {
                     "line": 1,
                     "column": 38
                 }
-            },
-            "range": [
-                37,
-                38
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                38,
+                39
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -638,11 +644,7 @@ module.exports = {
                     "line": 1,
                     "column": 39
                 }
-            },
-            "range": [
-                38,
-                39
-            ]
+            }
         }
     ]
 };

--- a/tests/fixtures/ecma-features/classes/class-two-methods-computed-constructor.result.js
+++ b/tests/fixtures/ecma-features/classes/class-two-methods-computed-constructor.result.js
@@ -1,5 +1,9 @@
 module.exports = {
     "type": "Program",
+    "range": [
+        0,
+        48
+    ],
     "loc": {
         "start": {
             "line": 1,
@@ -10,14 +14,13 @@ module.exports = {
             "column": 48
         }
     },
-    "range": [
-        0,
-        48
-    ],
     "body": [
         {
             "type": "ClassDeclaration",
-            "decorators": [],
+            "range": [
+                0,
+                47
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -28,12 +31,12 @@ module.exports = {
                     "column": 47
                 }
             },
-            "range": [
-                0,
-                47
-            ],
             "id": {
                 "type": "Identifier",
+                "range": [
+                    6,
+                    7
+                ],
                 "loc": {
                     "start": {
                         "line": 1,
@@ -44,33 +47,17 @@ module.exports = {
                         "column": 7
                     }
                 },
-                "range": [
-                    6,
-                    7
-                ],
                 "name": "A"
             },
-            "superClass": null,
-            "implements": [],
             "body": {
                 "type": "ClassBody",
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 8
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 47
-                    }
-                },
-                "range": [
-                    8,
-                    47
-                ],
                 "body": [
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            9,
+                            26
+                        ],
                         "loc": {
                             "start": {
                                 "line": 1,
@@ -81,14 +68,12 @@ module.exports = {
                                 "column": 26
                             }
                         },
-                        "range": [
-                            9,
-                            26
-                        ],
-                        "computed": false,
-                        "decorators": [],
                         "key": {
                             "type": "Literal",
+                            "range": [
+                                9,
+                                22
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -99,37 +84,20 @@ module.exports = {
                                     "column": 22
                                 }
                             },
-                            "range": [
-                                9,
-                                22
-                            ],
                             "value": "constructor",
                             "raw": "\"constructor\""
                         },
-                        "static": false,
-                        "kind": "constructor",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 22
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 26
-                                }
-                            },
-                            "range": [
-                                22,
-                                26
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    24,
+                                    26
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 1,
@@ -140,16 +108,36 @@ module.exports = {
                                         "column": 26
                                     }
                                 },
-                                "range": [
-                                    24,
-                                    26
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                22,
+                                26
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 22
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 26
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": false,
+                        "kind": "constructor",
+                        "accessibility": null,
+                        "decorators": []
                     },
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            27,
+                            46
+                        ],
                         "loc": {
                             "start": {
                                 "line": 1,
@@ -160,14 +148,12 @@ module.exports = {
                                 "column": 46
                             }
                         },
-                        "range": [
-                            27,
-                            46
-                        ],
-                        "computed": true,
-                        "decorators": [],
                         "key": {
                             "type": "Literal",
+                            "range": [
+                                28,
+                                41
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -178,37 +164,20 @@ module.exports = {
                                     "column": 41
                                 }
                             },
-                            "range": [
-                                28,
-                                41
-                            ],
                             "value": "constructor",
                             "raw": "\"constructor\""
                         },
-                        "static": false,
-                        "kind": "method",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 42
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 46
-                                }
-                            },
-                            "range": [
-                                42,
-                                46
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    44,
+                                    46
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 1,
@@ -219,19 +188,56 @@ module.exports = {
                                         "column": 46
                                     }
                                 },
-                                "range": [
-                                    44,
-                                    46
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                42,
+                                46
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 42
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 46
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": true,
+                        "static": false,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": []
                     }
-                ]
-            }
+                ],
+                "range": [
+                    8,
+                    47
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 47
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
         },
         {
             "type": "EmptyStatement",
+            "range": [
+                47,
+                48
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -241,11 +247,7 @@ module.exports = {
                     "line": 1,
                     "column": 48
                 }
-            },
-            "range": [
-                47,
-                48
-            ]
+            }
         }
     ],
     "sourceType": "script",
@@ -253,6 +255,10 @@ module.exports = {
         {
             "type": "Keyword",
             "value": "class",
+            "range": [
+                0,
+                5
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -262,15 +268,15 @@ module.exports = {
                     "line": 1,
                     "column": 5
                 }
-            },
-            "range": [
-                0,
-                5
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "A",
+            "range": [
+                6,
+                7
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -280,15 +286,15 @@ module.exports = {
                     "line": 1,
                     "column": 7
                 }
-            },
-            "range": [
-                6,
-                7
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                8,
+                9
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -298,15 +304,15 @@ module.exports = {
                     "line": 1,
                     "column": 9
                 }
-            },
-            "range": [
-                8,
-                9
-            ]
+            }
         },
         {
             "type": "String",
             "value": "\"constructor\"",
+            "range": [
+                9,
+                22
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -316,15 +322,15 @@ module.exports = {
                     "line": 1,
                     "column": 22
                 }
-            },
-            "range": [
-                9,
-                22
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                22,
+                23
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -334,15 +340,15 @@ module.exports = {
                     "line": 1,
                     "column": 23
                 }
-            },
-            "range": [
-                22,
-                23
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                23,
+                24
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -352,15 +358,15 @@ module.exports = {
                     "line": 1,
                     "column": 24
                 }
-            },
-            "range": [
-                23,
-                24
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                24,
+                25
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -370,15 +376,15 @@ module.exports = {
                     "line": 1,
                     "column": 25
                 }
-            },
-            "range": [
-                24,
-                25
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                25,
+                26
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -388,15 +394,15 @@ module.exports = {
                     "line": 1,
                     "column": 26
                 }
-            },
-            "range": [
-                25,
-                26
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "[",
+            "range": [
+                27,
+                28
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -406,15 +412,15 @@ module.exports = {
                     "line": 1,
                     "column": 28
                 }
-            },
-            "range": [
-                27,
-                28
-            ]
+            }
         },
         {
             "type": "String",
             "value": "\"constructor\"",
+            "range": [
+                28,
+                41
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -424,15 +430,15 @@ module.exports = {
                     "line": 1,
                     "column": 41
                 }
-            },
-            "range": [
-                28,
-                41
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "]",
+            "range": [
+                41,
+                42
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -442,15 +448,15 @@ module.exports = {
                     "line": 1,
                     "column": 42
                 }
-            },
-            "range": [
-                41,
-                42
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                42,
+                43
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -460,15 +466,15 @@ module.exports = {
                     "line": 1,
                     "column": 43
                 }
-            },
-            "range": [
-                42,
-                43
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                43,
+                44
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -478,15 +484,15 @@ module.exports = {
                     "line": 1,
                     "column": 44
                 }
-            },
-            "range": [
-                43,
-                44
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                44,
+                45
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -496,15 +502,15 @@ module.exports = {
                     "line": 1,
                     "column": 45
                 }
-            },
-            "range": [
-                44,
-                45
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                45,
+                46
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -514,15 +520,15 @@ module.exports = {
                     "line": 1,
                     "column": 46
                 }
-            },
-            "range": [
-                45,
-                46
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                46,
+                47
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -532,15 +538,15 @@ module.exports = {
                     "line": 1,
                     "column": 47
                 }
-            },
-            "range": [
-                46,
-                47
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                47,
+                48
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -550,11 +556,7 @@ module.exports = {
                     "line": 1,
                     "column": 48
                 }
-            },
-            "range": [
-                47,
-                48
-            ]
+            }
         }
     ]
 };

--- a/tests/fixtures/ecma-features/classes/class-two-methods-semi.result.js
+++ b/tests/fixtures/ecma-features/classes/class-two-methods-semi.result.js
@@ -1,5 +1,9 @@
 module.exports = {
     "type": "Program",
+    "range": [
+        0,
+        22
+    ],
     "loc": {
         "start": {
             "line": 1,
@@ -10,14 +14,13 @@ module.exports = {
             "column": 22
         }
     },
-    "range": [
-        0,
-        22
-    ],
     "body": [
         {
             "type": "ClassDeclaration",
-            "decorators": [],
+            "range": [
+                0,
+                21
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -28,12 +31,12 @@ module.exports = {
                     "column": 21
                 }
             },
-            "range": [
-                0,
-                21
-            ],
             "id": {
                 "type": "Identifier",
+                "range": [
+                    6,
+                    7
+                ],
                 "loc": {
                     "start": {
                         "line": 1,
@@ -44,33 +47,17 @@ module.exports = {
                         "column": 7
                     }
                 },
-                "range": [
-                    6,
-                    7
-                ],
                 "name": "A"
             },
-            "superClass": null,
-            "implements": [],
             "body": {
                 "type": "ClassBody",
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 8
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 21
-                    }
-                },
-                "range": [
-                    8,
-                    21
-                ],
                 "body": [
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            9,
+                            14
+                        ],
                         "loc": {
                             "start": {
                                 "line": 1,
@@ -81,14 +68,12 @@ module.exports = {
                                 "column": 14
                             }
                         },
-                        "range": [
-                            9,
-                            14
-                        ],
-                        "computed": false,
-                        "decorators": [],
                         "key": {
                             "type": "Identifier",
+                            "range": [
+                                9,
+                                10
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -99,36 +84,19 @@ module.exports = {
                                     "column": 10
                                 }
                             },
-                            "range": [
-                                9,
-                                10
-                            ],
                             "name": "a"
                         },
-                        "static": false,
-                        "kind": "method",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 10
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 14
-                                }
-                            },
-                            "range": [
-                                10,
-                                14
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    12,
+                                    14
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 1,
@@ -139,16 +107,36 @@ module.exports = {
                                         "column": 14
                                     }
                                 },
-                                "range": [
-                                    12,
-                                    14
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                10,
+                                14
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 10
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 14
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": false,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": []
                     },
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            15,
+                            20
+                        ],
                         "loc": {
                             "start": {
                                 "line": 1,
@@ -159,14 +147,12 @@ module.exports = {
                                 "column": 20
                             }
                         },
-                        "range": [
-                            15,
-                            20
-                        ],
-                        "computed": false,
-                        "decorators": [],
                         "key": {
                             "type": "Identifier",
+                            "range": [
+                                15,
+                                16
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -177,36 +163,19 @@ module.exports = {
                                     "column": 16
                                 }
                             },
-                            "range": [
-                                15,
-                                16
-                            ],
                             "name": "b"
                         },
-                        "static": false,
-                        "kind": "method",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 16
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 20
-                                }
-                            },
-                            "range": [
-                                16,
-                                20
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    18,
+                                    20
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 1,
@@ -217,19 +186,56 @@ module.exports = {
                                         "column": 20
                                     }
                                 },
-                                "range": [
-                                    18,
-                                    20
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                16,
+                                20
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 16
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 20
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": false,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": []
                     }
-                ]
-            }
+                ],
+                "range": [
+                    8,
+                    21
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 21
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
         },
         {
             "type": "EmptyStatement",
+            "range": [
+                21,
+                22
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -239,11 +245,7 @@ module.exports = {
                     "line": 1,
                     "column": 22
                 }
-            },
-            "range": [
-                21,
-                22
-            ]
+            }
         }
     ],
     "sourceType": "script",
@@ -251,6 +253,10 @@ module.exports = {
         {
             "type": "Keyword",
             "value": "class",
+            "range": [
+                0,
+                5
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -260,15 +266,15 @@ module.exports = {
                     "line": 1,
                     "column": 5
                 }
-            },
-            "range": [
-                0,
-                5
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "A",
+            "range": [
+                6,
+                7
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -278,15 +284,15 @@ module.exports = {
                     "line": 1,
                     "column": 7
                 }
-            },
-            "range": [
-                6,
-                7
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                8,
+                9
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -296,15 +302,15 @@ module.exports = {
                     "line": 1,
                     "column": 9
                 }
-            },
-            "range": [
-                8,
-                9
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "a",
+            "range": [
+                9,
+                10
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -314,15 +320,15 @@ module.exports = {
                     "line": 1,
                     "column": 10
                 }
-            },
-            "range": [
-                9,
-                10
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                10,
+                11
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -332,15 +338,15 @@ module.exports = {
                     "line": 1,
                     "column": 11
                 }
-            },
-            "range": [
-                10,
-                11
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                11,
+                12
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -350,15 +356,15 @@ module.exports = {
                     "line": 1,
                     "column": 12
                 }
-            },
-            "range": [
-                11,
-                12
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                12,
+                13
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -368,15 +374,15 @@ module.exports = {
                     "line": 1,
                     "column": 13
                 }
-            },
-            "range": [
-                12,
-                13
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                13,
+                14
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -386,15 +392,15 @@ module.exports = {
                     "line": 1,
                     "column": 14
                 }
-            },
-            "range": [
-                13,
-                14
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                14,
+                15
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -404,15 +410,15 @@ module.exports = {
                     "line": 1,
                     "column": 15
                 }
-            },
-            "range": [
-                14,
-                15
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "b",
+            "range": [
+                15,
+                16
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -422,15 +428,15 @@ module.exports = {
                     "line": 1,
                     "column": 16
                 }
-            },
-            "range": [
-                15,
-                16
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                16,
+                17
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -440,15 +446,15 @@ module.exports = {
                     "line": 1,
                     "column": 17
                 }
-            },
-            "range": [
-                16,
-                17
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                17,
+                18
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -458,15 +464,15 @@ module.exports = {
                     "line": 1,
                     "column": 18
                 }
-            },
-            "range": [
-                17,
-                18
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                18,
+                19
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -476,15 +482,15 @@ module.exports = {
                     "line": 1,
                     "column": 19
                 }
-            },
-            "range": [
-                18,
-                19
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                19,
+                20
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -494,15 +500,15 @@ module.exports = {
                     "line": 1,
                     "column": 20
                 }
-            },
-            "range": [
-                19,
-                20
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                20,
+                21
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -512,15 +518,15 @@ module.exports = {
                     "line": 1,
                     "column": 21
                 }
-            },
-            "range": [
-                20,
-                21
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                21,
+                22
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -530,11 +536,7 @@ module.exports = {
                     "line": 1,
                     "column": 22
                 }
-            },
-            "range": [
-                21,
-                22
-            ]
+            }
         }
     ]
 };

--- a/tests/fixtures/ecma-features/classes/class-two-methods-three-semi.result.js
+++ b/tests/fixtures/ecma-features/classes/class-two-methods-three-semi.result.js
@@ -1,5 +1,9 @@
 module.exports = {
     "type": "Program",
+    "range": [
+        0,
+        24
+    ],
     "loc": {
         "start": {
             "line": 1,
@@ -10,14 +14,13 @@ module.exports = {
             "column": 24
         }
     },
-    "range": [
-        0,
-        24
-    ],
     "body": [
         {
             "type": "ClassDeclaration",
-            "decorators": [],
+            "range": [
+                0,
+                23
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -28,12 +31,12 @@ module.exports = {
                     "column": 23
                 }
             },
-            "range": [
-                0,
-                23
-            ],
             "id": {
                 "type": "Identifier",
+                "range": [
+                    6,
+                    7
+                ],
                 "loc": {
                     "start": {
                         "line": 1,
@@ -44,33 +47,17 @@ module.exports = {
                         "column": 7
                     }
                 },
-                "range": [
-                    6,
-                    7
-                ],
                 "name": "A"
             },
-            "superClass": null,
-            "implements": [],
             "body": {
                 "type": "ClassBody",
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 8
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 23
-                    }
-                },
-                "range": [
-                    8,
-                    23
-                ],
                 "body": [
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            10,
+                            15
+                        ],
                         "loc": {
                             "start": {
                                 "line": 1,
@@ -81,14 +68,12 @@ module.exports = {
                                 "column": 15
                             }
                         },
-                        "range": [
-                            10,
-                            15
-                        ],
-                        "computed": false,
-                        "decorators": [],
                         "key": {
                             "type": "Identifier",
+                            "range": [
+                                10,
+                                11
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -99,36 +84,19 @@ module.exports = {
                                     "column": 11
                                 }
                             },
-                            "range": [
-                                10,
-                                11
-                            ],
                             "name": "a"
                         },
-                        "static": false,
-                        "kind": "method",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 11
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 15
-                                }
-                            },
-                            "range": [
-                                11,
-                                15
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    13,
+                                    15
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 1,
@@ -139,16 +107,36 @@ module.exports = {
                                         "column": 15
                                     }
                                 },
-                                "range": [
-                                    13,
-                                    15
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                11,
+                                15
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 11
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 15
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": false,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": []
                     },
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            16,
+                            21
+                        ],
                         "loc": {
                             "start": {
                                 "line": 1,
@@ -159,14 +147,12 @@ module.exports = {
                                 "column": 21
                             }
                         },
-                        "range": [
-                            16,
-                            21
-                        ],
-                        "computed": false,
-                        "decorators": [],
                         "key": {
                             "type": "Identifier",
+                            "range": [
+                                16,
+                                17
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -177,36 +163,19 @@ module.exports = {
                                     "column": 17
                                 }
                             },
-                            "range": [
-                                16,
-                                17
-                            ],
                             "name": "b"
                         },
-                        "static": false,
-                        "kind": "method",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 17
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 21
-                                }
-                            },
-                            "range": [
-                                17,
-                                21
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    19,
+                                    21
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 1,
@@ -217,19 +186,56 @@ module.exports = {
                                         "column": 21
                                     }
                                 },
-                                "range": [
-                                    19,
-                                    21
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                17,
+                                21
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 17
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 21
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": false,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": []
                     }
-                ]
-            }
+                ],
+                "range": [
+                    8,
+                    23
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 23
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
         },
         {
             "type": "EmptyStatement",
+            "range": [
+                23,
+                24
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -239,11 +245,7 @@ module.exports = {
                     "line": 1,
                     "column": 24
                 }
-            },
-            "range": [
-                23,
-                24
-            ]
+            }
         }
     ],
     "sourceType": "script",
@@ -251,6 +253,10 @@ module.exports = {
         {
             "type": "Keyword",
             "value": "class",
+            "range": [
+                0,
+                5
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -260,15 +266,15 @@ module.exports = {
                     "line": 1,
                     "column": 5
                 }
-            },
-            "range": [
-                0,
-                5
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "A",
+            "range": [
+                6,
+                7
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -278,15 +284,15 @@ module.exports = {
                     "line": 1,
                     "column": 7
                 }
-            },
-            "range": [
-                6,
-                7
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                8,
+                9
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -296,15 +302,15 @@ module.exports = {
                     "line": 1,
                     "column": 9
                 }
-            },
-            "range": [
-                8,
-                9
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                9,
+                10
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -314,15 +320,15 @@ module.exports = {
                     "line": 1,
                     "column": 10
                 }
-            },
-            "range": [
-                9,
-                10
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "a",
+            "range": [
+                10,
+                11
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -332,15 +338,15 @@ module.exports = {
                     "line": 1,
                     "column": 11
                 }
-            },
-            "range": [
-                10,
-                11
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                11,
+                12
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -350,15 +356,15 @@ module.exports = {
                     "line": 1,
                     "column": 12
                 }
-            },
-            "range": [
-                11,
-                12
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                12,
+                13
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -368,15 +374,15 @@ module.exports = {
                     "line": 1,
                     "column": 13
                 }
-            },
-            "range": [
-                12,
-                13
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                13,
+                14
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -386,15 +392,15 @@ module.exports = {
                     "line": 1,
                     "column": 14
                 }
-            },
-            "range": [
-                13,
-                14
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                14,
+                15
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -404,15 +410,15 @@ module.exports = {
                     "line": 1,
                     "column": 15
                 }
-            },
-            "range": [
-                14,
-                15
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                15,
+                16
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -422,15 +428,15 @@ module.exports = {
                     "line": 1,
                     "column": 16
                 }
-            },
-            "range": [
-                15,
-                16
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "b",
+            "range": [
+                16,
+                17
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -440,15 +446,15 @@ module.exports = {
                     "line": 1,
                     "column": 17
                 }
-            },
-            "range": [
-                16,
-                17
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                17,
+                18
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -458,15 +464,15 @@ module.exports = {
                     "line": 1,
                     "column": 18
                 }
-            },
-            "range": [
-                17,
-                18
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                18,
+                19
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -476,15 +482,15 @@ module.exports = {
                     "line": 1,
                     "column": 19
                 }
-            },
-            "range": [
-                18,
-                19
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                19,
+                20
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -494,15 +500,15 @@ module.exports = {
                     "line": 1,
                     "column": 20
                 }
-            },
-            "range": [
-                19,
-                20
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                20,
+                21
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -512,15 +518,15 @@ module.exports = {
                     "line": 1,
                     "column": 21
                 }
-            },
-            "range": [
-                20,
-                21
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                21,
+                22
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -530,15 +536,15 @@ module.exports = {
                     "line": 1,
                     "column": 22
                 }
-            },
-            "range": [
-                21,
-                22
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                22,
+                23
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -548,15 +554,15 @@ module.exports = {
                     "line": 1,
                     "column": 23
                 }
-            },
-            "range": [
-                22,
-                23
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                23,
+                24
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -566,11 +572,7 @@ module.exports = {
                     "line": 1,
                     "column": 24
                 }
-            },
-            "range": [
-                23,
-                24
-            ]
+            }
         }
     ]
 };

--- a/tests/fixtures/ecma-features/classes/class-two-methods-two-semi.result.js
+++ b/tests/fixtures/ecma-features/classes/class-two-methods-two-semi.result.js
@@ -1,5 +1,9 @@
 module.exports = {
     "type": "Program",
+    "range": [
+        0,
+        23
+    ],
     "loc": {
         "start": {
             "line": 1,
@@ -10,14 +14,13 @@ module.exports = {
             "column": 23
         }
     },
-    "range": [
-        0,
-        23
-    ],
     "body": [
         {
             "type": "ClassDeclaration",
-            "decorators": [],
+            "range": [
+                0,
+                22
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -28,12 +31,12 @@ module.exports = {
                     "column": 22
                 }
             },
-            "range": [
-                0,
-                22
-            ],
             "id": {
                 "type": "Identifier",
+                "range": [
+                    6,
+                    7
+                ],
                 "loc": {
                     "start": {
                         "line": 1,
@@ -44,33 +47,17 @@ module.exports = {
                         "column": 7
                     }
                 },
-                "range": [
-                    6,
-                    7
-                ],
                 "name": "A"
             },
-            "superClass": null,
-            "implements": [],
             "body": {
                 "type": "ClassBody",
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 8
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 22
-                    }
-                },
-                "range": [
-                    8,
-                    22
-                ],
                 "body": [
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            9,
+                            14
+                        ],
                         "loc": {
                             "start": {
                                 "line": 1,
@@ -81,14 +68,12 @@ module.exports = {
                                 "column": 14
                             }
                         },
-                        "range": [
-                            9,
-                            14
-                        ],
-                        "computed": false,
-                        "decorators": [],
                         "key": {
                             "type": "Identifier",
+                            "range": [
+                                9,
+                                10
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -99,36 +84,19 @@ module.exports = {
                                     "column": 10
                                 }
                             },
-                            "range": [
-                                9,
-                                10
-                            ],
                             "name": "a"
                         },
-                        "static": false,
-                        "kind": "method",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 10
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 14
-                                }
-                            },
-                            "range": [
-                                10,
-                                14
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    12,
+                                    14
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 1,
@@ -139,16 +107,36 @@ module.exports = {
                                         "column": 14
                                     }
                                 },
-                                "range": [
-                                    12,
-                                    14
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                10,
+                                14
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 10
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 14
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": false,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": []
                     },
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            15,
+                            20
+                        ],
                         "loc": {
                             "start": {
                                 "line": 1,
@@ -159,14 +147,12 @@ module.exports = {
                                 "column": 20
                             }
                         },
-                        "range": [
-                            15,
-                            20
-                        ],
-                        "computed": false,
-                        "decorators": [],
                         "key": {
                             "type": "Identifier",
+                            "range": [
+                                15,
+                                16
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -177,36 +163,19 @@ module.exports = {
                                     "column": 16
                                 }
                             },
-                            "range": [
-                                15,
-                                16
-                            ],
                             "name": "b"
                         },
-                        "static": false,
-                        "kind": "method",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 16
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 20
-                                }
-                            },
-                            "range": [
-                                16,
-                                20
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    18,
+                                    20
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 1,
@@ -217,19 +186,56 @@ module.exports = {
                                         "column": 20
                                     }
                                 },
-                                "range": [
-                                    18,
-                                    20
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                16,
+                                20
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 16
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 20
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": false,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": []
                     }
-                ]
-            }
+                ],
+                "range": [
+                    8,
+                    22
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 22
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
         },
         {
             "type": "EmptyStatement",
+            "range": [
+                22,
+                23
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -239,11 +245,7 @@ module.exports = {
                     "line": 1,
                     "column": 23
                 }
-            },
-            "range": [
-                22,
-                23
-            ]
+            }
         }
     ],
     "sourceType": "script",
@@ -251,6 +253,10 @@ module.exports = {
         {
             "type": "Keyword",
             "value": "class",
+            "range": [
+                0,
+                5
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -260,15 +266,15 @@ module.exports = {
                     "line": 1,
                     "column": 5
                 }
-            },
-            "range": [
-                0,
-                5
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "A",
+            "range": [
+                6,
+                7
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -278,15 +284,15 @@ module.exports = {
                     "line": 1,
                     "column": 7
                 }
-            },
-            "range": [
-                6,
-                7
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                8,
+                9
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -296,15 +302,15 @@ module.exports = {
                     "line": 1,
                     "column": 9
                 }
-            },
-            "range": [
-                8,
-                9
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "a",
+            "range": [
+                9,
+                10
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -314,15 +320,15 @@ module.exports = {
                     "line": 1,
                     "column": 10
                 }
-            },
-            "range": [
-                9,
-                10
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                10,
+                11
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -332,15 +338,15 @@ module.exports = {
                     "line": 1,
                     "column": 11
                 }
-            },
-            "range": [
-                10,
-                11
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                11,
+                12
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -350,15 +356,15 @@ module.exports = {
                     "line": 1,
                     "column": 12
                 }
-            },
-            "range": [
-                11,
-                12
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                12,
+                13
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -368,15 +374,15 @@ module.exports = {
                     "line": 1,
                     "column": 13
                 }
-            },
-            "range": [
-                12,
-                13
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                13,
+                14
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -386,15 +392,15 @@ module.exports = {
                     "line": 1,
                     "column": 14
                 }
-            },
-            "range": [
-                13,
-                14
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                14,
+                15
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -404,15 +410,15 @@ module.exports = {
                     "line": 1,
                     "column": 15
                 }
-            },
-            "range": [
-                14,
-                15
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "b",
+            "range": [
+                15,
+                16
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -422,15 +428,15 @@ module.exports = {
                     "line": 1,
                     "column": 16
                 }
-            },
-            "range": [
-                15,
-                16
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                16,
+                17
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -440,15 +446,15 @@ module.exports = {
                     "line": 1,
                     "column": 17
                 }
-            },
-            "range": [
-                16,
-                17
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                17,
+                18
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -458,15 +464,15 @@ module.exports = {
                     "line": 1,
                     "column": 18
                 }
-            },
-            "range": [
-                17,
-                18
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                18,
+                19
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -476,15 +482,15 @@ module.exports = {
                     "line": 1,
                     "column": 19
                 }
-            },
-            "range": [
-                18,
-                19
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                19,
+                20
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -494,15 +500,15 @@ module.exports = {
                     "line": 1,
                     "column": 20
                 }
-            },
-            "range": [
-                19,
-                20
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                20,
+                21
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -512,15 +518,15 @@ module.exports = {
                     "line": 1,
                     "column": 21
                 }
-            },
-            "range": [
-                20,
-                21
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                21,
+                22
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -530,15 +536,15 @@ module.exports = {
                     "line": 1,
                     "column": 22
                 }
-            },
-            "range": [
-                21,
-                22
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                22,
+                23
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -548,11 +554,7 @@ module.exports = {
                     "line": 1,
                     "column": 23
                 }
-            },
-            "range": [
-                22,
-                23
-            ]
+            }
         }
     ]
 };

--- a/tests/fixtures/ecma-features/classes/class-two-methods.result.js
+++ b/tests/fixtures/ecma-features/classes/class-two-methods.result.js
@@ -1,5 +1,9 @@
 module.exports = {
     "type": "Program",
+    "range": [
+        0,
+        21
+    ],
     "loc": {
         "start": {
             "line": 1,
@@ -10,14 +14,13 @@ module.exports = {
             "column": 21
         }
     },
-    "range": [
-        0,
-        21
-    ],
     "body": [
         {
             "type": "ClassDeclaration",
-            "decorators": [],
+            "range": [
+                0,
+                20
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -28,12 +31,12 @@ module.exports = {
                     "column": 20
                 }
             },
-            "range": [
-                0,
-                20
-            ],
             "id": {
                 "type": "Identifier",
+                "range": [
+                    6,
+                    7
+                ],
                 "loc": {
                     "start": {
                         "line": 1,
@@ -44,33 +47,17 @@ module.exports = {
                         "column": 7
                     }
                 },
-                "range": [
-                    6,
-                    7
-                ],
                 "name": "A"
             },
-            "superClass": null,
-            "implements": [],
             "body": {
                 "type": "ClassBody",
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 8
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 20
-                    }
-                },
-                "range": [
-                    8,
-                    20
-                ],
                 "body": [
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            9,
+                            14
+                        ],
                         "loc": {
                             "start": {
                                 "line": 1,
@@ -81,14 +68,12 @@ module.exports = {
                                 "column": 14
                             }
                         },
-                        "range": [
-                            9,
-                            14
-                        ],
-                        "computed": false,
-                        "decorators": [],
                         "key": {
                             "type": "Identifier",
+                            "range": [
+                                9,
+                                10
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -99,36 +84,19 @@ module.exports = {
                                     "column": 10
                                 }
                             },
-                            "range": [
-                                9,
-                                10
-                            ],
                             "name": "a"
                         },
-                        "static": false,
-                        "kind": "method",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 10
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 14
-                                }
-                            },
-                            "range": [
-                                10,
-                                14
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    12,
+                                    14
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 1,
@@ -139,16 +107,36 @@ module.exports = {
                                         "column": 14
                                     }
                                 },
-                                "range": [
-                                    12,
-                                    14
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                10,
+                                14
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 10
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 14
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": false,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": []
                     },
                     {
                         "type": "MethodDefinition",
+                        "range": [
+                            14,
+                            19
+                        ],
                         "loc": {
                             "start": {
                                 "line": 1,
@@ -159,14 +147,12 @@ module.exports = {
                                 "column": 19
                             }
                         },
-                        "range": [
-                            14,
-                            19
-                        ],
-                        "computed": false,
-                        "decorators": [],
                         "key": {
                             "type": "Identifier",
+                            "range": [
+                                14,
+                                15
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -177,36 +163,19 @@ module.exports = {
                                     "column": 15
                                 }
                             },
-                            "range": [
-                                14,
-                                15
-                            ],
                             "name": "b"
                         },
-                        "static": false,
-                        "kind": "method",
                         "value": {
                             "type": "FunctionExpression",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 15
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 19
-                                }
-                            },
-                            "range": [
-                                15,
-                                19
-                            ],
                             "id": null,
                             "generator": false,
                             "expression": false,
-                            "params": [],
                             "body": {
                                 "type": "BlockStatement",
+                                "range": [
+                                    17,
+                                    19
+                                ],
                                 "loc": {
                                     "start": {
                                         "line": 1,
@@ -217,19 +186,56 @@ module.exports = {
                                         "column": 19
                                     }
                                 },
-                                "range": [
-                                    17,
-                                    19
-                                ],
                                 "body": []
-                            }
-                        }
+                            },
+                            "range": [
+                                15,
+                                19
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 15
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 19
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": false,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": []
                     }
-                ]
-            }
+                ],
+                "range": [
+                    8,
+                    20
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 20
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
         },
         {
             "type": "EmptyStatement",
+            "range": [
+                20,
+                21
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -239,11 +245,7 @@ module.exports = {
                     "line": 1,
                     "column": 21
                 }
-            },
-            "range": [
-                20,
-                21
-            ]
+            }
         }
     ],
     "sourceType": "script",
@@ -251,6 +253,10 @@ module.exports = {
         {
             "type": "Keyword",
             "value": "class",
+            "range": [
+                0,
+                5
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -260,15 +266,15 @@ module.exports = {
                     "line": 1,
                     "column": 5
                 }
-            },
-            "range": [
-                0,
-                5
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "A",
+            "range": [
+                6,
+                7
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -278,15 +284,15 @@ module.exports = {
                     "line": 1,
                     "column": 7
                 }
-            },
-            "range": [
-                6,
-                7
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                8,
+                9
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -296,15 +302,15 @@ module.exports = {
                     "line": 1,
                     "column": 9
                 }
-            },
-            "range": [
-                8,
-                9
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "a",
+            "range": [
+                9,
+                10
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -314,15 +320,15 @@ module.exports = {
                     "line": 1,
                     "column": 10
                 }
-            },
-            "range": [
-                9,
-                10
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                10,
+                11
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -332,15 +338,15 @@ module.exports = {
                     "line": 1,
                     "column": 11
                 }
-            },
-            "range": [
-                10,
-                11
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                11,
+                12
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -350,15 +356,15 @@ module.exports = {
                     "line": 1,
                     "column": 12
                 }
-            },
-            "range": [
-                11,
-                12
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                12,
+                13
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -368,15 +374,15 @@ module.exports = {
                     "line": 1,
                     "column": 13
                 }
-            },
-            "range": [
-                12,
-                13
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                13,
+                14
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -386,15 +392,15 @@ module.exports = {
                     "line": 1,
                     "column": 14
                 }
-            },
-            "range": [
-                13,
-                14
-            ]
+            }
         },
         {
             "type": "Identifier",
             "value": "b",
+            "range": [
+                14,
+                15
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -404,15 +410,15 @@ module.exports = {
                     "line": 1,
                     "column": 15
                 }
-            },
-            "range": [
-                14,
-                15
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "(",
+            "range": [
+                15,
+                16
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -422,15 +428,15 @@ module.exports = {
                     "line": 1,
                     "column": 16
                 }
-            },
-            "range": [
-                15,
-                16
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ")",
+            "range": [
+                16,
+                17
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -440,15 +446,15 @@ module.exports = {
                     "line": 1,
                     "column": 17
                 }
-            },
-            "range": [
-                16,
-                17
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "{",
+            "range": [
+                17,
+                18
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -458,15 +464,15 @@ module.exports = {
                     "line": 1,
                     "column": 18
                 }
-            },
-            "range": [
-                17,
-                18
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                18,
+                19
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -476,15 +482,15 @@ module.exports = {
                     "line": 1,
                     "column": 19
                 }
-            },
-            "range": [
-                18,
-                19
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": "}",
+            "range": [
+                19,
+                20
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -494,15 +500,15 @@ module.exports = {
                     "line": 1,
                     "column": 20
                 }
-            },
-            "range": [
-                19,
-                20
-            ]
+            }
         },
         {
             "type": "Punctuator",
             "value": ";",
+            "range": [
+                20,
+                21
+            ],
             "loc": {
                 "start": {
                     "line": 1,
@@ -512,11 +518,7 @@ module.exports = {
                     "line": 1,
                     "column": 21
                 }
-            },
-            "range": [
-                20,
-                21
-            ]
+            }
         }
     ]
 };

--- a/tests/fixtures/ecma-features/classes/class-two-static-methods-named-constructor.result.js
+++ b/tests/fixtures/ecma-features/classes/class-two-static-methods-named-constructor.result.js
@@ -105,6 +105,7 @@ module.exports = {
                             "name": "constructor"
                         },
                         "static": true,
+                        "accessibility": null,
                         "kind": "method",
                         "value": {
                             "type": "FunctionExpression",
@@ -181,6 +182,7 @@ module.exports = {
                             ],
                             "name": "constructor"
                         },
+                        "accessibility": null,
                         "static": true,
                         "kind": "method",
                         "value": {

--- a/tests/fixtures/ecma-features/classes/class-with-constructor.result.js
+++ b/tests/fixtures/ecma-features/classes/class-with-constructor.result.js
@@ -104,6 +104,7 @@ module.exports = {
                             ],
                             "name": "constructor"
                         },
+                        "accessibility": null,
                         "static": false,
                         "kind": "constructor",
                         "value": {

--- a/tests/fixtures/typescript/basics/abstract-class-with-abstract-method.result.js
+++ b/tests/fixtures/typescript/basics/abstract-class-with-abstract-method.result.js
@@ -91,7 +91,6 @@ module.exports = {
                             "value": {
                                 "type": "FunctionExpression",
                                 "id": null,
-                                "params": [],
                                 "generator": false,
                                 "expression": false,
                                 "body": null,
@@ -181,11 +180,13 @@ module.exports = {
                                             }
                                         ]
                                     }
-                                }
+                                },
+                                "params": []
                             },
                             "computed": false,
                             "static": false,
                             "kind": "method",
+                            "accessibility": null,
                             "decorators": []
                         }
                     ],

--- a/tests/fixtures/typescript/basics/class-with-accessibility-modifiers.result.js
+++ b/tests/fixtures/typescript/basics/class-with-accessibility-modifiers.result.js
@@ -1,0 +1,1253 @@
+module.exports = {
+    "type": "Program",
+    "range": [
+        0,
+        173
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 10,
+            "column": 1
+        }
+    },
+    "body": [
+        {
+            "type": "ClassDeclaration",
+            "range": [
+                0,
+                173
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 10,
+                    "column": 1
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    6,
+                    9
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 9
+                    }
+                },
+                "name": "Foo"
+            },
+            "body": {
+                "type": "ClassBody",
+                "body": [
+                    {
+                        "type": "ClassProperty",
+                        "range": [
+                            14,
+                            35
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 23
+                            }
+                        },
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                22,
+                                25
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 10
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 13
+                                }
+                            },
+                            "name": "bar"
+                        },
+                        "value": null,
+                        "computed": false,
+                        "static": false,
+                        "accessibility": "private",
+                        "decorators": []
+                    },
+                    {
+                        "type": "ClassProperty",
+                        "range": [
+                            38,
+                            65
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 3,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 29
+                            }
+                        },
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                52,
+                                55
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 16
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 19
+                                }
+                            },
+                            "name": "baz"
+                        },
+                        "value": null,
+                        "computed": false,
+                        "static": true,
+                        "accessibility": "public",
+                        "decorators": []
+                    },
+                    {
+                        "type": "MethodDefinition",
+                        "range": [
+                            68,
+                            111
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 4,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 3
+                            }
+                        },
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                75,
+                                81
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 4,
+                                    "column": 9
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 15
+                                }
+                            },
+                            "name": "getBar"
+                        },
+                        "value": {
+                            "type": "FunctionExpression",
+                            "id": null,
+                            "generator": false,
+                            "expression": false,
+                            "body": {
+                                "type": "BlockStatement",
+                                "range": [
+                                    85,
+                                    111
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 4,
+                                        "column": 19
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 3
+                                    }
+                                },
+                                "body": [
+                                    {
+                                        "type": "ReturnStatement",
+                                        "range": [
+                                            91,
+                                            107
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 5,
+                                                "column": 4
+                                            },
+                                            "end": {
+                                                "line": 5,
+                                                "column": 20
+                                            }
+                                        },
+                                        "argument": {
+                                            "type": "MemberExpression",
+                                            "range": [
+                                                98,
+                                                106
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 5,
+                                                    "column": 11
+                                                },
+                                                "end": {
+                                                    "line": 5,
+                                                    "column": 19
+                                                }
+                                            },
+                                            "object": {
+                                                "type": "ThisExpression",
+                                                "range": [
+                                                    98,
+                                                    102
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 5,
+                                                        "column": 11
+                                                    },
+                                                    "end": {
+                                                        "line": 5,
+                                                        "column": 15
+                                                    }
+                                                }
+                                            },
+                                            "property": {
+                                                "type": "Identifier",
+                                                "range": [
+                                                    103,
+                                                    106
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 5,
+                                                        "column": 16
+                                                    },
+                                                    "end": {
+                                                        "line": 5,
+                                                        "column": 19
+                                                    }
+                                                },
+                                                "name": "bar"
+                                            },
+                                            "computed": false
+                                        }
+                                    }
+                                ]
+                            },
+                            "range": [
+                                81,
+                                111
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 4,
+                                    "column": 15
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 3
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": false,
+                        "kind": "method",
+                        "accessibility": "public",
+                        "decorators": []
+                    },
+                    {
+                        "type": "MethodDefinition",
+                        "range": [
+                            114,
+                            171
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 7,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 9,
+                                "column": 3
+                            }
+                        },
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                124,
+                                130
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 7,
+                                    "column": 12
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 18
+                                }
+                            },
+                            "name": "setBar"
+                        },
+                        "value": {
+                            "type": "FunctionExpression",
+                            "id": null,
+                            "generator": false,
+                            "expression": false,
+                            "body": {
+                                "type": "BlockStatement",
+                                "range": [
+                                    146,
+                                    171
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 7,
+                                        "column": 34
+                                    },
+                                    "end": {
+                                        "line": 9,
+                                        "column": 3
+                                    }
+                                },
+                                "body": [
+                                    {
+                                        "type": "ExpressionStatement",
+                                        "range": [
+                                            152,
+                                            167
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 8,
+                                                "column": 4
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 19
+                                            }
+                                        },
+                                        "expression": {
+                                            "type": "AssignmentExpression",
+                                            "range": [
+                                                152,
+                                                166
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 8,
+                                                    "column": 4
+                                                },
+                                                "end": {
+                                                    "line": 8,
+                                                    "column": 18
+                                                }
+                                            },
+                                            "operator": "=",
+                                            "left": {
+                                                "type": "MemberExpression",
+                                                "range": [
+                                                    152,
+                                                    160
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 8,
+                                                        "column": 4
+                                                    },
+                                                    "end": {
+                                                        "line": 8,
+                                                        "column": 12
+                                                    }
+                                                },
+                                                "object": {
+                                                    "type": "ThisExpression",
+                                                    "range": [
+                                                        152,
+                                                        156
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 8,
+                                                            "column": 4
+                                                        },
+                                                        "end": {
+                                                            "line": 8,
+                                                            "column": 8
+                                                        }
+                                                    }
+                                                },
+                                                "property": {
+                                                    "type": "Identifier",
+                                                    "range": [
+                                                        157,
+                                                        160
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 8,
+                                                            "column": 9
+                                                        },
+                                                        "end": {
+                                                            "line": 8,
+                                                            "column": 12
+                                                        }
+                                                    },
+                                                    "name": "bar"
+                                                },
+                                                "computed": false
+                                            },
+                                            "right": {
+                                                "type": "Identifier",
+                                                "range": [
+                                                    163,
+                                                    166
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 8,
+                                                        "column": 15
+                                                    },
+                                                    "end": {
+                                                        "line": 8,
+                                                        "column": 18
+                                                    }
+                                                },
+                                                "name": "bar"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "range": [
+                                130,
+                                171
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 7,
+                                    "column": 18
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 3
+                                }
+                            },
+                            "params": [
+                                {
+                                    "type": "Identifier",
+                                    "range": [
+                                        132,
+                                        135
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 7,
+                                            "column": 20
+                                        },
+                                        "end": {
+                                            "line": 7,
+                                            "column": 23
+                                        }
+                                    },
+                                    "name": "bar",
+                                    "decorators": []
+                                }
+                            ]
+                        },
+                        "computed": false,
+                        "static": false,
+                        "kind": "method",
+                        "accessibility": "protected",
+                        "decorators": []
+                    }
+                ],
+                "range": [
+                    10,
+                    173
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 10
+                    },
+                    "end": {
+                        "line": 10,
+                        "column": 1
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "class",
+            "range": [
+                0,
+                5
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Foo",
+            "range": [
+                6,
+                9
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 6
+                },
+                "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                10,
+                11
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 10
+                },
+                "end": {
+                    "line": 1,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "private",
+            "range": [
+                14,
+                21
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 2
+                },
+                "end": {
+                    "line": 2,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "range": [
+                22,
+                25
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 10
+                },
+                "end": {
+                    "line": 2,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                26,
+                27
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 14
+                },
+                "end": {
+                    "line": 2,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                28,
+                34
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 16
+                },
+                "end": {
+                    "line": 2,
+                    "column": 22
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                34,
+                35
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 22
+                },
+                "end": {
+                    "line": 2,
+                    "column": 23
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "public",
+            "range": [
+                38,
+                44
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 2
+                },
+                "end": {
+                    "line": 3,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "range": [
+                45,
+                51
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 9
+                },
+                "end": {
+                    "line": 3,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "baz",
+            "range": [
+                52,
+                55
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 16
+                },
+                "end": {
+                    "line": 3,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                56,
+                57
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 20
+                },
+                "end": {
+                    "line": 3,
+                    "column": 21
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "number",
+            "range": [
+                58,
+                64
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 22
+                },
+                "end": {
+                    "line": 3,
+                    "column": 28
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                64,
+                65
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 28
+                },
+                "end": {
+                    "line": 3,
+                    "column": 29
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "public",
+            "range": [
+                68,
+                74
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 2
+                },
+                "end": {
+                    "line": 4,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "getBar",
+            "range": [
+                75,
+                81
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 9
+                },
+                "end": {
+                    "line": 4,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                82,
+                83
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 16
+                },
+                "end": {
+                    "line": 4,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                83,
+                84
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 17
+                },
+                "end": {
+                    "line": 4,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                85,
+                86
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 19
+                },
+                "end": {
+                    "line": 4,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "return",
+            "range": [
+                91,
+                97
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 4
+                },
+                "end": {
+                    "line": 5,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "this",
+            "range": [
+                98,
+                102
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 11
+                },
+                "end": {
+                    "line": 5,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "range": [
+                102,
+                103
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 15
+                },
+                "end": {
+                    "line": 5,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "range": [
+                103,
+                106
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 16
+                },
+                "end": {
+                    "line": 5,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                106,
+                107
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 19
+                },
+                "end": {
+                    "line": 5,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                110,
+                111
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 2
+                },
+                "end": {
+                    "line": 6,
+                    "column": 3
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "protected",
+            "range": [
+                114,
+                123
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 2
+                },
+                "end": {
+                    "line": 7,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "setBar",
+            "range": [
+                124,
+                130
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 12
+                },
+                "end": {
+                    "line": 7,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                131,
+                132
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 19
+                },
+                "end": {
+                    "line": 7,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "range": [
+                132,
+                135
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 20
+                },
+                "end": {
+                    "line": 7,
+                    "column": 23
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                136,
+                137
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 24
+                },
+                "end": {
+                    "line": 7,
+                    "column": 25
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                138,
+                144
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 26
+                },
+                "end": {
+                    "line": 7,
+                    "column": 32
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                144,
+                145
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 32
+                },
+                "end": {
+                    "line": 7,
+                    "column": 33
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                146,
+                147
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 34
+                },
+                "end": {
+                    "line": 7,
+                    "column": 35
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "this",
+            "range": [
+                152,
+                156
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 4
+                },
+                "end": {
+                    "line": 8,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "range": [
+                156,
+                157
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 8
+                },
+                "end": {
+                    "line": 8,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "range": [
+                157,
+                160
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 9
+                },
+                "end": {
+                    "line": 8,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "range": [
+                161,
+                162
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 13
+                },
+                "end": {
+                    "line": 8,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "range": [
+                163,
+                166
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 15
+                },
+                "end": {
+                    "line": 8,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                166,
+                167
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 18
+                },
+                "end": {
+                    "line": 8,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                170,
+                171
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 2
+                },
+                "end": {
+                    "line": 9,
+                    "column": 3
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                172,
+                173
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 0
+                },
+                "end": {
+                    "line": 10,
+                    "column": 1
+                }
+            }
+        }
+    ]
+};

--- a/tests/fixtures/typescript/basics/class-with-accessibility-modifiers.src.ts
+++ b/tests/fixtures/typescript/basics/class-with-accessibility-modifiers.src.ts
@@ -1,0 +1,10 @@
+class Foo {
+  private bar : string;
+  public static baz : number;
+  public getBar () {
+    return this.bar;
+  }
+  protected setBar (bar : string) {
+    this.bar = bar;
+  }
+}

--- a/tests/fixtures/typescript/decorators/accessor-decorators/accessor-decorator-factory-instance-member.result.js
+++ b/tests/fixtures/typescript/decorators/accessor-decorators/accessor-decorator-factory-instance-member.result.js
@@ -199,6 +199,7 @@ module.exports = {
                         "computed": false,
                         "static": false,
                         "kind": "get",
+                        "accessibility": null,
                         "decorators": [
                             {
                                 "type": "CallExpression",

--- a/tests/fixtures/typescript/decorators/accessor-decorators/accessor-decorator-factory-static-member.result.js
+++ b/tests/fixtures/typescript/decorators/accessor-decorators/accessor-decorator-factory-static-member.result.js
@@ -199,6 +199,7 @@ module.exports = {
                         "computed": false,
                         "static": true,
                         "kind": "get",
+                        "accessibility": null,
                         "decorators": [
                             {
                                 "type": "CallExpression",

--- a/tests/fixtures/typescript/decorators/accessor-decorators/accessor-decorator-instance-member.result.js
+++ b/tests/fixtures/typescript/decorators/accessor-decorators/accessor-decorator-instance-member.result.js
@@ -199,6 +199,7 @@ module.exports = {
                         "computed": false,
                         "static": false,
                         "kind": "get",
+                        "accessibility": null,
                         "decorators": [
                             {
                                 "type": "Identifier",

--- a/tests/fixtures/typescript/decorators/accessor-decorators/accessor-decorator-static-member.result.js
+++ b/tests/fixtures/typescript/decorators/accessor-decorators/accessor-decorator-static-member.result.js
@@ -255,6 +255,7 @@ module.exports = {
                         "computed": false,
                         "static": true,
                         "kind": "set",
+                        "accessibility": null,
                         "decorators": [
                             {
                                 "type": "Identifier",

--- a/tests/fixtures/typescript/decorators/method-decorators/method-decorator-factory-instance-member.result.js
+++ b/tests/fixtures/typescript/decorators/method-decorators/method-decorator-factory-instance-member.result.js
@@ -31,7 +31,6 @@ module.exports = {
                     "column": 1
                 }
             },
-            "decorators": [],
             "id": {
                 "type": "Identifier",
                 "range": [
@@ -90,7 +89,6 @@ module.exports = {
                         "value": {
                             "type": "FunctionExpression",
                             "id": null,
-                            "params": [],
                             "generator": false,
                             "expression": false,
                             "body": {
@@ -124,67 +122,69 @@ module.exports = {
                                     "line": 3,
                                     "column": 23
                                 }
-                            }
+                            },
+                            "params": []
                         },
                         "computed": false,
                         "static": false,
                         "kind": "method",
+                        "accessibility": null,
                         "decorators": [
                             {
-                                "arguments": [
-                                    {
-                                        "loc": {
-                                            "end": {
-                                                "column": 19,
-                                                "line": 2
-                                            },
-                                            "start": {
-                                                "column": 14,
-                                                "line": 2
-                                            }
-                                        },
-                                        "range": [
-                                            24,
-                                            29
-                                        ],
-                                        "raw": "false",
-                                        "type": "Literal",
-                                        "value": false
-                                    }
-                                ],
-                                "callee": {
-                                    "loc": {
-                                        "end": {
-                                            "column": 13,
-                                            "line": 2
-                                        },
-                                        "start": {
-                                            "column": 5,
-                                            "line": 2
-                                        }
-                                    },
-                                    "name": "readonly",
-                                    "range": [
-                                        15,
-                                        23
-                                    ],
-                                    "type": "Identifier"
-                                },
-                                "loc": {
-                                    "end": {
-                                        "column": 20,
-                                        "line": 2
-                                    },
-                                    "start": {
-                                        "column": 5,
-                                        "line": 2
-                                    }
-                                },
+                                "type": "CallExpression",
                                 "range": [
                                     15,
                                     30
                                 ],
-                                "type": "CallExpression"
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 5
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 20
+                                    }
+                                },
+                                "callee": {
+                                    "type": "Identifier",
+                                    "range": [
+                                        15,
+                                        23
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 5
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 13
+                                        }
+                                    },
+                                    "name": "readonly"
+                                },
+                                "arguments": [
+                                    {
+                                        "type": "Literal",
+                                        "range": [
+                                            24,
+                                            29
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 2,
+                                                "column": 14
+                                            },
+                                            "end": {
+                                                "line": 2,
+                                                "column": 19
+                                            }
+                                        },
+                                        "value": false,
+                                        "raw": "false"
+                                    }
+                                ]
                             }
                         ]
                     }
@@ -205,262 +205,263 @@ module.exports = {
                 }
             },
             "superClass": null,
-            "implements": []
+            "implements": [],
+            "decorators": []
         }
     ],
     "sourceType": "script",
     "tokens": [
         {
-            "loc": {
-                "end": {
-                    "column": 5,
-                    "line": 1
-                },
-                "start": {
-                    "column": 0,
-                    "line": 1
-                }
-            },
+            "type": "Keyword",
+            "value": "class",
             "range": [
                 0,
                 5
             ],
-            "type": "Keyword",
-            "value": "class"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 5
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 7,
-                    "line": 1
-                },
-                "start": {
-                    "column": 6,
-                    "line": 1
-                }
-            },
+            "type": "Identifier",
+            "value": "B",
             "range": [
                 6,
                 7
             ],
-            "type": "Identifier",
-            "value": "B"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 6
+                },
+                "end": {
+                    "line": 1,
+                    "column": 7
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 9,
-                    "line": 1
-                },
-                "start": {
-                    "column": 8,
-                    "line": 1
-                }
-            },
+            "type": "Punctuator",
+            "value": "{",
             "range": [
                 8,
                 9
             ],
-            "type": "Punctuator",
-            "value": "{"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 8
+                },
+                "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 5,
-                    "line": 2
-                },
-                "start": {
-                    "column": 4,
-                    "line": 2
-                }
-            },
+            "type": "Punctuator",
+            "value": "@",
             "range": [
                 14,
                 15
             ],
-            "type": "Punctuator",
-            "value": "@"
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 5
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 13,
-                    "line": 2
-                },
-                "start": {
-                    "column": 5,
-                    "line": 2
-                }
-            },
+            "type": "Identifier",
+            "value": "readonly",
             "range": [
                 15,
                 23
             ],
-            "type": "Identifier",
-            "value": "readonly"
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 5
+                },
+                "end": {
+                    "line": 2,
+                    "column": 13
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 14,
-                    "line": 2
-                },
-                "start": {
-                    "column": 13,
-                    "line": 2
-                }
-            },
+            "type": "Punctuator",
+            "value": "(",
             "range": [
                 23,
                 24
             ],
-            "type": "Punctuator",
-            "value": "("
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 13
+                },
+                "end": {
+                    "line": 2,
+                    "column": 14
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 19,
-                    "line": 2
-                },
-                "start": {
-                    "column": 14,
-                    "line": 2
-                }
-            },
+            "type": "Boolean",
+            "value": "false",
             "range": [
                 24,
                 29
             ],
-            "type": "Boolean",
-            "value": "false"
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 14
+                },
+                "end": {
+                    "line": 2,
+                    "column": 19
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 20,
-                    "line": 2
-                },
-                "start": {
-                    "column": 19,
-                    "line": 2
-                }
-            },
+            "type": "Punctuator",
+            "value": ")",
             "range": [
                 29,
                 30
             ],
-            "type": "Punctuator",
-            "value": ")"
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 19
+                },
+                "end": {
+                    "line": 2,
+                    "column": 20
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 18,
-                    "line": 3
-                },
-                "start": {
-                    "column": 4,
-                    "line": 3
-                }
-            },
+            "type": "Identifier",
+            "value": "instanceMethod",
             "range": [
                 35,
                 49
             ],
-            "type": "Identifier",
-            "value": "instanceMethod"
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 4
+                },
+                "end": {
+                    "line": 3,
+                    "column": 18
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 19,
-                    "line": 3
-                },
-                "start": {
-                    "column": 18,
-                    "line": 3
-                }
-            },
+            "type": "Punctuator",
+            "value": "(",
             "range": [
                 49,
                 50
             ],
-            "type": "Punctuator",
-            "value": "("
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 18
+                },
+                "end": {
+                    "line": 3,
+                    "column": 19
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 20,
-                    "line": 3
-                },
-                "start": {
-                    "column": 19,
-                    "line": 3
-                }
-            },
+            "type": "Punctuator",
+            "value": ")",
             "range": [
                 50,
                 51
             ],
-            "type": "Punctuator",
-            "value": ")"
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 19
+                },
+                "end": {
+                    "line": 3,
+                    "column": 20
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 22,
-                    "line": 3
-                },
-                "start": {
-                    "column": 21,
-                    "line": 3
-                }
-            },
+            "type": "Punctuator",
+            "value": "{",
             "range": [
                 52,
                 53
             ],
-            "type": "Punctuator",
-            "value": "{"
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 21
+                },
+                "end": {
+                    "line": 3,
+                    "column": 22
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 23,
-                    "line": 3
-                },
-                "start": {
-                    "column": 22,
-                    "line": 3
-                }
-            },
+            "type": "Punctuator",
+            "value": "}",
             "range": [
                 53,
                 54
             ],
-            "type": "Punctuator",
-            "value": "}"
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 22
+                },
+                "end": {
+                    "line": 3,
+                    "column": 23
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 1,
-                    "line": 4
-                },
-                "start": {
-                    "column": 0,
-                    "line": 4
-                }
-            },
+            "type": "Punctuator",
+            "value": "}",
             "range": [
                 55,
                 56
             ],
-            "type": "Punctuator",
-            "value": "}"
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 0
+                },
+                "end": {
+                    "line": 4,
+                    "column": 1
+                }
+            }
         }
     ]
 };

--- a/tests/fixtures/typescript/decorators/method-decorators/method-decorator-factory-static-member.result.js
+++ b/tests/fixtures/typescript/decorators/method-decorators/method-decorator-factory-static-member.result.js
@@ -31,7 +31,6 @@ module.exports = {
                     "column": 1
                 }
             },
-            "decorators": [],
             "id": {
                 "type": "Identifier",
                 "range": [
@@ -90,7 +89,6 @@ module.exports = {
                         "value": {
                             "type": "FunctionExpression",
                             "id": null,
-                            "params": [],
                             "generator": false,
                             "expression": false,
                             "body": {
@@ -124,67 +122,69 @@ module.exports = {
                                     "line": 3,
                                     "column": 28
                                 }
-                            }
+                            },
+                            "params": []
                         },
                         "computed": false,
                         "static": true,
                         "kind": "method",
+                        "accessibility": null,
                         "decorators": [
                             {
-                                "arguments": [
-                                    {
-                                        "loc": {
-                                            "end": {
-                                                "column": 14,
-                                                "line": 2
-                                            },
-                                            "start": {
-                                                "column": 9,
-                                                "line": 2
-                                            }
-                                        },
-                                        "range": [
-                                            19,
-                                            24
-                                        ],
-                                        "raw": "false",
-                                        "type": "Literal",
-                                        "value": false
-                                    }
-                                ],
-                                "callee": {
-                                    "loc": {
-                                        "end": {
-                                            "column": 8,
-                                            "line": 2
-                                        },
-                                        "start": {
-                                            "column": 5,
-                                            "line": 2
-                                        }
-                                    },
-                                    "name": "Foo",
-                                    "range": [
-                                        15,
-                                        18
-                                    ],
-                                    "type": "Identifier"
-                                },
-                                "loc": {
-                                    "end": {
-                                        "column": 15,
-                                        "line": 2
-                                    },
-                                    "start": {
-                                        "column": 5,
-                                        "line": 2
-                                    }
-                                },
+                                "type": "CallExpression",
                                 "range": [
                                     15,
                                     25
                                 ],
-                                "type": "CallExpression"
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 5
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 15
+                                    }
+                                },
+                                "callee": {
+                                    "type": "Identifier",
+                                    "range": [
+                                        15,
+                                        18
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 5
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 8
+                                        }
+                                    },
+                                    "name": "Foo"
+                                },
+                                "arguments": [
+                                    {
+                                        "type": "Literal",
+                                        "range": [
+                                            19,
+                                            24
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 2,
+                                                "column": 9
+                                            },
+                                            "end": {
+                                                "line": 2,
+                                                "column": 14
+                                            }
+                                        },
+                                        "value": false,
+                                        "raw": "false"
+                                    }
+                                ]
                             }
                         ]
                     }
@@ -205,7 +205,8 @@ module.exports = {
                 }
             },
             "superClass": null,
-            "implements": []
+            "implements": [],
+            "decorators": []
         }
     ],
     "sourceType": "script",
@@ -319,22 +320,22 @@ module.exports = {
             }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 14,
-                    "line": 2
-                },
-                "start": {
-                    "column": 9,
-                    "line": 2
-                }
-            },
+            "type": "Boolean",
+            "value": "false",
             "range": [
                 19,
                 24
             ],
-            "type": "Boolean",
-            "value": "false"
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 9
+                },
+                "end": {
+                    "line": 2,
+                    "column": 14
+                }
+            }
         },
         {
             "type": "Punctuator",

--- a/tests/fixtures/typescript/decorators/method-decorators/method-decorator-instance-member.result.js
+++ b/tests/fixtures/typescript/decorators/method-decorators/method-decorator-instance-member.result.js
@@ -31,7 +31,6 @@ module.exports = {
                     "column": 1
                 }
             },
-            "decorators": [],
             "id": {
                 "type": "Identifier",
                 "range": [
@@ -90,7 +89,6 @@ module.exports = {
                         "value": {
                             "type": "FunctionExpression",
                             "id": null,
-                            "params": [],
                             "generator": false,
                             "expression": false,
                             "body": {
@@ -124,29 +122,31 @@ module.exports = {
                                     "line": 3,
                                     "column": 23
                                 }
-                            }
+                            },
+                            "params": []
                         },
                         "computed": false,
                         "static": false,
                         "kind": "method",
+                        "accessibility": null,
                         "decorators": [
                             {
-                                "loc": {
-                                    "end": {
-                                        "column": 13,
-                                        "line": 2
-                                    },
-                                    "start": {
-                                        "column": 5,
-                                        "line": 2
-                                    }
-                                },
-                                "name": "readonly",
+                                "type": "Identifier",
                                 "range": [
                                     15,
                                     23
                                 ],
-                                "type": "Identifier"
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 5
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 13
+                                    }
+                                },
+                                "name": "readonly"
                             }
                         ]
                     }
@@ -167,7 +167,8 @@ module.exports = {
                 }
             },
             "superClass": null,
-            "implements": []
+            "implements": [],
+            "decorators": []
         }
     ],
     "sourceType": "script",

--- a/tests/fixtures/typescript/decorators/method-decorators/method-decorator-static-member.result.js
+++ b/tests/fixtures/typescript/decorators/method-decorators/method-decorator-static-member.result.js
@@ -31,7 +31,6 @@ module.exports = {
                     "column": 1
                 }
             },
-            "decorators": [],
             "id": {
                 "type": "Identifier",
                 "range": [
@@ -90,7 +89,6 @@ module.exports = {
                         "value": {
                             "type": "FunctionExpression",
                             "id": null,
-                            "params": [],
                             "generator": false,
                             "expression": false,
                             "body": {
@@ -124,29 +122,31 @@ module.exports = {
                                     "line": 3,
                                     "column": 28
                                 }
-                            }
+                            },
+                            "params": []
                         },
                         "computed": false,
                         "static": true,
                         "kind": "method",
+                        "accessibility": null,
                         "decorators": [
                             {
-                                "loc": {
-                                    "end": {
-                                        "column": 8,
-                                        "line": 2
-                                    },
-                                    "start": {
-                                        "column": 5,
-                                        "line": 2
-                                    }
-                                },
-                                "name": "Foo",
+                                "type": "Identifier",
                                 "range": [
                                     15,
                                     18
                                 ],
-                                "type": "Identifier"
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 5
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 8
+                                    }
+                                },
+                                "name": "Foo"
                             }
                         ]
                     }
@@ -167,7 +167,8 @@ module.exports = {
                 }
             },
             "superClass": null,
-            "implements": []
+            "implements": [],
+            "decorators": []
         }
     ],
     "sourceType": "script",

--- a/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-constructor.result.js
+++ b/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-constructor.result.js
@@ -345,6 +345,7 @@ module.exports = {
                                 }
                             }
                         },
+                        "accessibility": null,
                         "computed": false,
                         "static": false,
                         "kind": "constructor"

--- a/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-decorator-instance-member.result.js
+++ b/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-decorator-instance-member.result.js
@@ -17,7 +17,6 @@ module.exports = {
     "body": [
         {
             "type": "ClassDeclaration",
-            "decorators": [],
             "range": [
                 0,
                 52
@@ -90,84 +89,6 @@ module.exports = {
                         "value": {
                             "type": "FunctionExpression",
                             "id": null,
-                            "params": [
-                                {
-                                    "type": "Identifier",
-                                    "range": [
-                                        35,
-                                        38
-                                    ],
-                                    "loc": {
-                                        "start": {
-                                            "line": 2,
-                                            "column": 23
-                                        },
-                                        "end": {
-                                            "line": 2,
-                                            "column": 26
-                                        }
-                                    },
-                                    "name": "baz",
-                                    "decorators": [
-                                        {
-                                            "arguments": [
-                                                {
-                                                    "loc": {
-                                                        "end": {
-                                                            "column": 21,
-                                                            "line": 2
-                                                        },
-                                                        "start": {
-                                                            "column": 17,
-                                                            "line": 2
-                                                        }
-                                                    },
-                                                    "range": [
-                                                        29,
-                                                        33
-                                                    ],
-                                                    "raw": "true",
-                                                    "type": "Literal",
-                                                    "value": true
-                                                }
-                                            ],
-                                            "callee": {
-                                                "loc": {
-                                                    "end": {
-                                                        "column": 16,
-                                                        "line": 2
-                                                    },
-                                                    "start": {
-                                                        "column": 9,
-                                                        "line": 2
-                                                    }
-                                                },
-                                                "name": "special",
-                                                "range": [
-                                                    21,
-                                                    28
-                                                ],
-                                                "type": "Identifier"
-                                            },
-                                            "loc": {
-                                                "end": {
-                                                    "column": 22,
-                                                    "line": 2
-                                                },
-                                                "start": {
-                                                    "column": 9,
-                                                    "line": 2
-                                                }
-                                            },
-                                            "range": [
-                                                21,
-                                                34
-                                            ],
-                                            "type": "CallExpression"
-                                        }
-                                    ]
-                                }
-                            ],
                             "generator": false,
                             "expression": false,
                             "body": {
@@ -201,11 +122,90 @@ module.exports = {
                                     "line": 2,
                                     "column": 38
                                 }
-                            }
+                            },
+                            "params": [
+                                {
+                                    "type": "Identifier",
+                                    "range": [
+                                        35,
+                                        38
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 23
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 26
+                                        }
+                                    },
+                                    "name": "baz",
+                                    "decorators": [
+                                        {
+                                            "type": "CallExpression",
+                                            "range": [
+                                                21,
+                                                34
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 2,
+                                                    "column": 9
+                                                },
+                                                "end": {
+                                                    "line": 2,
+                                                    "column": 22
+                                                }
+                                            },
+                                            "callee": {
+                                                "type": "Identifier",
+                                                "range": [
+                                                    21,
+                                                    28
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 2,
+                                                        "column": 9
+                                                    },
+                                                    "end": {
+                                                        "line": 2,
+                                                        "column": 16
+                                                    }
+                                                },
+                                                "name": "special"
+                                            },
+                                            "arguments": [
+                                                {
+                                                    "type": "Literal",
+                                                    "range": [
+                                                        29,
+                                                        33
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 2,
+                                                            "column": 17
+                                                        },
+                                                        "end": {
+                                                            "line": 2,
+                                                            "column": 21
+                                                        }
+                                                    },
+                                                    "value": true,
+                                                    "raw": "true"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
                         },
                         "computed": false,
                         "static": false,
                         "kind": "method",
+                        "accessibility": null,
                         "decorators": []
                     }
                 ],
@@ -225,7 +225,8 @@ module.exports = {
                 }
             },
             "superClass": null,
-            "implements": []
+            "implements": [],
+            "decorators": []
         }
     ],
     "sourceType": "script",

--- a/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-decorator-static-member.result.js
+++ b/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-decorator-static-member.result.js
@@ -17,7 +17,6 @@ module.exports = {
     "body": [
         {
             "type": "ClassDeclaration",
-            "decorators": [],
             "range": [
                 0,
                 65
@@ -90,84 +89,6 @@ module.exports = {
                         "value": {
                             "type": "FunctionExpression",
                             "id": null,
-                            "params": [
-                                {
-                                    "type": "Identifier",
-                                    "range": [
-                                        48,
-                                        51
-                                    ],
-                                    "loc": {
-                                        "start": {
-                                            "line": 2,
-                                            "column": 30
-                                        },
-                                        "end": {
-                                            "line": 2,
-                                            "column": 33
-                                        }
-                                    },
-                                    "name": "baz",
-                                    "decorators": [
-                                        {
-                                            "arguments": [
-                                                {
-                                                    "loc": {
-                                                        "end": {
-                                                            "column": 28,
-                                                            "line": 2
-                                                        },
-                                                        "start": {
-                                                            "column": 24,
-                                                            "line": 2
-                                                        }
-                                                    },
-                                                    "range": [
-                                                        42,
-                                                        46
-                                                    ],
-                                                    "raw": "true",
-                                                    "type": "Literal",
-                                                    "value": true
-                                                }
-                                            ],
-                                            "callee": {
-                                                "loc": {
-                                                    "end": {
-                                                        "column": 23,
-                                                        "line": 2
-                                                    },
-                                                    "start": {
-                                                        "column": 16,
-                                                        "line": 2
-                                                    }
-                                                },
-                                                "name": "special",
-                                                "range": [
-                                                    34,
-                                                    41
-                                                ],
-                                                "type": "Identifier"
-                                            },
-                                            "loc": {
-                                                "end": {
-                                                    "column": 29,
-                                                    "line": 2
-                                                },
-                                                "start": {
-                                                    "column": 16,
-                                                    "line": 2
-                                                }
-                                            },
-                                            "range": [
-                                                34,
-                                                47
-                                            ],
-                                            "type": "CallExpression"
-                                        }
-                                    ]
-                                }
-                            ],
                             "generator": false,
                             "expression": false,
                             "body": {
@@ -201,11 +122,90 @@ module.exports = {
                                     "line": 2,
                                     "column": 45
                                 }
-                            }
+                            },
+                            "params": [
+                                {
+                                    "type": "Identifier",
+                                    "range": [
+                                        48,
+                                        51
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 30
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 33
+                                        }
+                                    },
+                                    "name": "baz",
+                                    "decorators": [
+                                        {
+                                            "type": "CallExpression",
+                                            "range": [
+                                                34,
+                                                47
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 2,
+                                                    "column": 16
+                                                },
+                                                "end": {
+                                                    "line": 2,
+                                                    "column": 29
+                                                }
+                                            },
+                                            "callee": {
+                                                "type": "Identifier",
+                                                "range": [
+                                                    34,
+                                                    41
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 2,
+                                                        "column": 16
+                                                    },
+                                                    "end": {
+                                                        "line": 2,
+                                                        "column": 23
+                                                    }
+                                                },
+                                                "name": "special"
+                                            },
+                                            "arguments": [
+                                                {
+                                                    "type": "Literal",
+                                                    "range": [
+                                                        42,
+                                                        46
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 2,
+                                                            "column": 24
+                                                        },
+                                                        "end": {
+                                                            "line": 2,
+                                                            "column": 28
+                                                        }
+                                                    },
+                                                    "value": true,
+                                                    "raw": "true"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
                         },
                         "computed": false,
                         "static": true,
                         "kind": "method",
+                        "accessibility": null,
                         "decorators": []
                     }
                 ],
@@ -225,7 +225,8 @@ module.exports = {
                 }
             },
             "superClass": null,
-            "implements": []
+            "implements": [],
+            "decorators": []
         }
     ],
     "sourceType": "script",

--- a/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-instance-member.result.js
+++ b/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-instance-member.result.js
@@ -17,7 +17,6 @@ module.exports = {
     "body": [
         {
             "type": "ClassDeclaration",
-            "decorators": [],
             "range": [
                 0,
                 97
@@ -90,46 +89,6 @@ module.exports = {
                         "value": {
                             "type": "FunctionExpression",
                             "id": null,
-                            "params": [
-                                {
-                                    "type": "Identifier",
-                                    "range": [
-                                        36,
-                                        40
-                                    ],
-                                    "loc": {
-                                        "start": {
-                                            "line": 2,
-                                            "column": 20
-                                        },
-                                        "end": {
-                                            "line": 2,
-                                            "column": 24
-                                        }
-                                    },
-                                    "name": "name",
-                                    "decorators": [
-                                        {
-                                            "loc": {
-                                                "end": {
-                                                    "column": 19,
-                                                    "line": 2
-                                                },
-                                                "start": {
-                                                    "column": 11,
-                                                    "line": 2
-                                                }
-                                            },
-                                            "name": "required",
-                                            "range": [
-                                                27,
-                                                35
-                                            ],
-                                            "type": "Identifier"
-                                        }
-                                    ]
-                                }
-                            ],
                             "generator": false,
                             "expression": false,
                             "body": {
@@ -273,11 +232,52 @@ module.exports = {
                                     "line": 4,
                                     "column": 5
                                 }
-                            }
+                            },
+                            "params": [
+                                {
+                                    "type": "Identifier",
+                                    "range": [
+                                        36,
+                                        40
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 20
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 24
+                                        }
+                                    },
+                                    "name": "name",
+                                    "decorators": [
+                                        {
+                                            "type": "Identifier",
+                                            "range": [
+                                                27,
+                                                35
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 2,
+                                                    "column": 11
+                                                },
+                                                "end": {
+                                                    "line": 2,
+                                                    "column": 19
+                                                }
+                                            },
+                                            "name": "required"
+                                        }
+                                    ]
+                                }
+                            ]
                         },
                         "computed": false,
                         "static": false,
                         "kind": "method",
+                        "accessibility": null,
                         "decorators": []
                     }
                 ],
@@ -297,7 +297,8 @@ module.exports = {
                 }
             },
             "superClass": null,
-            "implements": []
+            "implements": [],
+            "decorators": []
         }
     ],
     "sourceType": "script",

--- a/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-static-member.result.js
+++ b/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-static-member.result.js
@@ -17,7 +17,6 @@ module.exports = {
     "body": [
         {
             "type": "ClassDeclaration",
-            "decorators": [],
             "range": [
                 0,
                 110
@@ -90,46 +89,6 @@ module.exports = {
                         "value": {
                             "type": "FunctionExpression",
                             "id": null,
-                            "params": [
-                                {
-                                    "type": "Identifier",
-                                    "range": [
-                                        49,
-                                        53
-                                    ],
-                                    "loc": {
-                                        "start": {
-                                            "line": 2,
-                                            "column": 27
-                                        },
-                                        "end": {
-                                            "line": 2,
-                                            "column": 31
-                                        }
-                                    },
-                                    "name": "name",
-                                    "decorators": [
-                                        {
-                                            "loc": {
-                                                "end": {
-                                                    "column": 26,
-                                                    "line": 2
-                                                },
-                                                "start": {
-                                                    "column": 18,
-                                                    "line": 2
-                                                }
-                                            },
-                                            "name": "required",
-                                            "range": [
-                                                40,
-                                                48
-                                            ],
-                                            "type": "Identifier"
-                                        }
-                                    ]
-                                }
-                            ],
                             "generator": false,
                             "expression": false,
                             "body": {
@@ -273,11 +232,52 @@ module.exports = {
                                     "line": 4,
                                     "column": 5
                                 }
-                            }
+                            },
+                            "params": [
+                                {
+                                    "type": "Identifier",
+                                    "range": [
+                                        49,
+                                        53
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 27
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 31
+                                        }
+                                    },
+                                    "name": "name",
+                                    "decorators": [
+                                        {
+                                            "type": "Identifier",
+                                            "range": [
+                                                40,
+                                                48
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 2,
+                                                    "column": 18
+                                                },
+                                                "end": {
+                                                    "line": 2,
+                                                    "column": 26
+                                                }
+                                            },
+                                            "name": "required"
+                                        }
+                                    ]
+                                }
+                            ]
                         },
                         "computed": false,
                         "static": true,
                         "kind": "method",
+                        "accessibility": null,
                         "decorators": []
                     }
                 ],
@@ -297,7 +297,8 @@ module.exports = {
                 }
             },
             "superClass": null,
-            "implements": []
+            "implements": [],
+            "decorators": []
         }
     ],
     "sourceType": "script",

--- a/tests/fixtures/typescript/decorators/property-decorators/property-decorator-factory-instance-member.result.js
+++ b/tests/fixtures/typescript/decorators/property-decorators/property-decorator-factory-instance-member.result.js
@@ -53,191 +53,193 @@ module.exports = {
                 "type": "ClassBody",
                 "body": [
                     {
-                        "computed": false,
-                        "decorators": [
-                            {
-                                "arguments": [],
-                                "callee": {
-                                    "loc": {
-                                        "end": {
-                                            "column": 10,
-                                            "line": 2
-                                        },
-                                        "start": {
-                                            "column": 5,
-                                            "line": 2
-                                        }
-                                    },
-                                    "name": "Input",
-                                    "range": [
-                                        27,
-                                        32
-                                    ],
-                                    "type": "Identifier"
-                                },
-                                "loc": {
-                                    "end": {
-                                        "column": 12,
-                                        "line": 2
-                                    },
-                                    "start": {
-                                        "column": 5,
-                                        "line": 2
-                                    }
-                                },
-                                "range": [
-                                    27,
-                                    34
-                                ],
-                                "type": "CallExpression"
-                            }
-                        ],
-                        "key": {
-                            "loc": {
-                                "end": {
-                                    "column": 17,
-                                    "line": 2
-                                },
-                                "start": {
-                                    "column": 13,
-                                    "line": 2
-                                }
-                            },
-                            "name": "data",
-                            "range": [
-                                35,
-                                39
-                            ],
-                            "type": "Identifier"
-                        },
-                        "loc": {
-                            "end": {
-                                "column": 18,
-                                "line": 2
-                            },
-                            "start": {
-                                "column": 4,
-                                "line": 2
-                            }
-                        },
+                        "type": "ClassProperty",
                         "range": [
                             26,
                             40
                         ],
-                        "static": false,
-                        "type": "ClassProperty",
-                        "value": null
-                    },
-                    {
-                        "computed": false,
-                        "decorators": [
-                            {
-                                "arguments": [],
-                                "callee": {
-                                    "loc": {
-                                        "end": {
-                                            "column": 11,
-                                            "line": 3
-                                        },
-                                        "start": {
-                                            "column": 5,
-                                            "line": 3
-                                        }
-                                    },
-                                    "name": "Output",
-                                    "range": [
-                                        46,
-                                        52
-                                    ],
-                                    "type": "Identifier"
-                                },
-                                "loc": {
-                                    "end": {
-                                        "column": 13,
-                                        "line": 3
-                                    },
-                                    "start": {
-                                        "column": 5,
-                                        "line": 3
-                                    }
-                                },
-                                "range": [
-                                    46,
-                                    54
-                                ],
-                                "type": "CallExpression"
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 18
                             }
-                        ],
+                        },
                         "key": {
+                            "type": "Identifier",
+                            "range": [
+                                35,
+                                39
+                            ],
                             "loc": {
-                                "end": {
-                                    "column": 9,
-                                    "line": 4
-                                },
                                 "start": {
-                                    "column": 4,
-                                    "line": 4
+                                    "line": 2,
+                                    "column": 13
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 17
                                 }
                             },
-                            "name": "click",
-                            "range": [
-                                59,
-                                64
-                            ],
-                            "type": "Identifier"
+                            "name": "data"
                         },
-                        "loc": {
-                            "end": {
-                                "column": 31,
-                                "line": 4
-                            },
-                            "start": {
-                                "column": 4,
-                                "line": 3
+                        "value": null,
+                        "computed": false,
+                        "static": false,
+                        "accessibility": null,
+                        "decorators": [
+                            {
+                                "type": "CallExpression",
+                                "range": [
+                                    27,
+                                    34
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 5
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 12
+                                    }
+                                },
+                                "callee": {
+                                    "type": "Identifier",
+                                    "range": [
+                                        27,
+                                        32
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 5
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 10
+                                        }
+                                    },
+                                    "name": "Input"
+                                },
+                                "arguments": []
                             }
-                        },
+                        ]
+                    },
+                    {
+                        "type": "ClassProperty",
                         "range": [
                             45,
                             86
                         ],
-                        "static": false,
-                        "type": "ClassProperty",
-                        "value": {
-                            "arguments": [],
-                            "callee": {
-                                "loc": {
-                                    "end": {
-                                        "column": 28,
-                                        "line": 4
-                                    },
-                                    "start": {
-                                        "column": 16,
-                                        "line": 4
-                                    }
-                                },
-                                "name": "EventEmitter",
-                                "range": [
-                                    71,
-                                    83
-                                ],
-                                "type": "Identifier"
+                        "loc": {
+                            "start": {
+                                "line": 3,
+                                "column": 4
                             },
+                            "end": {
+                                "line": 4,
+                                "column": 31
+                            }
+                        },
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                59,
+                                64
+                            ],
                             "loc": {
-                                "end": {
-                                    "column": 30,
-                                    "line": 4
-                                },
                                 "start": {
-                                    "column": 12,
-                                    "line": 4
+                                    "line": 4,
+                                    "column": 4
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 9
                                 }
                             },
+                            "name": "click"
+                        },
+                        "value": {
+                            "type": "NewExpression",
                             "range": [
                                 67,
                                 85
                             ],
-                            "type": "NewExpression"
-                        }
+                            "loc": {
+                                "start": {
+                                    "line": 4,
+                                    "column": 12
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 30
+                                }
+                            },
+                            "callee": {
+                                "type": "Identifier",
+                                "range": [
+                                    71,
+                                    83
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 4,
+                                        "column": 16
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 28
+                                    }
+                                },
+                                "name": "EventEmitter"
+                            },
+                            "arguments": []
+                        },
+                        "computed": false,
+                        "static": false,
+                        "accessibility": null,
+                        "decorators": [
+                            {
+                                "type": "CallExpression",
+                                "range": [
+                                    46,
+                                    54
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 3,
+                                        "column": 5
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 13
+                                    }
+                                },
+                                "callee": {
+                                    "type": "Identifier",
+                                    "range": [
+                                        46,
+                                        52
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 3,
+                                            "column": 5
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 11
+                                        }
+                                    },
+                                    "name": "Output"
+                                },
+                                "arguments": []
+                            }
+                        ]
                     }
                 ],
                 "range": [

--- a/tests/fixtures/typescript/decorators/property-decorators/property-decorator-factory-static-member.result.js
+++ b/tests/fixtures/typescript/decorators/property-decorators/property-decorator-factory-static-member.result.js
@@ -89,6 +89,7 @@ module.exports = {
                         "value": null,
                         "computed": false,
                         "static": true,
+                        "accessibility": null,
                         "decorators": [
                             {
                                 "type": "CallExpression",
@@ -185,6 +186,7 @@ module.exports = {
                         "value": null,
                         "computed": false,
                         "static": true,
+                        "accessibility": null,
                         "decorators": [
                             {
                                 "type": "CallExpression",

--- a/tests/fixtures/typescript/decorators/property-decorators/property-decorator-instance-member.result.js
+++ b/tests/fixtures/typescript/decorators/property-decorators/property-decorator-instance-member.result.js
@@ -89,6 +89,7 @@ module.exports = {
                         "value": null,
                         "computed": false,
                         "static": false,
+                        "accessibility": null,
                         "decorators": [
                             {
                                 "type": "Identifier",
@@ -147,6 +148,7 @@ module.exports = {
                         "value": null,
                         "computed": false,
                         "static": false,
+                        "accessibility": null,
                         "decorators": [
                             {
                                 "type": "Identifier",

--- a/tests/fixtures/typescript/decorators/property-decorators/property-decorator-static-member.result.js
+++ b/tests/fixtures/typescript/decorators/property-decorators/property-decorator-static-member.result.js
@@ -89,6 +89,7 @@ module.exports = {
                         "value": null,
                         "computed": false,
                         "static": true,
+                        "accessibility": null,
                         "decorators": [
                             {
                                 "type": "Identifier",
@@ -147,6 +148,7 @@ module.exports = {
                         "value": null,
                         "computed": false,
                         "static": true,
+                        "accessibility": null,
                         "decorators": [
                             {
                                 "type": "Identifier",


### PR DESCRIPTION
Issue (#87)

This pull request is about getting the `public`, `protected`, and `private` keywords into the ESLint AST.

The accessibility modifier keywords can appear on `ClassProperty` and `MethodProperty`.

http://astexplorer.net/#/FfIL8GurdC