### PR TITLE
Fix: Add parameter type annotations to the AST (refs #105)

### DIFF
--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -1089,7 +1089,7 @@ module.exports = function(ast, extra) {
                 } else { // class
 
                     /**
-                     * Unlinke in object literal methods, class method params can have decorators
+                     * Unlike in object literal methods, class method params can have decorators
                      */
                     method.params = node.parameters.map(function(param) {
                         var convertedParam = convertChild(param);
@@ -1408,7 +1408,11 @@ module.exports = function(ast, extra) {
                         right: convertChild(node.initializer)
                     });
                 } else {
-                    return convert(node.name, parent);
+                    var convertedParameter = convert(node.name, parent);
+                    if (node.type) {
+                        convertedParameter.typeAnnotation = convertTypeAnnotation(node.type);
+                    }
+                    return convertedParameter;
                 }
 
                 break;

--- a/tests/fixtures/typescript/basics/arrow-function-with-type-parameters.result.js
+++ b/tests/fixtures/typescript/basics/arrow-function-with-type-parameters.result.js
@@ -1,510 +1,562 @@
 module.exports = {
+    "type": "Program",
+    "range": [
+        0,
+        33
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 3,
+            "column": 1
+        }
+    },
     "body": [
         {
+            "type": "ExpressionStatement",
+            "range": [
+                0,
+                33
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 1
+                }
+            },
             "expression": {
-                "body": {
-                    "body": [
-                        {
-                            "argument": {
-                                "loc": {
-                                    "end": {
-                                        "column": 12,
-                                        "line": 2
-                                    },
-                                    "start": {
-                                        "column": 11,
-                                        "line": 2
-                                    }
-                                },
-                                "name": "b",
-                                "range": [
-                                    29,
-                                    30
-                                ],
-                                "type": "Identifier"
-                            },
-                            "loc": {
-                                "end": {
-                                    "column": 13,
-                                    "line": 2
-                                },
-                                "start": {
-                                    "column": 4,
-                                    "line": 2
-                                }
-                            },
-                            "range": [
-                                22,
-                                31
-                            ],
-                            "type": "ReturnStatement"
-                        }
-                    ],
-                    "loc": {
-                        "end": {
-                            "column": 1,
-                            "line": 3
-                        },
-                        "start": {
-                            "column": 16,
-                            "line": 1
-                        }
-                    },
-                    "range": [
-                        16,
-                        33
-                    ],
-                    "type": "BlockStatement"
-                },
-                "expression": false,
-                "generator": false,
-                "id": null,
-                "loc": {
-                    "end": {
-                        "column": 1,
-                        "line": 3
-                    },
-                    "start": {
-                        "column": 0,
-                        "line": 1
-                    }
-                },
-                "params": [
-                    {
-                        "loc": {
-                            "end": {
-                                "column": 5,
-                                "line": 1
-                            },
-                            "start": {
-                                "column": 4,
-                                "line": 1
-                            }
-                        },
-                        "name": "b",
-                        "range": [
-                            4,
-                            5
-                        ],
-                        "type": "Identifier"
-                    }
-                ],
+                "type": "ArrowFunctionExpression",
                 "range": [
                     0,
                     33
                 ],
-                "returnType": {
-                    "loc": {
-                        "end": {
-                            "column": 12,
-                            "line": 1
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 1
+                    }
+                },
+                "generator": false,
+                "id": null,
+                "params": [
+                    {
+                        "type": "Identifier",
+                        "range": [
+                            4,
+                            5
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 5
+                            }
                         },
+                        "name": "b",
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 7
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 8
+                                }
+                            },
+                            "range": [
+                                7,
+                                8
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSTypeReference",
+                                "range": [
+                                    7,
+                                    8
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 7
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 8
+                                    }
+                                },
+                                "typeName": {
+                                    "type": "Identifier",
+                                    "range": [
+                                        7,
+                                        8
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 1,
+                                            "column": 7
+                                        },
+                                        "end": {
+                                            "line": 1,
+                                            "column": 8
+                                        }
+                                    },
+                                    "name": "X"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "body": {
+                    "type": "BlockStatement",
+                    "range": [
+                        16,
+                        33
+                    ],
+                    "loc": {
                         "start": {
-                            "column": 11,
-                            "line": 1
+                            "line": 1,
+                            "column": 16
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 1
+                        }
+                    },
+                    "body": [
+                        {
+                            "type": "ReturnStatement",
+                            "range": [
+                                22,
+                                31
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 4
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 13
+                                }
+                            },
+                            "argument": {
+                                "type": "Identifier",
+                                "range": [
+                                    29,
+                                    30
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 11
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 12
+                                    }
+                                },
+                                "name": "b"
+                            }
+                        }
+                    ]
+                },
+                "expression": false,
+                "returnType": {
+                    "type": "TypeAnnotation",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 11
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 12
                         }
                     },
                     "range": [
                         11,
                         12
                     ],
-                    "type": "TypeAnnotation",
                     "typeAnnotation": {
-                        "loc": {
-                            "end": {
-                                "column": 12,
-                                "line": 1
-                            },
-                            "start": {
-                                "column": 11,
-                                "line": 1
-                            }
-                        },
+                        "type": "TSTypeReference",
                         "range": [
                             11,
                             12
                         ],
-                        "type": "TSTypeReference",
-                        "typeName": {
-                            "loc": {
-                                "end": {
-                                    "column": 12,
-                                    "line": 1
-                                },
-                                "start": {
-                                    "column": 11,
-                                    "line": 1
-                                }
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 11
                             },
-                            "name": "X",
+                            "end": {
+                                "line": 1,
+                                "column": 12
+                            }
+                        },
+                        "typeName": {
+                            "type": "Identifier",
                             "range": [
                                 11,
                                 12
                             ],
-                            "type": "Identifier"
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 11
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 12
+                                }
+                            },
+                            "name": "X"
                         }
                     }
                 },
-                "type": "ArrowFunctionExpression",
                 "typeParameters": {
-                    "loc": {
-                        "end": {
-                            "column": 3,
-                            "line": 1
-                        },
-                        "start": {
-                            "column": 0,
-                            "line": 1
-                        }
-                    },
-                    "params": [
-                        {
-                            "loc": {
-                                "end": {
-                                    "column": 2,
-                                    "line": 1
-                                },
-                                "start": {
-                                    "column": 1,
-                                    "line": 1
-                                }
-                            },
-                            "name": "X",
-                            "range": [
-                                1,
-                                2
-                            ],
-                            "type": "TypeParameter"
-                        }
-                    ],
+                    "type": "TypeParameterDeclaration",
                     "range": [
                         0,
                         3
                     ],
-                    "type": "TypeParameterDeclaration"
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 3
+                        }
+                    },
+                    "params": [
+                        {
+                            "type": "TypeParameter",
+                            "range": [
+                                1,
+                                2
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 1
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 2
+                                }
+                            },
+                            "name": "X"
+                        }
+                    ]
                 }
