### PR TITLE
New: parseForESLint method and parser services

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,4 +1,5 @@
 env:
     node: true
+    es6: true
 
 extends: eslint

--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -408,6 +408,12 @@ module.exports = function(ast, extra) {
     }
 
     /**
+     * Create a map between converted ESTreeNodes and their original TSNodes.
+     * This will be exported as part of the parser services for use in ESLint.
+     */
+    var nodeMap = new WeakMap();
+
+    /**
      * Converts a TypeScript node into an ESTree node
      * @param  {TSNode} node   the TSNode
      * @param  {TSNode} parent the parent TSNode
@@ -1851,6 +1857,11 @@ module.exports = function(ast, extra) {
                 deeplyCopy();
         }
 
+        /**
+         * Add to the ESTreeNode:TSNode map
+         */
+        nodeMap.set(result, node);
+
         return result;
     }
 
@@ -1869,6 +1880,9 @@ module.exports = function(ast, extra) {
         estree.comments = extra.comments || [];
     }
 
-    return estree;
+    return {
+        ast: estree,
+        nodeMap: nodeMap
+    };
 
 };

--- a/parser.js
+++ b/parser.js
@@ -9,6 +9,7 @@
 "use strict";
 
 var astNodeTypes = require("./lib/ast-node-types"),
+    astConverter = require("./lib/ast-converter"),
     ts = require("typescript");
 
 var extra;
@@ -86,17 +87,14 @@ function getLocFor(start, end, ast) {
     };
 }
 
-//------------------------------------------------------------------------------
-// Parser
-//------------------------------------------------------------------------------
-
 /**
- * Parses the given source code to produce a valid AST
+ * Parses the given source code to produce a valid TypeScript AST
+ * and track options on `extra`
  * @param  {mixed} code    TypeScript code
  * @param  {object} options configuration object for the parser
- * @returns {object}         the AST
+ * @returns {object}         An object containing TypeScript AST and the current program
  */
-function parse(code, options) {
+function generateTypeScriptASTAndConfigureExtra(code, options) {
 
     var program,
         toString = String;
@@ -215,9 +213,51 @@ function parse(code, options) {
 
     }
 
-    var convert = require("./lib/ast-converter");
+    return {
+        ast: ast,
+        program: program
+    };
 
-    return convert(ast, extra);
+}
+
+//------------------------------------------------------------------------------
+// Parser
+//------------------------------------------------------------------------------
+
+/**
+ * Parses the given source code to produce a valid ESTree AST
+ * @param  {mixed} code    TypeScript code
+ * @param  {object} options configuration object for the parser
+ * @returns {object}         the ESTree AST
+ */
+function parse(code, options) {
+    var typescriptData = generateTypeScriptASTAndConfigureExtra(code, options);
+    var converted = astConverter(typescriptData.ast, extra);
+    return converted.ast;
+}
+
+/**
+ * Parses the given source code to produce a valid ESTree AST, and parser services
+ * to be used in ESLint
+ * @param  {mixed} code    TypeScript code
+ * @param  {object} options configuration object for the parser
+ * @returns {object}         object containing the ESTree AST and parser services
+ */
+function parseForESLint(code, options) {
+    var typescriptData = generateTypeScriptASTAndConfigureExtra(code, options);
+    var converted = astConverter(typescriptData.ast, extra);
+    return {
+        ast: converted.ast,
+        services: {
+            ts: ts,
+            getCurrentProgram: function getCurrentProgram() {
+                return typescriptData.program;
+            },
+            getTSNode: function getTSNode(node) {
+                return converted.nodeMap.get(node);
+            }
+        }
+    };
 }
 
 //------------------------------------------------------------------------------
@@ -227,6 +267,8 @@ function parse(code, options) {
 exports.version = require("./package.json").version;
 
 exports.parse = parse;
+
+exports.parseForESLint = parseForESLint;
 
 // Deep copy.
 /* istanbul ignore next */


### PR DESCRIPTION
Here is the source for the `restrict-plus-operands` rule I was able to create in `eslint-plugin-typescript` when using this feature branch and the branch from this ESLint PR https://github.com/eslint/eslint/pull/6975:

![unspecified-7](https://cloud.githubusercontent.com/assets/900523/18609369/7b66bec0-7cf8-11e6-905c-13016149db37.png)

It will be very hard to predict / hard to maintain exactly which TypeScript helpers will be useful in plugins rules, so for now I have exposed the full TypeScript API via `ts`. 
