### PR TITLE
Fix: Added missing yml lf gitattribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 * text=auto
 *.js eol=lf
 *.ts eol=lf
+*.yml eol=lf


### PR DESCRIPTION
Since the gitattribute file was added in https://github.com/eslint/typescript-eslint-parser/pull/97, my mac has automatically had unstaged changes relating to yml files.

I have never used gitattributes before, but adding a definition for yml seems to do the trick...