### PR TITLE
Fix: export type alias ExportNamedDeclaration node generation (fixes #134)

### DIFF
--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -1941,16 +1941,23 @@ module.exports = function(ast, extra) {
                     init: convertChild(node.type),
                     range: [node.name.getStart(), node.end]
                 };
+
                 typeAliasDeclarator.loc = getLocFor(typeAliasDeclarator.range[0], typeAliasDeclarator.range[1], ast);
+
                 // Process typeParameters
                 if (node.typeParameters && node.typeParameters.length) {
                     typeAliasDeclarator.typeParameters = convertTSTypeParametersToTypeParametersDeclaration(node.typeParameters);
                 }
+
                 assign(result, {
                     type: "VariableDeclaration",
                     kind: "type",
                     declarations: [typeAliasDeclarator]
                 });
+
+                // check for exports
+                result = fixExports(node, result, ast);
+
                 break;
 
             default:

--- a/tests/fixtures/typescript/basics/export-type-alias-declaration.result.js
+++ b/tests/fixtures/typescript/basics/export-type-alias-declaration.result.js
@@ -1,0 +1,293 @@
+module.exports = {
+    "type": "Program",
+    "range": [
+        0,
+        40
+    ],
+    "loc": {
+        "end": {
+            "line": 1,
+            "column": 40
+        },
+        "start": {
+            "line": 1,
+            "column": 0
+        }
+    },
+    "body": [
+        {
+            "type": "ExportNamedDeclaration",
+            "range": [
+                0,
+                40
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 40
+                },
+                "start": {
+                    "line": 1,
+                    "column": 0
+                }
+            },
+            "declaration": {
+                "type": "VariableDeclaration",
+                "range": [
+                    7,
+                    40
+                ],
+                "loc": {
+                    "end": {
+                        "line": 1,
+                        "column": 40
+                    },
+                    "start": {
+                        "line": 1,
+                        "column": 7
+                    }
+                },
+                "kind": "type",
+                "declarations": [
+                    {
+                        "type": "VariableDeclarator",
+                        "range": [
+                            12,
+                            40
+                        ],
+                        "loc": {
+                            "end": {
+                                "line": 1,
+                                "column": 40
+                            },
+                            "start": {
+                                "line": 1,
+                                "column": 12
+                            }
+                        },
+                        "id": {
+                            "type": "Identifier",
+                            "range": [
+                                12,
+                                21
+                            ],
+                            "loc": {
+                                "end": {
+                                    "line": 1,
+                                    "column": 21
+                                },
+                                "start": {
+                                    "line": 1,
+                                    "column": 12
+                                }
+                            },
+                            "name": "TestAlias"
+                        },
+                        "init": {
+                            "type": "TSUnionType",
+                            "loc": {
+                                "end": {
+                                    "line": 1,
+                                    "column": 39
+                                },
+                                "start": {
+                                    "line": 1,
+                                    "column": 24
+                                }
+                            },
+                            "range": [
+                                24,
+                                39
+                            ],
+                            "types": [
+                                {
+                                    "type": "TSStringKeyword",
+                                    "range": [
+                                        24,
+                                        30
+                                    ],
+                                    "loc": {
+                                        "end": {
+                                            "line": 1,
+                                            "column": 30
+                                        },
+                                        "start": {
+                                            "line": 1,
+                                            "column": 24
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "TSNumberKeyword",
+                                    "range": [
+                                        33,
+                                        39
+                                    ],
+                                    "loc": {
+                                        "end": {
+                                            "line": 1,
+                                            "column": 39
+                                        },
+                                        "start": {
+                                            "line": 1,
+                                            "column": 33
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "source": null,
+            "specifiers": []
+        }
+    ],
+    "sourceType": "module",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "range": [
+                0,
+                6
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 6
+                },
+                "start": {
+                    "line": 1,
+                    "column": 0
+                }
+            },
+            "value": "export"
+        },
+        {
+            "type": "Identifier",
+            "range": [
+                7,
+                11
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 11
+                },
+                "start": {
+                    "line": 1,
+                    "column": 7
+                }
+            },
+            "value": "type"
+        },
+        {
+            "type": "Identifier",
+            "range": [
+                12,
+                21
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 21
+                },
+                "start": {
+                    "line": 1,
+                    "column": 12
+                }
+            },
+            "value": "TestAlias"
+        },
+        {
+            "type": "Punctuator",
+            "range": [
+                22,
+                23
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 23
+                },
+                "start": {
+                    "line": 1,
+                    "column": 22
+                }
+            },
+            "value": "="
+        },
+        {
+            "type": "Identifier",
+            "range": [
+                24,
+                30
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 30
+                },
+                "start": {
+                    "line": 1,
+                    "column": 24
+                }
+            },
+            "value": "string"
+        },
+        {
+            "type": "Punctuator",
+            "range": [
+                31,
+                32
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 32
+                },
+                "start": {
+                    "line": 1,
+                    "column": 31
+                }
+            },
+            "value": "|"
+        },
+        {
+            "type": "Identifier",
+            "range": [
+                33,
+                39
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 39
+                },
+                "start": {
+                    "line": 1,
+                    "column": 33
+                }
+            },
+            "value": "number"
+        },
+        {
+            "type": "Punctuator",
+            "range": [
+                39,
+                40
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 40
+                },
+                "start": {
+                    "line": 1,
+                    "column": 39
+                }
+            },
+            "value": ";"
+        }
+    ]
+};