-            },
-            "loc": {
-                "end": {
-                    "column": 1,
-                    "line": 3
-                },
-                "start": {
-                    "column": 0,
-                    "line": 1
-                }
-            },
-            "range": [
-                0,
-                33
-            ],
-            "type": "ExpressionStatement"
+            }
         }
-    ],
-    "loc": {
-        "end": {
-            "column": 1,
-            "line": 3
-        },
-        "start": {
-            "column": 0,
-            "line": 1
-        }
-    },
-    "range": [
-        0,
-        33
     ],
     "sourceType": "script",
     "tokens": [
         {
-            "loc": {
-                "end": {
-                    "column": 1,
-                    "line": 1
-                },
-                "start": {
-                    "column": 0,
-                    "line": 1
-                }
-            },
+            "type": "Punctuator",
+            "value": "<",
             "range": [
                 0,
                 1
             ],
-            "type": "Punctuator",
-            "value": "<"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 1
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 2,
-                    "line": 1
-                },
-                "start": {
-                    "column": 1,
-                    "line": 1
-                }
-            },
+            "type": "Identifier",
+            "value": "X",
             "range": [
                 1,
                 2
             ],
-            "type": "Identifier",
-            "value": "X"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 1
+                },
+                "end": {
+                    "line": 1,
+                    "column": 2
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 3,
-                    "line": 1
-                },
-                "start": {
-                    "column": 2,
-                    "line": 1
-                }
-            },
+            "type": "Punctuator",
+            "value": ">",
             "range": [
                 2,
                 3
             ],
-            "type": "Punctuator",
-            "value": ">"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 2
+                },
+                "end": {
+                    "line": 1,
+                    "column": 3
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 4,
-                    "line": 1
-                },
-                "start": {
-                    "column": 3,
-                    "line": 1
-                }
-            },
+            "type": "Punctuator",
+            "value": "(",
             "range": [
                 3,
                 4
             ],
-            "type": "Punctuator",
-            "value": "("
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 3
+                },
+                "end": {
+                    "line": 1,
+                    "column": 4
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 5,
-                    "line": 1
-                },
-                "start": {
-                    "column": 4,
-                    "line": 1
-                }
-            },
+            "type": "Identifier",
+            "value": "b",
             "range": [
                 4,
                 5
             ],
-            "type": "Identifier",
-            "value": "b"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 4
+                },
+                "end": {
+                    "line": 1,
+                    "column": 5
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 6,
-                    "line": 1
-                },
-                "start": {
-                    "column": 5,
-                    "line": 1
-                }
-            },
+            "type": "Punctuator",
+            "value": ":",
             "range": [
                 5,
                 6
             ],
-            "type": "Punctuator",
-            "value": ":"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 5
+                },
+                "end": {
+                    "line": 1,
+                    "column": 6
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 8,
-                    "line": 1
-                },
-                "start": {
-                    "column": 7,
-                    "line": 1
-                }
-            },
+            "type": "Identifier",
+            "value": "X",
             "range": [
                 7,
                 8
             ],
-            "type": "Identifier",
-            "value": "X"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 7
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 9,
-                    "line": 1
-                },
-                "start": {
-                    "column": 8,
-                    "line": 1
-                }
-            },
+            "type": "Punctuator",
+            "value": ")",
             "range": [
                 8,
                 9
             ],
-            "type": "Punctuator",
-            "value": ")"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 8
+                },
+                "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 10,
-                    "line": 1
-                },
-                "start": {
-                    "column": 9,
-                    "line": 1
-                }
-            },
+            "type": "Punctuator",
+            "value": ":",
             "range": [
                 9,
                 10
             ],
-            "type": "Punctuator",
-            "value": ":"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 10
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 12,
-                    "line": 1
-                },
-                "start": {
-                    "column": 11,
-                    "line": 1
-                }
-            },
+            "type": "Identifier",
+            "value": "X",
             "range": [
                 11,
                 12
             ],
-            "type": "Identifier",
-            "value": "X"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 11
+                },
+                "end": {
+                    "line": 1,
+                    "column": 12
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 15,
-                    "line": 1
-                },
-                "start": {
-                    "column": 13,
-                    "line": 1
-                }
-            },
+            "type": "Punctuator",
+            "value": "=>",
             "range": [
                 13,
                 15
             ],
-            "type": "Punctuator",
-            "value": "=>"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 15
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 17,
-                    "line": 1
-                },
-                "start": {
-                    "column": 16,
-                    "line": 1
-                }
-            },
+            "type": "Punctuator",
+            "value": "{",
             "range": [
                 16,
                 17
             ],
-            "type": "Punctuator",
-            "value": "{"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 16
+                },
+                "end": {
+                    "line": 1,
+                    "column": 17
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 10,
-                    "line": 2
-                },
-                "start": {
-                    "column": 4,
-                    "line": 2
-                }
-            },
+            "type": "Keyword",
+            "value": "return",
             "range": [
                 22,
                 28
             ],
-            "type": "Keyword",
-            "value": "return"
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 10
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 12,
-                    "line": 2
-                },
-                "start": {
-                    "column": 11,
-                    "line": 2
-                }
-            },
+            "type": "Identifier",
+            "value": "b",
             "range": [
                 29,
                 30
             ],
-            "type": "Identifier",
-            "value": "b"
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 11
+                },
+                "end": {
+                    "line": 2,
+                    "column": 12
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 13,
-                    "line": 2
-                },
-                "start": {
-                    "column": 12,
-                    "line": 2
-                }
-            },
+            "type": "Punctuator",
+            "value": ";",
             "range": [
                 30,
                 31
             ],
-            "type": "Punctuator",
-            "value": ";"
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 12
+                },
+                "end": {
+                    "line": 2,
+                    "column": 13
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 1,
-                    "line": 3
-                },
-                "start": {
-                    "column": 0,
-                    "line": 3
-                }
-            },
+            "type": "Punctuator",
+            "value": "}",
             "range": [
                 32,
                 33
             ],
-            "type": "Punctuator",
-            "value": "}"
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 1
+                }
+            }
         }
-    ],
-    "type": "Program"
+    ]
 };

--- a/tests/fixtures/typescript/basics/class-with-accessibility-modifiers.result.js
+++ b/tests/fixtures/typescript/basics/class-with-accessibility-modifiers.result.js
@@ -478,6 +478,40 @@ module.exports = {
                                         }
                                     },
                                     "name": "bar",
+                                    "typeAnnotation": {
+                                        "type": "TypeAnnotation",
+                                        "loc": {
+                                            "start": {
+                                                "line": 7,
+                                                "column": 26
+                                            },
+                                            "end": {
+                                                "line": 7,
+                                                "column": 32
+                                            }
+                                        },
+                                        "range": [
+                                            138,
+                                            144
+                                        ],
+                                        "typeAnnotation": {
+                                            "type": "TSStringKeyword",
+                                            "range": [
+                                                138,
+                                                144
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 7,
+                                                    "column": 26
+                                                },
+                                                "end": {
+                                                    "line": 7,
+                                                    "column": 32
+                                                }
+                                            }
+                                        }
+                                    },
                                     "decorators": []
                                 }
                             ]

