### PR TITLE
Fix: Add loc and range data to generated VariableDeclarator node

### DIFF
--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -1871,8 +1871,10 @@ module.exports = function(ast, extra) {
                 var typeAliasDeclarator = {
                     type: "VariableDeclarator",
                     id: convertChild(node.name),
-                    init: convertChild(node.type)
+                    init: convertChild(node.type),
+                    range: [node.name.getStart(), node.end]
                 };
+                typeAliasDeclarator.loc = getLocFor(typeAliasDeclarator.range[0], typeAliasDeclarator.range[1], ast);
                 // Process typeParameters
                 if (node.typeParameters && node.typeParameters.length) {
                     typeAliasDeclarator.typeParameters = convertTSTypeParametersToTypeParametersDeclaration(node.typeParameters);

--- a/tests/fixtures/typescript/basics/type-alias-declaration.result.js
+++ b/tests/fixtures/typescript/basics/type-alias-declaration.result.js
@@ -20,6 +20,20 @@ module.exports = {
             "kind": "type",
             "declarations": [
                 {
+                    "loc": {
+                        "end": {
+                            "column": 37,
+                            "line": 1
+                        },
+                        "start": {
+                            "column": 5,
+                            "line": 1
+                        }
+                    },
+                    "range": [
+                        5,
+                        37
+                    ],
                     "type": "VariableDeclarator",
                     "id": {
                         "type": "Identifier",


### PR DESCRIPTION
I am really sorry this has now taken a 3rd PR to get right.

This adds `loc` and `range` data for the generated `VariableDeclarator` - core `indent` is currently throwing an error because `loc` is undefined