### PR TITLE
Fix: Exclude TSNode.flags when deeplyCopy fallback is used (refs #105)

### DIFF
--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -589,7 +589,7 @@ module.exports = function(ast, extra) {
         function deeplyCopy() {
             result.type = "TS" + SyntaxKind[node.kind];
             Object.keys(node).filter(function(key) {
-                return !(/^(?:kind|parent|pos|end)$/.test(key));
+                return !(/^(?:kind|parent|pos|end|flags)$/.test(key));
             }).forEach(function(key) {
                 if (key === "type") {
                     result.typeAnnotation = convertTypeAnnotation(node.type);

--- a/tests/fixtures/typescript/basics/abstract-class-with-abstract-method.result.js
+++ b/tests/fixtures/typescript/basics/abstract-class-with-abstract-method.result.js
@@ -140,7 +140,6 @@ module.exports = {
                                                 "column": 44
                                             }
                                         },
-                                        "flags": 0,
                                         "typeName": {
                                             "type": "Identifier",
                                             "range": [
@@ -175,8 +174,7 @@ module.exports = {
                                                         "line": 2,
                                                         "column": 43
                                                     }
-                                                },
-                                                "flags": 0
+                                                }
                                             }
                                         ]
                                     }

--- a/tests/fixtures/typescript/basics/arrow-function-with-type-parameters.result.js
+++ b/tests/fixtures/typescript/basics/arrow-function-with-type-parameters.result.js
@@ -110,7 +110,6 @@ module.exports = {
                     ],
                     "type": "TypeAnnotation",
                     "typeAnnotation": {
-                        "flags": 0,
                         "loc": {
                             "end": {
                                 "column": 12,

--- a/tests/fixtures/typescript/basics/declare-function.result.js
+++ b/tests/fixtures/typescript/basics/declare-function.result.js
@@ -103,8 +103,7 @@ module.exports = {
                             "line": 1,
                             "column": 41
                         }
-                    },
-                    "flags": 0
+                    }
                 }
             }
         }

--- a/tests/fixtures/typescript/basics/declare-namespace-with-exported-function.result.js
+++ b/tests/fixtures/typescript/basics/declare-namespace-with-exported-function.result.js
@@ -31,7 +31,6 @@ module.exports = {
                     "column": 1
                 }
             },
-            "flags": 65540,
             "modifiers": [
                 {
                     "type": "TSDeclareKeyword",
@@ -48,8 +47,7 @@ module.exports = {
                             "line": 1,
                             "column": 7
                         }
-                    },
-                    "flags": 0
+                    }
                 }
             ],
             "name": {
@@ -86,7 +84,6 @@ module.exports = {
                         "column": 1
                     }
                 },
-                "flags": 0,
                 "statements": [
                     {
                         "type": "TSNamespaceExportDeclaration",
@@ -179,7 +176,6 @@ module.exports = {
                                             "column": 58
                                         }
                                     },
-                                    "flags": 0,
                                     "typeName": {
                                         "type": "Identifier",
                                         "range": [
@@ -214,8 +210,7 @@ module.exports = {
                                                     "line": 2,
                                                     "column": 57
                                                 }
-                                            },
-                                            "flags": 0
+                                            }
                                         }
                                     ]
                                 }

--- a/tests/fixtures/typescript/basics/function-with-type-parameters.result.js
+++ b/tests/fixtures/typescript/basics/function-with-type-parameters.result.js
@@ -164,7 +164,6 @@ module.exports = {
                 ],
                 "type": "TypeAnnotation",
                 "typeAnnotation": {
-                    "flags": 0,
                     "loc": {
                         "end": {
                             "column": 22,

--- a/tests/fixtures/typescript/basics/function-with-types.result.js
+++ b/tests/fixtures/typescript/basics/function-with-types.result.js
@@ -156,8 +156,7 @@ module.exports = {
                             "line": 1,
                             "column": 36
                         }
-                    },
-                    "flags": 0
+                    }
                 }
             }
         }

--- a/tests/fixtures/typescript/basics/type-alias-declaration.result.js
+++ b/tests/fixtures/typescript/basics/type-alias-declaration.result.js
@@ -91,7 +91,6 @@ module.exports = {
                         "type": "TypeParameterDeclaration"
                     },
                     "init": {
-                        "flags": 0,
                         "loc": {
                             "end": {
                                 "column": 37,
@@ -109,7 +108,6 @@ module.exports = {
                         "type": "TSUnionType",
                         "types": [
                             {
-                                "flags": 0,
                                 "loc": {
                                     "end": {
                                         "column": 27,
@@ -127,7 +125,6 @@ module.exports = {
                                 "type": "TSTypeReference",
                                 "typeArguments": [
                                     {
-                                        "flags": 0,
                                         "loc": {
                                             "end": {
                                                 "column": 26,
@@ -183,7 +180,6 @@ module.exports = {
                                 }
                             },
                             {
-                                "flags": 0,
                                 "loc": {
                                     "end": {
                                         "column": 37,

--- a/tests/fixtures/typescript/basics/var-with-type.result.js
+++ b/tests/fixtures/typescript/basics/var-with-type.result.js
@@ -96,8 +96,7 @@ module.exports = {
                                         "line": 1,
                                         "column": 15
                                     }
-                                },
-                                "flags": 0
+                                }
                             }
                         }
                     },


### PR DESCRIPTION
Whilst we do use TSNode.flags for some node checks, there is not actually any reason to pass them through to the converted AST when using the `deeplyCopy()` fallback. It does not currently provide any benefit, and we will always be exposed to breaking changes.

Please see #105 for additional background on why this came up