--- a/tests/fixtures/typescript/basics/class-with-implements-generic-multiple.result.js
+++ b/tests/fixtures/typescript/basics/class-with-implements-generic-multiple.result.js
@@ -31,7 +31,6 @@ module.exports = {
                     "column": 1
                 }
             },
-            "decorators": [],
             "id": {
                 "type": "Identifier",
                 "range": [
@@ -194,7 +193,8 @@ module.exports = {
                         ]
                     }
                 }
-            ]
+            ],
+            "decorators": []
         }
     ],
     "sourceType": "script",

--- a/tests/fixtures/typescript/basics/class-with-implements-generic.result.js
+++ b/tests/fixtures/typescript/basics/class-with-implements-generic.result.js
@@ -31,7 +31,6 @@ module.exports = {
                     "column": 1
                 }
             },
-            "decorators": [],
             "id": {
                 "type": "Identifier",
                 "range": [
@@ -159,7 +158,8 @@ module.exports = {
                         ]
                     }
                 }
-            ]
+            ],
+            "decorators": []
         }
     ],
     "sourceType": "script",

--- a/tests/fixtures/typescript/basics/class-with-implements.result.js
+++ b/tests/fixtures/typescript/basics/class-with-implements.result.js
@@ -31,7 +31,6 @@ module.exports = {
                     "column": 1
                 }
             },
-            "decorators": [],
             "id": {
                 "type": "Identifier",
                 "range": [
@@ -105,7 +104,8 @@ module.exports = {
                         "name": "Bar"
                     }
                 }
-            ]
+            ],
+            "decorators": []
         }
     ],
     "sourceType": "script",

--- a/tests/fixtures/typescript/basics/declare-function.result.js
+++ b/tests/fixtures/typescript/basics/declare-function.result.js
@@ -68,7 +68,41 @@ module.exports = {
                             "column": 24
                         }
                     },
-                    "name": "bar"
+                    "name": "bar",
+                    "typeAnnotation": {
+                        "type": "TypeAnnotation",
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 26
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 32
+                            }
+                        },
+                        "range": [
+                            26,
+                            32
+                        ],
+                        "typeAnnotation": {
+                            "type": "TSStringKeyword",
+                            "range": [
+                                26,
+                                32
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 26
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 32
+                                }
+                            }
+                        }
+                    }
                 }
             ],
             "body": null,

--- a/tests/fixtures/typescript/basics/function-with-type-parameters.result.js
+++ b/tests/fixtures/typescript/basics/function-with-type-parameters.result.js
@@ -1,528 +1,580 @@
 module.exports = {
+    "type": "Program",
+    "range": [
+        0,
+        40
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 3,
+            "column": 1
+        }
+    },
     "body": [
         {
             "type": "FunctionDeclaration",
-            "body": {
-                "body": [
-                    {
-                        "argument": {
-                            "loc": {
-                                "end": {
-                                    "column": 12,
-                                    "line": 2
-                                },
-                                "start": {
-                                    "column": 11,
-                                    "line": 2
-                                }
-                            },
-                            "name": "b",
-                            "range": [
-                                36,
-                                37
-                            ],
-                            "type": "Identifier"
-                        },
-                        "loc": {
-                            "end": {
-                                "column": 13,
-                                "line": 2
-                            },
-                            "start": {
-                                "column": 4,
-                                "line": 2
-                            }
-                        },
-                        "range": [
-                            29,
-                            38
-                        ],
-                        "type": "ReturnStatement"
-                    }
-                ],
-                "loc": {
-                    "end": {
-                        "column": 1,
-                        "line": 3
-                    },
-                    "start": {
-                        "column": 23,
-                        "line": 1
-                    }
-                },
-                "range": [
-                    23,
-                    40
-                ],
-                "type": "BlockStatement"
-            },
-            "expression": false,
-            "generator": false,
-            "id": {
-                "loc": {
-                    "end": {
-                        "column": 10,
-                        "line": 1
-                    },
-                    "start": {
-                        "column": 9,
-                        "line": 1
-                    }
-                },
-                "name": "a",
-                "range": [
-                    9,
-                    10
-                ],
-                "type": "Identifier"
-            },
-            "loc": {
-                "end": {
-                    "column": 1,
-                    "line": 3
-                },
-                "start": {
-                    "column": 0,
-                    "line": 1
-                }
-            },
-            "params": [
-                {
-                    "loc": {
-                        "end": {
-                            "column": 15,
-                            "line": 1
-                        },
-                        "start": {
-                            "column": 14,
-                            "line": 1
-                        }
-                    },
-                    "name": "b",
-                    "range": [
-                        14,
-                        15
-                    ],
-                    "type": "Identifier"
-                }
-            ],
             "range": [
                 0,
                 40
             ],
-            "typeParameters": {
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 1
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    9,
+                    10
+                ],
                 "loc": {
-                    "end": {
-                        "column": 13,
-                        "line": 1
-                    },
                     "start": {
-                        "column": 10,
-                        "line": 1
+                        "line": 1,
+                        "column": 9
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 10
                     }
                 },
-                "params": [
-                    {
+                "name": "a"
+            },
+            "generator": false,
+            "expression": false,
+            "params": [
+                {
+                    "type": "Identifier",
+                    "range": [
+                        14,
+                        15
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 14
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 15
+                        }
+                    },
+                    "name": "b",
+                    "typeAnnotation": {
+                        "type": "TypeAnnotation",
                         "loc": {
-                            "end": {
-                                "column": 12,
-                                "line": 1
-                            },
                             "start": {
-                                "column": 11,
-                                "line": 1
+                                "line": 1,
+                                "column": 17
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 18
                             }
                         },
-                        "name": "X",
                         "range": [
-                            11,
-                            12
+                            17,
+                            18
                         ],
-                        "type": "TypeParameter"
+                        "typeAnnotation": {
+                            "type": "TSTypeReference",
+                            "range": [
+                                17,
+                                18
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 17
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 18
+                                }
+                            },
+                            "typeName": {
+                                "type": "Identifier",
+                                "range": [
+                                    17,
+                                    18
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 17
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 18
+                                    }
+                                },
+                                "name": "X"
+                            }
+                        }
                     }
-                ],
+                }
+            ],
+            "body": {
+                "type": "BlockStatement",
                 "range": [
-                    10,
-                    13
+                    23,
+                    40
                 ],
-                "type": "TypeParameterDeclaration"
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 23
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 1
+                    }
+                },
+                "body": [
+                    {
+                        "type": "ReturnStatement",
+                        "range": [
+                            29,
+                            38
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 13
+                            }
+                        },
+                        "argument": {
+                            "type": "Identifier",
+                            "range": [
+                                36,
+                                37
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 11
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 12
+                                }
+                            },
+                            "name": "b"
+                        }
+                    }
+                ]
             },
             "returnType": {
+                "type": "TypeAnnotation",
                 "loc": {
-                    "end": {
-                        "column": 22,
-                        "line": 1
-                    },
                     "start": {
-                        "column": 21,
-                        "line": 1
+                        "line": 1,
+                        "column": 21
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 22
                     }
                 },
                 "range": [
                     21,
                     22
                 ],
-                "type": "TypeAnnotation",
                 "typeAnnotation": {
-                    "loc": {
-                        "end": {
-                            "column": 22,
-                            "line": 1
-                        },
-                        "start": {
-                            "column": 21,
-                            "line": 1
-                        }
-                    },
+                    "type": "TSTypeReference",
                     "range": [
                         21,
                         22
                     ],
-                    "type": "TSTypeReference",
-                    "typeName": {
-                        "loc": {
-                            "end": {
-                                "column": 22,
-                                "line": 1
-                            },
-                            "start": {
-                                "column": 21,
-                                "line": 1
-                            }
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 21
                         },
-                        "name": "X",
+                        "end": {
+                            "line": 1,
+                            "column": 22
+                        }
+                    },
+                    "typeName": {
+                        "type": "Identifier",
                         "range": [
                             21,
                             22
                         ],
-                        "type": "Identifier"
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 21
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 22
+                            }
+                        },
+                        "name": "X"
                     }
                 }
