### PR TITLE
Fix: Tests break with Windows line-endings (fixes #93)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+*.js eol=lf
+*.ts eol=lf


### PR DESCRIPTION
This is to address issues for Windows uses. 
`\r\n` is twice as many characters as `\n` so test ranges are always off.