--- a/tests/fixtures/typescript/basics/export-type-alias-declaration.src.ts
+++ b/tests/fixtures/typescript/basics/export-type-alias-declaration.src.ts
@@ -1,0 +1,1 @@
+export type TestAlias = string | number;

--- a/tests/fixtures/typescript/basics/export-type-class-declaration.result.js
+++ b/tests/fixtures/typescript/basics/export-type-class-declaration.result.js
@@ -1,0 +1,364 @@
+module.exports = {
+    "type": "Program",
+    "range": [
+        0,
+        51
+    ],
+    "loc": {
+        "end": {
+            "line": 3,
+            "column": 2
+        },
+        "start": {
+            "line": 1,
+            "column": 0
+        }
+    },
+    "body": [
+        {
+            "type": "ExportNamedDeclaration",
+            "range": [
+                0,
+                51
+            ],
+            "loc": {
+                "end": {
+                    "line": 3,
+                    "column": 2
+                },
+                "start": {
+                    "line": 1,
+                    "column": 0
+                }
+            },
+            "declaration": {
+                "type": "VariableDeclaration",
+                "range": [
+                    7,
+                    51
+                ],
+                "loc": {
+                    "end": {
+                        "line": 3,
+                        "column": 2
+                    },
+                    "start": {
+                        "line": 1,
+                        "column": 7
+                    }
+                },
+                "kind": "type",
+                "declarations": [
+                    {
+                        "type": "VariableDeclarator",
+                        "range": [
+                            12,
+                            51
+                        ],
+                        "loc": {
+                            "end": {
+                                "line": 3,
+                                "column": 2
+                            },
+                            "start": {
+                                "line": 1,
+                                "column": 12
+                            }
+                        },
+                        "id": {
+                            "type": "Identifier",
+                            "range": [
+                                12,
+                                26
+                            ],
+                            "loc": {
+                                "end": {
+                                    "line": 1,
+                                    "column": 26
+                                },
+                                "start": {
+                                    "line": 1,
+                                    "column": 12
+                                }
+                            },
+                            "name": "TestClassProps"
+                        },
+                        "init": {
+                            "type": "TSTypeLiteral",
+                            "range": [
+                                29,
+                                50
+                            ],
+                            "loc": {
+                                "end": {
+                                    "line": 3,
+                                    "column": 1
+                                },
+                                "start": {
+                                    "line": 1,
+                                    "column": 29
+                                }
+                            },
+                            "members": [
+                                {
+                                    "type": "TSPropertySignature",
+                                    "range": [
+                                        35,
+                                        48
+                                    ],
+                                    "loc": {
+                                        "end": {
+                                            "line": 2,
+                                            "column": 17
+                                        },
+                                        "start": {
+                                            "line": 2,
+                                            "column": 4
+                                        }
+                                    },
+                                    "name": {
+                                        "type": "Identifier",
+                                        "range": [
+                                            35,
+                                            40
+                                        ],
+                                        "loc": {
+                                            "end": {
+                                                "line": 2,
+                                                "column": 9
+                                            },
+                                            "start": {
+                                                "line": 2,
+                                                "column": 4
+                                            }
+                                        },
+                                        "name": "count"
+                                    },
+                                    "typeAnnotation": {
+                                        "type": "TypeAnnotation",
+                                        "range": [
+                                            42,
+                                            48
+                                        ],
+                                        "loc": {
+                                            "end": {
+                                                "line": 2,
+                                                "column": 17
+                                            },
+                                            "start": {
+                                                "line": 2,
+                                                "column": 11
+                                            }
+                                        },
+                                        "typeAnnotation": {
+                                            "type": "TSNumberKeyword",
+                                            "range": [
+                                                42,
+                                                48
+                                            ],
+                                            "loc": {
+                                                "end": {
+                                                    "line": 2,
+                                                    "column": 17
+                                                },
+                                                "start": {
+                                                    "line": 2,
+                                                    "column": 11
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "source": null,
+            "specifiers": []
+        }
+    ],
+    "sourceType": "module",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "range": [
+                0,
+                6
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 6
+                },
+                "start": {
+                    "line": 1,
+                    "column": 0
+                }
+            },
+            "value": "export"
+        },
+        {
+            "type": "Identifier",
+            "range": [
+                7,
+                11
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 11
+                },
+                "start": {
+                    "line": 1,
+                    "column": 7
+                }
+            },
+            "value": "type"
+        },
+        {
+            "type": "Identifier",
+            "range": [
+                12,
+                26
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 26
+                },
+                "start": {
+                    "line": 1,
+                    "column": 12
+                }
+            },
+            "value": "TestClassProps"
+        },
+        {
+            "type": "Punctuator",
+            "range": [
+                27,
+                28
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 28
+                },
+                "start": {
+                    "line": 1,
+                    "column": 27
+                }
+            },
+            "value": "="
+        },
+        {
+            "type": "Punctuator",
+            "range": [
+                29,
+                30
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 30
+                },
+                "start": {
+                    "line": 1,
+                    "column": 29
+                }
+            },
+            "value": "{"
+        },
+        {
+            "type": "Identifier",
+            "range": [
+                35,
+                40
+            ],
+            "loc": {
+                "end": {
+                    "line": 2,
+                    "column": 9
+                },
+                "start": {
+                    "line": 2,
+                    "column": 4
+                }
+            },
+            "value": "count"
+        },
+        {
+            "type": "Punctuator",
+            "range": [
+                40,
+                41
+            ],
+            "loc": {
+                "end": {
+                    "line": 2,
+                    "column": 10
+                },
+                "start": {
+                    "line": 2,
+                    "column": 9
+                }
+            },
+            "value": ":"
+        },
+        {
+            "type": "Identifier",
+            "range": [
+                42,
+                48
+            ],
+            "loc": {
+                "end": {
+                    "line": 2,
+                    "column": 17
+                },
+                "start": {
+                    "line": 2,
+                    "column": 11
+                }
+            },
+            "value": "number"
+        },
+        {
+            "type": "Punctuator",
+            "range": [
+                49,
+                50
+            ],
+            "loc": {
+                "end": {
+                    "line": 3,
+                    "column": 1
+                },
+                "start": {
+                    "line": 3,
+                    "column": 0
+                }
+            },
+            "value": "}"
+        },
+        {
+            "type": "Punctuator",
+            "range": [
+                50,
+                51
+            ],
+            "loc": {
+                "end": {
+                    "line": 3,
+                    "column": 2
+                },
+                "start": {
+                    "line": 3,
+                    "column": 1
+                }
+            },
+            "value": ";"
+        }
+    ]
+};

--- a/tests/fixtures/typescript/basics/export-type-class-declaration.src.ts
+++ b/tests/fixtures/typescript/basics/export-type-class-declaration.src.ts
@@ -1,0 +1,3 @@
+export type TestClassProps = {
+    count: number
+};

--- a/tests/fixtures/typescript/basics/export-type-function-declaration.result.js
+++ b/tests/fixtures/typescript/basics/export-type-function-declaration.result.js
@@ -1,0 +1,417 @@
+module.exports = {
+    "type": "Program",
+    "range": [
+        0,
+        47
+    ],
+    "loc": {
+        "end": {
+            "line": 1,
+            "column": 47
+        },
+        "start": {
+            "line": 1,
+            "column": 0
+        }
+    },
+    "body": [
+        {
+            "type": "ExportNamedDeclaration",
+            "range": [
+                0,
+                47
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 47
+                },
+                "start": {
+                    "line": 1,
+                    "column": 0
+                }
+            },
+            "declaration": {
+                "type": "VariableDeclaration",
+                "range": [
+                    7,
+                    47
+                ],
+                "loc": {
+                    "end": {
+                        "line": 1,
+                        "column": 47
+                    },
+                    "start": {
+                        "line": 1,
+                        "column": 7
+                    }
+                },
+                "kind": "type",
+                "declarations": [
+                    {
+                        "type": "VariableDeclarator",
+                        "range": [
+                            12,
+                            47
+                        ],
+                        "loc": {
+                            "end": {
+                                "line": 1,
+                                "column": 47
+                            },
+                            "start": {
+                                "line": 1,
+                                "column": 12
+                            }
+                        },
+                        "id": {
+                            "type": "Identifier",
+                            "range": [
+                                12,
+                                24
+                            ],
+                            "loc": {
+                                "end": {
+                                    "line": 1,
+                                    "column": 24
+                                },
+                                "start": {
+                                    "line": 1,
+                                    "column": 12
+                                }
+                            },
+                            "name": "TestCallback"
+                        },
+                        "init": {
+                            "type": "TSFunctionType",
+                            "range": [
+                                27,
+                                46
+                            ],
+                            "loc": {
+                                "end": {
+                                    "line": 1,
+                                    "column": 46
+                                },
+                                "start": {
+                                    "line": 1,
+                                    "column": 27
+                                }
+                            },
+                            "parameters": [
+                                {
+                                    "type": "Identifier",
+                                    "range": [
+                                        28,
+                                        29
+                                    ],
+                                    "loc": {
+                                        "end": {
+                                            "line": 1,
+                                            "column": 29
+                                        },
+                                        "start": {
+                                            "line": 1,
+                                            "column": 28
+                                        }
+                                    },
+                                    "name": "a",
+                                    "typeAnnotation": {
+                                        "type": "TypeAnnotation",
+                                        "range": [
+                                            31,
+                                            37
+                                        ],
+                                        "loc": {
+                                            "end": {
+                                                "line": 1,
+                                                "column": 37
+                                            },
+                                            "start": {
+                                                "line": 1,
+                                                "column": 31
+                                            }
+                                        },
+                                        "typeAnnotation": {
+                                            "type": "TSNumberKeyword",
+                                            "range": [
+                                                31,
+                                                37
+                                            ],
+                                            "loc": {
+                                                "end": {
+                                                    "line": 1,
+                                                    "column": 37
+                                                },
+                                                "start": {
+                                                    "line": 1,
+                                                    "column": 31
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "typeAnnotation": {
+                                "type": "TypeAnnotation",
+                                "range": [
+                                    42,
+                                    46
+                                ],
+                                "loc": {
+                                    "end": {
+                                        "line": 1,
+                                        "column": 46
+                                    },
+                                    "start": {
+                                        "line": 1,
+                                        "column": 42
+                                    }
+                                },
+                                "typeAnnotation": {
+                                    "type": "TSVoidKeyword",
+                                    "range": [
+                                        42,
+                                        46
+                                    ],
+                                    "loc": {
+                                        "end": {
+                                            "line": 1,
+                                            "column": 46
+                                        },
+                                        "start": {
+                                            "line": 1,
+                                            "column": 42
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
+            "source": null,
+            "specifiers": []
+        }
+    ],
+    "sourceType": "module",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "range": [
+                0,
+                6
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 6
+                },
+                "start": {
+                    "line": 1,
+                    "column": 0
+                }
+            },
+            "value": "export"
+        },
+        {
+            "type": "Identifier",
+            "range": [
+                7,
+                11
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 11
+                },
+                "start": {
+                    "line": 1,
+                    "column": 7
+                }
+            },
+            "value": "type"
+        },
+        {
+            "type": "Identifier",
+            "range": [
+                12,
+                24
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 24
+                },
+                "start": {
+                    "line": 1,
+                    "column": 12
+                }
+            },
+            "value": "TestCallback"
+        },
+        {
+            "type": "Punctuator",
+            "range": [
+                25,
+                26
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 26
+                },
+                "start": {
+                    "line": 1,
+                    "column": 25
+                }
+            },
+            "value": "="
+        },
+        {
+            "type": "Punctuator",
+            "range": [
+                27,
+                28
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 28
+                },
+                "start": {
+                    "line": 1,
+                    "column": 27
+                }
+            },
+            "value": "("
+        },
+        {
+            "type": "Identifier",
+            "range": [
+                28,
+                29
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 29
+                },
+                "start": {
+                    "line": 1,
+                    "column": 28
+                }
+            },
+            "value": "a"
+        },
+        {
+            "type": "Punctuator",
+            "range": [
+                29,
+                30
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 30
+                },
+                "start": {
+                    "line": 1,
+                    "column": 29
+                }
+            },
+            "value": ":"
+        },
+        {
+            "type": "Identifier",
+            "range": [
+                31,
+                37
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 37
+                },
+                "start": {
+                    "line": 1,
+                    "column": 31
+                }
+            },
+            "value": "number"
+        },
+        {
+            "type": "Punctuator",
+            "range": [
+                37,
+                38
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 38
+                },
+                "start": {
+                    "line": 1,
+                    "column": 37
+                }
+            },
+            "value": ")"
+        },
+        {
+            "type": "Punctuator",
+            "range": [
+                39,
+                41
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 41
+                },
+                "start": {
+                    "line": 1,
+                    "column": 39
+                }
+            },
+            "value": "=>"
+        },
+        {
+            "type": "Keyword",
+            "range": [
+                42,
+                46
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 46
+                },
+                "start": {
+                    "line": 1,
+                    "column": 42
+                }
+            },
+            "value": "void"
+        },
+        {
+            "type": "Punctuator",
+            "range": [
+                46,
+                47
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 47
+                },
+                "start": {
+                    "line": 1,
+                    "column": 46
+                }
+            },
+            "value": ";"
+        }
+    ]
+};

--- a/tests/fixtures/typescript/basics/export-type-function-declaration.src.ts
+++ b/tests/fixtures/typescript/basics/export-type-function-declaration.src.ts
@@ -1,0 +1,1 @@
+export type TestCallback = (a: number) => void;


### PR DESCRIPTION
This includes:
- Fix to ast-converter, addition of fixExports function call in SyntaxKind.TypeAliasDeclaration case statement.
- Corresponding tests