+            },
+            "typeParameters": {
+                "type": "TypeParameterDeclaration",
+                "range": [
+                    10,
+                    13
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 10
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 13
+                    }
+                },
+                "params": [
+                    {
+                        "type": "TypeParameter",
+                        "range": [
+                            11,
+                            12
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 11
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 12
+                            }
+                        },
+                        "name": "X"
+                    }
+                ]
             }
         }
-    ],
-    "loc": {
-        "end": {
-            "column": 1,
-            "line": 3
-        },
-        "start": {
-            "column": 0,
-            "line": 1
-        }
-    },
-    "range": [
-        0,
-        40
     ],
     "sourceType": "script",
     "tokens": [
         {
-            "loc": {
-                "end": {
-                    "column": 8,
-                    "line": 1
-                },
-                "start": {
-                    "column": 0,
-                    "line": 1
-                }
-            },
+            "type": "Keyword",
+            "value": "function",
             "range": [
                 0,
                 8
             ],
-            "type": "Keyword",
-            "value": "function"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 10,
-                    "line": 1
-                },
-                "start": {
-                    "column": 9,
-                    "line": 1
-                }
-            },
+            "type": "Identifier",
+            "value": "a",
             "range": [
                 9,
                 10
             ],
-            "type": "Identifier",
-            "value": "a"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 10
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 11,
-                    "line": 1
-                },
-                "start": {
-                    "column": 10,
-                    "line": 1
-                }
-            },
+            "type": "Punctuator",
+            "value": "<",
             "range": [
                 10,
                 11
             ],
-            "type": "Punctuator",
-            "value": "<"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 10
+                },
+                "end": {
+                    "line": 1,
+                    "column": 11
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 12,
-                    "line": 1
-                },
-                "start": {
-                    "column": 11,
-                    "line": 1
-                }
-            },
+            "type": "Identifier",
+            "value": "X",
             "range": [
                 11,
                 12
             ],
-            "type": "Identifier",
-            "value": "X"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 11
+                },
+                "end": {
+                    "line": 1,
+                    "column": 12
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 13,
-                    "line": 1
-                },
-                "start": {
-                    "column": 12,
-                    "line": 1
-                }
-            },
+            "type": "Punctuator",
+            "value": ">",
             "range": [
                 12,
                 13
             ],
-            "type": "Punctuator",
-            "value": ">"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 12
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 14,
-                    "line": 1
-                },
-                "start": {
-                    "column": 13,
-                    "line": 1
-                }
-            },
+            "type": "Punctuator",
+            "value": "(",
             "range": [
                 13,
                 14
             ],
-            "type": "Punctuator",
-            "value": "("
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 15,
-                    "line": 1
-                },
-                "start": {
-                    "column": 14,
-                    "line": 1
-                }
-            },
+            "type": "Identifier",
+            "value": "b",
             "range": [
                 14,
                 15
             ],
-            "type": "Identifier",
-            "value": "b"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 14
+                },
+                "end": {
+                    "line": 1,
+                    "column": 15
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 16,
-                    "line": 1
-                },
-                "start": {
-                    "column": 15,
-                    "line": 1
-                }
-            },
+            "type": "Punctuator",
+            "value": ":",
             "range": [
                 15,
                 16
             ],
-            "type": "Punctuator",
-            "value": ":"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 15
+                },
+                "end": {
+                    "line": 1,
+                    "column": 16
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 18,
-                    "line": 1
-                },
-                "start": {
-                    "column": 17,
-                    "line": 1
-                }
-            },
+            "type": "Identifier",
+            "value": "X",
             "range": [
                 17,
                 18
             ],
-            "type": "Identifier",
-            "value": "X"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 17
+                },
+                "end": {
+                    "line": 1,
+                    "column": 18
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 19,
-                    "line": 1
-                },
-                "start": {
-                    "column": 18,
-                    "line": 1
-                }
-            },
+            "type": "Punctuator",
+            "value": ")",
             "range": [
                 18,
                 19
             ],
-            "type": "Punctuator",
-            "value": ")"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 18
+                },
+                "end": {
+                    "line": 1,
+                    "column": 19
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 20,
-                    "line": 1
-                },
-                "start": {
-                    "column": 19,
-                    "line": 1
-                }
-            },
+            "type": "Punctuator",
+            "value": ":",
             "range": [
                 19,
                 20
             ],
-            "type": "Punctuator",
-            "value": ":"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 19
+                },
+                "end": {
+                    "line": 1,
+                    "column": 20
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 22,
-                    "line": 1
-                },
-                "start": {
-                    "column": 21,
-                    "line": 1
-                }
-            },
+            "type": "Identifier",
+            "value": "X",
             "range": [
                 21,
                 22
             ],
-            "type": "Identifier",
-            "value": "X"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 21
+                },
+                "end": {
+                    "line": 1,
+                    "column": 22
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 24,
-                    "line": 1
-                },
-                "start": {
-                    "column": 23,
-                    "line": 1
-                }
-            },
+            "type": "Punctuator",
+            "value": "{",
             "range": [
                 23,
                 24
             ],
-            "type": "Punctuator",
-            "value": "{"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 23
+                },
+                "end": {
+                    "line": 1,
+                    "column": 24
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 10,
-                    "line": 2
-                },
-                "start": {
-                    "column": 4,
-                    "line": 2
-                }
-            },
+            "type": "Keyword",
+            "value": "return",
             "range": [
                 29,
                 35
             ],
-            "type": "Keyword",
-            "value": "return"
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 10
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 12,
-                    "line": 2
-                },
-                "start": {
-                    "column": 11,
-                    "line": 2
-                }
-            },
+            "type": "Identifier",
+            "value": "b",
             "range": [
                 36,
                 37
             ],
-            "type": "Identifier",
-            "value": "b"
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 11
+                },
+                "end": {
+                    "line": 2,
+                    "column": 12
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 13,
-                    "line": 2
-                },
-                "start": {
-                    "column": 12,
-                    "line": 2
-                }
-            },
+            "type": "Punctuator",
+            "value": ";",
             "range": [
                 37,
                 38
             ],
