### PR TITLE
Fix: Rename decorator example to avoid issue in TS 2.x (refs #105)

### DIFF
--- a/tests/fixtures/typescript/decorators/method-decorators/method-decorator-factory-instance-member.result.js
+++ b/tests/fixtures/typescript/decorators/method-decorators/method-decorator-factory-instance-member.result.js
@@ -162,7 +162,7 @@ module.exports = {
                                             "column": 13
                                         }
                                     },
-                                    "name": "readonly"
+                                    "name": "onlyRead"
                                 },
                                 "arguments": [
                                     {
@@ -285,7 +285,7 @@ module.exports = {
         },
         {
             "type": "Identifier",
-            "value": "readonly",
+            "value": "onlyRead",
             "range": [
                 15,
                 23

--- a/tests/fixtures/typescript/decorators/method-decorators/method-decorator-factory-instance-member.src.ts
+++ b/tests/fixtures/typescript/decorators/method-decorators/method-decorator-factory-instance-member.src.ts
@@ -1,4 +1,4 @@
 class B {
-    @readonly(false)
+    @onlyRead(false)
     instanceMethod() {}
 }

--- a/tests/fixtures/typescript/decorators/method-decorators/method-decorator-instance-member.result.js
+++ b/tests/fixtures/typescript/decorators/method-decorators/method-decorator-instance-member.result.js
@@ -146,7 +146,7 @@ module.exports = {
                                         "column": 13
                                     }
                                 },
-                                "name": "readonly"
+                                "name": "onlyRead"
                             }
                         ]
                     }
@@ -247,7 +247,7 @@ module.exports = {
         },
         {
             "type": "Identifier",
-            "value": "readonly",
+            "value": "onlyRead",
             "range": [
                 15,
                 23

--- a/tests/fixtures/typescript/decorators/method-decorators/method-decorator-instance-member.src.ts
+++ b/tests/fixtures/typescript/decorators/method-decorators/method-decorator-instance-member.src.ts
@@ -1,4 +1,4 @@
 class A {
-    @readonly
+    @onlyRead
     instanceMethod() {}
 }


### PR DESCRIPTION
`readonly` became a keyword in TS 2.0, and so the coincidentally named decorator in the 2 test cases below would produce a different AST when moving from TS 1.x to TS 2.x