-            "type": "Punctuator",
-            "value": ";"
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 12
+                },
+                "end": {
+                    "line": 2,
+                    "column": 13
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 1,
-                    "line": 3
-                },
-                "start": {
-                    "column": 0,
-                    "line": 3
-                }
-            },
+            "type": "Punctuator",
+            "value": "}",
             "range": [
                 39,
                 40
             ],
-            "type": "Punctuator",
-            "value": "}"
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 1
+                }
+            }
         }
-    ],
-    "type": "Program"
+    ]
 };

--- a/tests/fixtures/typescript/basics/function-with-types.result.js
+++ b/tests/fixtures/typescript/basics/function-with-types.result.js
@@ -68,7 +68,41 @@ module.exports = {
                             "column": 21
                         }
                     },
-                    "name": "name"
+                    "name": "name",
+                    "typeAnnotation": {
+                        "type": "TypeAnnotation",
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 22
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 28
+                            }
+                        },
+                        "range": [
+                            22,
+                            28
+                        ],
+                        "typeAnnotation": {
+                            "type": "TSStringKeyword",
+                            "range": [
+                                22,
+                                28
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 22
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 28
+                                }
+                            }
+                        }
+                    }
                 }
             ],
             "body": {

--- a/tests/fixtures/typescript/basics/non-null-assertion-operator.result.js
+++ b/tests/fixtures/typescript/basics/non-null-assertion-operator.result.js
@@ -68,7 +68,59 @@ module.exports = {
                             "column": 24
                         }
                     },
-                    "name": "e"
+                    "name": "e",
+                    "typeAnnotation": {
+                        "type": "TypeAnnotation",
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 27
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 33
+                            }
+                        },
+                        "range": [
+                            27,
+                            33
+                        ],
+                        "typeAnnotation": {
+                            "type": "TSTypeReference",
+                            "range": [
+                                27,
+                                33
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 27
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 33
+                                }
+                            },
+                            "typeName": {
+                                "type": "Identifier",
+                                "range": [
+                                    27,
+                                    33
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 27
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 33
+                                    }
+                                },
+                                "name": "Entity"
+                            }
+                        }
+                    }
                 }
             ],
             "body": {

--- a/tests/fixtures/typescript/basics/type-alias-declaration.result.js
+++ b/tests/fixtures/typescript/basics/type-alias-declaration.result.js
@@ -17,23 +17,23 @@ module.exports = {
     "body": [
         {
             "type": "VariableDeclaration",
+            "range": [
+                0,
+                37
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 37
+                }
+            },
             "kind": "type",
             "declarations": [
                 {
-                    "loc": {
-                        "end": {
-                            "column": 37,
-                            "line": 1
-                        },
-                        "start": {
-                            "column": 5,
-                            "line": 1
-                        }
-                    },
-                    "range": [
-                        5,
-                        37
-                    ],
                     "type": "VariableDeclarator",
                     "id": {
                         "type": "Identifier",
@@ -53,185 +53,185 @@ module.exports = {
                         },
                         "name": "Result"
                     },
-                    "typeParameters": {
-                        "loc": {
-                            "end": {
-                                "column": 14,
-                                "line": 1
-                            },
-                            "start": {
-                                "column": 11,
-                                "line": 1
-                            }
-                        },
-                        "params": [
-                            {
-                                "loc": {
-                                    "end": {
-                                        "column": 13,
-                                        "line": 1
-                                    },
-                                    "start": {
-                                        "column": 12,
-                                        "line": 1
-                                    }
-                                },
-                                "name": "T",
-                                "range": [
-                                    12,
-                                    13
-                                ],
-                                "type": "TypeParameter"
-                            }
-                        ],
-                        "range": [
-                            11,
-                            14
-                        ],
-                        "type": "TypeParameterDeclaration"
-                    },
                     "init": {
-                        "loc": {
-                            "end": {
-                                "column": 37,
-                                "line": 1
-                            },
-                            "start": {
-                                "column": 17,
-                                "line": 1
-                            }
-                        },
+                        "type": "TSUnionType",
                         "range": [
                             17,
                             37
                         ],
-                        "type": "TSUnionType",
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 17
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 37
+                            }
+                        },
                         "types": [
                             {
-                                "loc": {
-                                    "end": {
-                                        "column": 27,
-                                        "line": 1
-                                    },
-                                    "start": {
-                                        "column": 17,
-                                        "line": 1
-                                    }
-                                },
+                                "type": "TSTypeReference",
                                 "range": [
                                     17,
                                     27
                                 ],
-                                "type": "TSTypeReference",
-                                "typeArguments": [
-                                    {
-                                        "loc": {
-                                            "end": {
-                                                "column": 26,
-                                                "line": 1
-                                            },
-                                            "start": {
-                                                "column": 25,
-                                                "line": 1
-                                            }
-                                        },
-                                        "range": [
-                                            25,
-                                            26
-                                        ],
-                                        "type": "TSTypeReference",
-                                        "typeName": {
-                                            "loc": {
-                                                "end": {
-                                                    "column": 26,
-                                                    "line": 1
-                                                },
-                                                "start": {
-                                                    "column": 25,
-                                                    "line": 1
-                                                }
-                                            },
-                                            "name": "T",
-                                            "range": [
-                                                25,
-                                                26
-                                            ],
-                                            "type": "Identifier"
-                                        }
-                                    }
-                                ],
-                                "typeName": {
-                                    "loc": {
-                                        "end": {
-                                            "column": 24,
-                                            "line": 1
-                                        },
-                                        "start": {
-                                            "column": 17,
-                                            "line": 1
-                                        }
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 17
                                     },
-                                    "name": "Success",
+                                    "end": {
+                                        "line": 1,
+                                        "column": 27
+                                    }
+                                },
+                                "typeName": {
+                                    "type": "Identifier",
                                     "range": [
                                         17,
                                         24
                                     ],
-                                    "type": "Identifier"
-                                }
+                                    "loc": {
+                                        "start": {
+                                            "line": 1,
+                                            "column": 17
+                                        },
+                                        "end": {
+                                            "line": 1,
+                                            "column": 24
+                                        }
+                                    },
+                                    "name": "Success"
+                                },
+                                "typeArguments": [
+                                    {
+                                        "type": "TSTypeReference",
+                                        "range": [
+                                            25,
+                                            26
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 1,
+                                                "column": 25
+                                            },
+                                            "end": {
+                                                "line": 1,
+                                                "column": 26
+                                            }
+                                        },
+                                        "typeName": {
+                                            "type": "Identifier",
+                                            "range": [
+                                                25,
+                                                26
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 1,
+                                                    "column": 25
+                                                },
+                                                "end": {
+                                                    "line": 1,
+                                                    "column": 26
+                                                }
+                                            },
+                                            "name": "T"
+                                        }
+                                    }
+                                ]
                             },
                             {
-                                "loc": {
-                                    "end": {
-                                        "column": 37,
-                                        "line": 1
-                                    },
-                                    "start": {
-                                        "column": 30,
-                                        "line": 1
-                                    }
-                                },
+                                "type": "TSTypeReference",
                                 "range": [
                                     30,
                                     37
                                 ],
-                                "type": "TSTypeReference",
-                                "typeName": {
-                                    "loc": {
-                                        "end": {
-                                            "column": 37,
-                                            "line": 1
-                                        },
-                                        "start": {
-                                            "column": 30,
-                                            "line": 1
-                                        }
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 30
                                     },
-                                    "name": "Failure",
+                                    "end": {
+                                        "line": 1,
+                                        "column": 37
+                                    }
+                                },
+                                "typeName": {
+                                    "type": "Identifier",
                                     "range": [
                                         30,
                                         37
                                     ],
-                                    "type": "Identifier"
+                                    "loc": {
+                                        "start": {
+                                            "line": 1,
+                                            "column": 30
+                                        },
+                                        "end": {
+                                            "line": 1,
+                                            "column": 37
+                                        }
+                                    },
+                                    "name": "Failure"
                                 }
+                            }
+                        ]
+                    },
+                    "range": [
+                        5,
+                        37
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 5
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 37
+                        }
+                    },
+                    "typeParameters": {
+                        "type": "TypeParameterDeclaration",
+                        "range": [
+                            11,
+                            14
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 11
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 14
+                            }
+                        },
+                        "params": [
+                            {
+                                "type": "TypeParameter",
+                                "range": [
+                                    12,
+                                    13
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 12
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 13
+                                    }
+                                },
+                                "name": "T"
                             }
                         ]
                     }
                 }
-            ],
-            "range": [
-                0,
-                37
-            ],
-            "loc": {
-                "start": {
-                    "line": 1,
-                    "column": 0
-                },
-                "end": {
-                    "line": 1,
-                    "column": 37
-                }
-            }
+            ]
         }
     ],
     "sourceType": "script",

--- a/tests/fixtures/typescript/decorators/class-decorators/class-decorator-factory.result.js
+++ b/tests/fixtures/typescript/decorators/class-decorators/class-decorator-factory.result.js
@@ -31,122 +31,6 @@ module.exports = {
                     "column": 21
                 }
             },
-            "decorators": [
-                {
-                    "arguments": [
-                        {
-                            "loc": {
-                                "end": {
-                                    "column": 1,
-                                    "line": 3
-                                },
-                                "start": {
-                                    "column": 11,
-                                    "line": 1
-                                }
-                            },
-                            "properties": [
-                                {
-                                    "computed": false,
-                                    "key": {
-                                        "loc": {
-                                            "end": {
-                                                "column": 12,
-                                                "line": 2
-                                            },
-                                            "start": {
-                                                "column": 4,
-                                                "line": 2
-                                            }
-                                        },
-                                        "name": "selector",
-                                        "range": [
-                                            17,
-                                            25
-                                        ],
-                                        "type": "Identifier"
-                                    },
-                                    "kind": "init",
-                                    "loc": {
-                                        "end": {
-                                            "column": 19,
-                                            "line": 2
-                                        },
-                                        "start": {
-                                            "column": 4,
-                                            "line": 2
-                                        }
-                                    },
-                                    "method": false,
-                                    "range": [
-                                        17,
-                                        32
-                                    ],
-                                    "shorthand": false,
-                                    "type": "Property",
-                                    "value": {
-                                        "loc": {
-                                            "end": {
-                                                "column": 19,
-                                                "line": 2
-                                            },
-                                            "start": {
-                                                "column": 14,
-                                                "line": 2
-                                            }
-                                        },
-                                        "range": [
-                                            27,
-                                            32
-                                        ],
-                                        "raw": "'foo'",
-                                        "type": "Literal",
-                                        "value": "foo"
-                                    }
-                                }
-                            ],
-                            "range": [
-                                11,
-                                35
-                            ],
-                            "type": "ObjectExpression"
-                        }
-                    ],
-                    "callee": {
-                        "loc": {
-                            "end": {
-                                "column": 10,
-                                "line": 1
-                            },
-                            "start": {
-                                "column": 1,
-                                "line": 1
-                            }
-                        },
-                        "name": "Component",
-                        "range": [
-                            1,
-                            10
-                        ],
-                        "type": "Identifier"
-                    },
-                    "loc": {
-                        "end": {
-                            "column": 2,
-                            "line": 3
-                        },
-                        "start": {
-                            "column": 1,
-                            "line": 1
-                        }
-                    },
-                    "range": [
-                        1,
-                        36
-                    ],
-                    "type": "CallExpression"
-                }
-            ],
             "id": {
                 "type": "Identifier",
                 "range": [
@@ -184,7 +68,123 @@ module.exports = {
                 }
             },
             "superClass": null,
-            "implements": []
+            "implements": [],
+            "decorators": [
+                {
+                    "type": "CallExpression",
+                    "range": [
+                        1,
+                        36
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 1
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 2
+                        }
+                    },
+                    "callee": {
+                        "type": "Identifier",
+                        "range": [
+                            1,
+                            10
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 1
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 10
+                            }
+                        },
+                        "name": "Component"
+                    },
+                    "arguments": [
+                        {
+                            "type": "ObjectExpression",
+                            "range": [
+                                11,
+                                35
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 11
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 1
+                                }
+                            },
+                            "properties": [
+                                {
+                                    "type": "Property",
+                                    "range": [
+                                        17,
+                                        32
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 19
+                                        }
+                                    },
+                                    "key": {
+                                        "type": "Identifier",
+                                        "range": [
+                                            17,
+                                            25
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 2,
+                                                "column": 4
+                                            },
+                                            "end": {
+                                                "line": 2,
+                                                "column": 12
+                                            }
+                                        },
+                                        "name": "selector"
+                                    },
+                                    "value": {
+                                        "type": "Literal",
+                                        "range": [
+                                            27,
+                                            32
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 2,
+                                                "column": 14
+                                            },
+                                            "end": {
+                                                "line": 2,
+                                                "column": 19
+                                            }
+                                        },
+                                        "value": "foo",
+                                        "raw": "'foo'"
+                                    },
+                                    "computed": false,
+                                    "method": false,
+                                    "shorthand": false,
+                                    "kind": "init"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         }
     ],
     "sourceType": "script",

--- a/tests/fixtures/typescript/decorators/class-decorators/class-decorator.result.js
+++ b/tests/fixtures/typescript/decorators/class-decorators/class-decorator.result.js
@@ -31,26 +31,6 @@ module.exports = {
                     "column": 12
                 }
             },
-            "decorators": [
-                {
-                    "loc": {
-                        "end": {
-                            "column": 7,
-                            "line": 1
-                        },
-                        "start": {
-                            "column": 1,
-                            "line": 1
-                        }
-                    },
-                    "name": "sealed",
-                    "range": [
-                        1,
-                        7
-                    ],
-                    "type": "Identifier"
-                }
-            ],
             "id": {
                 "type": "Identifier",
                 "range": [
@@ -88,7 +68,27 @@ module.exports = {
                 }
             },
             "superClass": null,
-            "implements": []
+            "implements": [],
+            "decorators": [
+                {
+                    "type": "Identifier",
+                    "range": [
+                        1,
+                        7
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 1
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 7
+                        }
+                    },
+                    "name": "sealed"
+                }
+            ]
         }
     ],
     "sourceType": "script",

--- a/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-constructor.result.js
+++ b/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-constructor.result.js
@@ -17,7 +17,6 @@ module.exports = {
     "body": [
         {
             "type": "ClassDeclaration",
-            "decorators": [],
             "range": [
                 0,
                 115
@@ -108,61 +107,113 @@ module.exports = {
                                         }
                                     },
                                     "name": "config",
-                                    "decorators": [
-                                        {
-                                            "arguments": [
-                                                {
-                                                    "loc": {
-                                                        "end": {
-                                                            "column": 34,
-                                                            "line": 2
-                                                        },
-                                                        "start": {
-                                                            "column": 24,
-                                                            "line": 2
-                                                        }
-                                                    },
-                                                    "name": "APP_CONFIG",
-                                                    "range": [
-                                                        40,
-                                                        50
-                                                    ],
-                                                    "type": "Identifier"
-                                                }
+                                    "typeAnnotation": {
+                                        "type": "TypeAnnotation",
+                                        "loc": {
+                                            "start": {
+                                                "line": 2,
+                                                "column": 44
+                                            },
+                                            "end": {
+                                                "line": 2,
+                                                "column": 53
+                                            }
+                                        },
+                                        "range": [
+                                            60,
+                                            69
+                                        ],
+                                        "typeAnnotation": {
+                                            "type": "TSTypeReference",
+                                            "range": [
+                                                60,
+                                                69
                                             ],
-                                            "callee": {
+                                            "loc": {
+                                                "start": {
+                                                    "line": 2,
+                                                    "column": 44
+                                                },
+                                                "end": {
+                                                    "line": 2,
+                                                    "column": 53
+                                                }
+                                            },
+                                            "typeName": {
+                                                "type": "Identifier",
+                                                "range": [
+                                                    60,
+                                                    69
+                                                ],
                                                 "loc": {
-                                                    "end": {
-                                                        "column": 23,
-                                                        "line": 2
-                                                    },
                                                     "start": {
-                                                        "column": 17,
-                                                        "line": 2
+                                                        "line": 2,
+                                                        "column": 44
+                                                    },
+                                                    "end": {
+                                                        "line": 2,
+                                                        "column": 53
                                                     }
                                                 },
-                                                "name": "Inject",
-                                                "range": [
-                                                    33,
-                                                    39
-                                                ],
-                                                "type": "Identifier"
-                                            },
-                                            "loc": {
-                                                "end": {
-                                                    "column": 35,
-                                                    "line": 2
-                                                },
-                                                "start": {
-                                                    "column": 17,
-                                                    "line": 2
-                                                }
-                                            },
+                                                "name": "AppConfig"
+                                            }
+                                        }
+                                    },
+                                    "decorators": [
+                                        {
+                                            "type": "CallExpression",
                                             "range": [
                                                 33,
                                                 51
                                             ],
-                                            "type": "CallExpression"
+                                            "loc": {
+                                                "start": {
+                                                    "line": 2,
+                                                    "column": 17
+                                                },
+                                                "end": {
+                                                    "line": 2,
+                                                    "column": 35
+                                                }
+                                            },
+                                            "callee": {
+                                                "type": "Identifier",
+                                                "range": [
+                                                    33,
+                                                    39
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 2,
+                                                        "column": 17
+                                                    },
+                                                    "end": {
+                                                        "line": 2,
+                                                        "column": 23
+                                                    }
+                                                },
+                                                "name": "Inject"
+                                            },
+                                            "arguments": [
+                                                {
+                                                    "type": "Identifier",
+                                                    "range": [
+                                                        40,
+                                                        50
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 2,
+                                                            "column": 24
+                                                        },
+                                                        "end": {
+                                                            "line": 2,
+                                                            "column": 34
+                                                        }
+                                                    },
+                                                    "name": "APP_CONFIG"
+                                                }
+                                            ]
                                         }
                                     ]
                                 }
@@ -345,8 +396,8 @@ module.exports = {
                                 }
                             }
                         },
-                        "accessibility": null,
                         "computed": false,
+                        "accessibility": null,
                         "static": false,
                         "kind": "constructor"
                     }
@@ -367,7 +418,8 @@ module.exports = {
                 }
             },
             "superClass": null,
-            "implements": []
+            "implements": [],
+            "decorators": []
         }
     ],
     "sourceType": "script",

--- a/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-decorator-instance-member.result.js
+++ b/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-decorator-instance-member.result.js
@@ -141,6 +141,40 @@ module.exports = {
                                         }
                                     },
                                     "name": "baz",
+                                    "typeAnnotation": {
+                                        "type": "TypeAnnotation",
+                                        "loc": {
+                                            "start": {
+                                                "line": 2,
+                                                "column": 28
+                                            },
+                                            "end": {
+                                                "line": 2,
+                                                "column": 34
+                                            }
+                                        },
+                                        "range": [
+                                            40,
+                                            46
+                                        ],
+                                        "typeAnnotation": {
+                                            "type": "TSNumberKeyword",
+                                            "range": [
+                                                40,
+                                                46
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 2,
+                                                    "column": 28
+                                                },
+                                                "end": {
+                                                    "line": 2,
+                                                    "column": 34
+                                                }
+                                            }
+                                        }
+                                    },
                                     "decorators": [
                                         {
                                             "type": "CallExpression",

--- a/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-decorator-static-member.result.js
+++ b/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-decorator-static-member.result.js
@@ -141,6 +141,40 @@ module.exports = {
                                         }
                                     },
                                     "name": "baz",
+                                    "typeAnnotation": {
+                                        "type": "TypeAnnotation",
+                                        "loc": {
+                                            "start": {
+                                                "line": 2,
+                                                "column": 35
+                                            },
+                                            "end": {
+                                                "line": 2,
+                                                "column": 41
+                                            }
+                                        },
+                                        "range": [
+                                            53,
+                                            59
+                                        ],
+                                        "typeAnnotation": {
+                                            "type": "TSNumberKeyword",
+                                            "range": [
+                                                53,
+                                                59
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 2,
+                                                    "column": 35
+                                                },
+                                                "end": {
+                                                    "line": 2,
+                                                    "column": 41
+                                                }
+                                            }
+                                        }
+                                    },
                                     "decorators": [
                                         {
                                             "type": "CallExpression",

--- a/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-instance-member.result.js
+++ b/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-instance-member.result.js
@@ -251,6 +251,40 @@ module.exports = {
                                         }
                                     },
                                     "name": "name",
+                                    "typeAnnotation": {
+                                        "type": "TypeAnnotation",
+                                        "loc": {
+                                            "start": {
+                                                "line": 2,
+                                                "column": 26
+                                            },
+                                            "end": {
+                                                "line": 2,
+                                                "column": 32
+                                            }
+                                        },
+                                        "range": [
+                                            42,
+                                            48
+                                        ],
+                                        "typeAnnotation": {
+                                            "type": "TSStringKeyword",
+                                            "range": [
+                                                42,
+                                                48
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 2,
+                                                    "column": 26
+                                                },
+                                                "end": {
+                                                    "line": 2,
+                                                    "column": 32
+                                                }
+                                            }
+                                        }
+                                    },
                                     "decorators": [
                                         {
                                             "type": "Identifier",

--- a/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-static-member.result.js
+++ b/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-static-member.result.js
@@ -251,6 +251,40 @@ module.exports = {
                                         }
                                     },
                                     "name": "name",
+                                    "typeAnnotation": {
+                                        "type": "TypeAnnotation",
+                                        "loc": {
+                                            "start": {
+                                                "line": 2,
+                                                "column": 33
+                                            },
+                                            "end": {
+                                                "line": 2,
+                                                "column": 39
+                                            }
+                                        },
+                                        "range": [
+                                            55,
+                                            61
+                                        ],
+                                        "typeAnnotation": {
+                                            "type": "TSStringKeyword",
+                                            "range": [
+                                                55,
+                                                61
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 2,
+                                                    "column": 33
+                                                },
+                                                "end": {
+                                                    "line": 2,
+                                                    "column": 39
+                                                }
+                                            }
+                                        }
+                                    },
                                     "decorators": [
                                         {
                                             "type": "Identifier",

--- a/tests/fixtures/typescript/namespaces-and-modules/declare-namespace-with-exported-function.result.js
+++ b/tests/fixtures/typescript/namespaces-and-modules/declare-namespace-with-exported-function.result.js
@@ -140,7 +140,41 @@ module.exports = {
                                             "column": 33
                                         }
                                     },
-                                    "name": "selector"
+                                    "name": "selector",
+                                    "typeAnnotation": {
+                                        "type": "TypeAnnotation",
+                                        "loc": {
+                                            "start": {
+                                                "line": 2,
+                                                "column": 35
+                                            },
+                                            "end": {
+                                                "line": 2,
+                                                "column": 41
+                                            }
+                                        },
+                                        "range": [
+                                            58,
+                                            64
+                                        ],
+                                        "typeAnnotation": {
+                                            "type": "TSStringKeyword",
+                                            "range": [
+                                                58,
+                                                64
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 2,
+                                                    "column": 35
+                                                },
+                                                "end": {
+                                                    "line": 2,
+                                                    "column": 41
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                             ],
                             "body": null,

--- a/tests/fixtures/typescript/namespaces-and-modules/shorthand-ambient-module-declaration.result.js
+++ b/tests/fixtures/typescript/namespaces-and-modules/shorthand-ambient-module-declaration.result.js
@@ -1,149 +1,149 @@
 module.exports = {
-    "body": [
-        {
-            "loc": {
-                "end": {
-                    "column": 32,
-                    "line": 1
-                },
-                "start": {
-                    "column": 0,
-                    "line": 1
-                }
-            },
-            "modifiers": [
-                {
-                    "loc": {
-                        "end": {
-                            "column": 7,
-                            "line": 1
-                        },
-                        "start": {
-                            "column": 0,
-                            "line": 1
-                        }
-                    },
-                    "range": [
-                        0,
-                        7
-                    ],
-                    "type": "TSDeclareKeyword"
-                }
-            ],
-            "name": {
-                "loc": {
-                    "end": {
-                        "column": 31,
-                        "line": 1
-                    },
-                    "start": {
-                        "column": 15,
-                        "line": 1
-                    }
-                },
-                "range": [
-                    15,
-                    31
-                ],
-                "raw": "\"hot-new-module\"",
-                "type": "Literal",
-                "value": "hot-new-module"
-            },
-            "range": [
-                0,
-                32
-            ],
-            "type": "TSModuleDeclaration"
-        }
-    ],
-    "loc": {
-        "end": {
-            "column": 32,
-            "line": 1
-        },
-        "start": {
-            "column": 0,
-            "line": 1
-        }
-    },
+    "type": "Program",
     "range": [
         0,
         32
     ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 32
+        }
+    },
+    "body": [
+        {
+            "type": "TSModuleDeclaration",
+            "range": [
+                0,
+                32
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 32
+                }
+            },
+            "modifiers": [
+                {
+                    "type": "TSDeclareKeyword",
+                    "range": [
+                        0,
+                        7
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 7
+                        }
+                    }
+                }
+            ],
+            "name": {
+                "type": "Literal",
+                "range": [
+                    15,
+                    31
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 15
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 31
+                    }
+                },
+                "value": "hot-new-module",
+                "raw": "\"hot-new-module\""
+            }
+        }
+    ],
     "sourceType": "script",
     "tokens": [
         {
-            "loc": {
-                "end": {
-                    "column": 7,
-                    "line": 1
-                },
-                "start": {
-                    "column": 0,
-                    "line": 1
-                }
-            },
+            "type": "Identifier",
+            "value": "declare",
             "range": [
                 0,
                 7
             ],
-            "type": "Identifier",
-            "value": "declare"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 7
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 14,
-                    "line": 1
-                },
-                "start": {
-                    "column": 8,
-                    "line": 1
-                }
-            },
+            "type": "Identifier",
+            "value": "module",
             "range": [
                 8,
                 14
             ],
-            "type": "Identifier",
-            "value": "module"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 8
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 31,
-                    "line": 1
-                },
-                "start": {
-                    "column": 15,
-                    "line": 1
-                }
-            },
+            "type": "String",
+            "value": "\"hot-new-module\"",
             "range": [
                 15,
                 31
             ],
-            "type": "String",
-            "value": "\"hot-new-module\""
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 15
+                },
+                "end": {
+                    "line": 1,
+                    "column": 31
+                }
+            }
         },
         {
-            "loc": {
-                "end": {
-                    "column": 32,
-                    "line": 1
-                },
-                "start": {
-                    "column": 31,
-                    "line": 1
-                }
-            },
+            "type": "Punctuator",
+            "value": ";",
             "range": [
                 31,
                 32
             ],
-            "type": "Punctuator",
-            "value": ";"
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 31
+                },
+                "end": {
+                    "line": 1,
+                    "column": 32
+                }
+            }
         }
-    ],
-    "type": "Program"
+    ]
 };


### PR DESCRIPTION
It turns out we were never actually adding the type annotations of function parameters to the final AST. The tokens were tracked, and so this was not having any adverse effects, but it means we were lacking some information that would be needed for future rules and assertions for the TS 2.x special "typed-this" parameter.

Once this PR goes in the final TS 2.x PR (relating to that typed-this assertion) is ready to go and we can ship our first TS 2 release :shipit: 

I am sorry about the large diff, given that this is a change which affects any typed function parameters it affects 11-12 different test cases.

I have traditionally reconciled things like this by hand to minimise the noise, but I did actually run your `node tools/update-typescript-tests.js` helper this time and it seems to have switched around the order of some things in the resulting AST.