### PR TITLE
Fix async function and variable declartions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+v1.0.1 - January 4, 2017
+
+* 9882a8e Fix: Add missing async property (#133) (James Henry)
+* 60843ad Fix: Handle async/await (fixes #119) (#129) (Philipp A)
+* 0ff19dd Fix: Exception thrown when space occurs after function name (fixes #123) (#124) (Reyad Attiyat)
+* ff283aa Fix: Allow running without options (fixes #121) (#120) (Philipp A)
+* dd03b2f Docs: Changed --save to --save-dev in readme (#132) (Amila Welihinda)
+* 41ccef5 Build: Add TS as dev-dep, only support minor range (#131) (James Henry)
+
 v1.0.0 - November 11, 2016
 
 * c60f216 Chore: Normalize .yml line endings (fixes #113) (#115) (James Henry)

--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -1058,7 +1058,7 @@ module.exports = function(ast, extra) {
                         generator: false,
                         expression: false,
                         body: convertChild(node.body),
-                        range: [ node.name.end, result.range[1]],
+                        range: [ node.parameters.pos - 1, result.range[1]],
                         loc: {
                             start: {
                                 line: methodLoc.line + 1,

--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -899,8 +899,10 @@ module.exports = function(ast, extra) {
 
                 var varStatementKind;
 
-                if (node.declarationList.flags) {
-                    varStatementKind = (node.declarationList.flags === ts.NodeFlags.Let) ? "let" : "const";
+                if (ts.isLet(node.declarationList)) {
+                    varStatementKind = "let";
+                } else if (ts.isConst(node.declarationList)) {
+                    varStatementKind = "const";
                 } else {
                     varStatementKind = "var";
                 }

--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -106,6 +106,17 @@ function isESTreeClassMember(node) {
 }
 
 /**
+ * Returns true if the given node is an async function
+ * @param  {TSNode}  node TypeScript AST node
+ * @returns {boolean}     is an async function
+ */
+function isAsyncFunction(node) {
+    return !!node.modifiers && !!node.modifiers.length && node.modifiers.some(function(modifier) {
+        return modifier.kind === SyntaxKind.AsyncKeyword;
+    });
+}
+
+/**
  * Returns true if the given TSToken is a comma
  * @param  {TSToken}  token the TypeScript token
  * @returns {boolean}       is comma
@@ -852,6 +863,7 @@ module.exports = function(ast, extra) {
                     id: convertChild(node.name),
                     generator: !!node.asteriskToken,
                     expression: false,
+                    async: isAsyncFunction(node),
                     params: node.parameters.map(convertChild),
                     body: convertChild(node.body)
                 });
@@ -1057,6 +1069,7 @@ module.exports = function(ast, extra) {
                         id: null,
                         generator: false,
                         expression: false,
+                        async: isAsyncFunction(node),
                         body: convertChild(node.body),
                         range: [ node.parameters.pos - 1, result.range[1]],
                         loc: {
@@ -1158,6 +1171,7 @@ module.exports = function(ast, extra) {
                         }),
                         generator: false,
                         expression: false,
+                        async: false,
                         body: convertChild(node.body),
                         range: [ result.range[0] + constructorStartOffset, result.range[1]],
                         loc: {
@@ -1226,6 +1240,7 @@ module.exports = function(ast, extra) {
                     generator: !!node.asteriskToken,
                     params: node.parameters.map(convertChild),
                     body: convertChild(node.body),
+                    async: isAsyncFunction(node),
                     expression: false
                 });
                 // Process returnType
@@ -1308,6 +1323,7 @@ module.exports = function(ast, extra) {
                     id: null,
                     params: node.parameters.map(convertChild),
                     body: convertChild(node.body),
+                    async: isAsyncFunction(node),
                     expression: node.body.kind !== SyntaxKind.Block
                 });
                 // Process returnType
@@ -1325,6 +1341,13 @@ module.exports = function(ast, extra) {
                     type: "YieldExpression",
                     delegate: !!node.asteriskToken,
                     argument: convertChild(node.expression)
+                });
+                break;
+
+            case SyntaxKind.AwaitExpression:
+                assign(result, {
+                    type: "AwaitExpression",
+                    expression: convertChild(node.expression)
                 });
                 break;
 

--- a/lib/ast-node-types.js
+++ b/lib/ast-node-types.js
@@ -23,6 +23,7 @@ module.exports = {
     ArrayExpression: "ArrayExpression",
     ArrayPattern: "ArrayPattern",
     ArrowFunctionExpression: "ArrowFunctionExpression",
+    AwaitExpression: "AwaitExpression",
     BlockStatement: "BlockStatement",
     BinaryExpression: "BinaryExpression",
     BreakStatement: "BreakStatement",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Nicholas C. Zakas <nicholas+npm@nczconsulting.com>",
   "homepage": "https://github.com/eslint/typescript-eslint-parser",
   "main": "parser.js",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "files": [
     "lib",
     "parser.js"

--- a/tests/fixtures/attach-comments/export-default-anonymous-class.result.js
+++ b/tests/fixtures/attach-comments/export-default-anonymous-class.result.js
@@ -56,6 +56,7 @@ module.exports = {
                                 },
                                 "generator": false,
                                 "expression": false,
+                                "async": false,
                                 "range": [
                                     110,
                                     119

--- a/tests/fixtures/attach-comments/surrounding-call-comments.result.js
+++ b/tests/fixtures/attach-comments/surrounding-call-comments.result.js
@@ -123,6 +123,7 @@ module.exports = {
                 ]
             },
             "expression": false,
+            "async": false,
             "generator": false
         }
     ],

--- a/tests/fixtures/attach-comments/surrounding-debugger-comments.result.js
+++ b/tests/fixtures/attach-comments/surrounding-debugger-comments.result.js
@@ -87,6 +87,7 @@ module.exports = {
                 ]
             },
             "expression": false,
+            "async": false,
             "generator": false
         }
     ],

--- a/tests/fixtures/attach-comments/surrounding-return-comments.result.js
+++ b/tests/fixtures/attach-comments/surrounding-return-comments.result.js
@@ -88,6 +88,7 @@ module.exports = {
                 ]
             },
             "expression": false,
+            "async": false,
             "generator": false
         }
     ],

--- a/tests/fixtures/attach-comments/surrounding-throw-comments.result.js
+++ b/tests/fixtures/attach-comments/surrounding-throw-comments.result.js
@@ -106,6 +106,7 @@ module.exports = {
                 ]
             },
             "expression": false,
+            "async": false,
             "generator": false
         }
     ],

--- a/tests/fixtures/attach-comments/surrounding-while-loop-comments.result.js
+++ b/tests/fixtures/attach-comments/surrounding-while-loop-comments.result.js
@@ -51,6 +51,7 @@ module.exports = {
             },
             "generator": false,
             "expression": false,
+            "async": false,
             "params": [],
             "body": {
                 "type": "BlockStatement",

--- a/tests/fixtures/attach-comments/switch-fallthrough-comment-in-function.result.js
+++ b/tests/fixtures/attach-comments/switch-fallthrough-comment-in-function.result.js
@@ -254,6 +254,7 @@ module.exports = {
                 ]
             },
             "expression": false,
+            "async": false,
             "generator": false
         }
     ],

--- a/tests/fixtures/attach-comments/switch-no-default-comment-in-function.result.js
+++ b/tests/fixtures/attach-comments/switch-no-default-comment-in-function.result.js
@@ -238,6 +238,7 @@ module.exports = {
                 ]
             },
             "expression": false,
+            "async": false,
             "generator": false
         }
     ],

--- a/tests/fixtures/attach-comments/switch-no-default-comment-in-nested-functions.result.js
+++ b/tests/fixtures/attach-comments/switch-no-default-comment-in-nested-functions.result.js
@@ -630,11 +630,13 @@ module.exports = {
                                     ]
                                 },
                                 "expression": false,
+                                "async": false,
                                 "generator": false
                             }
                         ]
                     },
                     "expression": false,
+                    "async": false,
                     "generator": false
                 }
             }

--- a/tests/fixtures/basics/new-without-parens.result.js
+++ b/tests/fixtures/basics/new-without-parens.result.js
@@ -51,6 +51,7 @@ module.exports = {
             },
             "generator": false,
             "expression": false,
+            "async": false,
             "params": [],
             "body": {
                 "type": "BlockStatement",

--- a/tests/fixtures/basics/update-expression.result.js
+++ b/tests/fixtures/basics/update-expression.result.js
@@ -148,8 +148,9 @@ module.exports = {
                 ],
                 "type": "BlockStatement"
             },
-            "expression": false,
             "generator": false,
+            "expression": false,
+            "async": false,
             "id": {
                 "loc": {
                     "end": {

--- a/tests/fixtures/ecma-features-mix/classes-and-generators/classes-and-generators.result.js
+++ b/tests/fixtures/ecma-features-mix/classes-and-generators/classes-and-generators.result.js
@@ -70,6 +70,7 @@ module.exports = {
                             },
                             "generator": true,
                             "expression": false,
+                            "async": false,
                             "range": [
                                 17,
                                 24

--- a/tests/fixtures/ecma-features-mix/classes-and-generators/computed-generator.result.js
+++ b/tests/fixtures/ecma-features-mix/classes-and-generators/computed-generator.result.js
@@ -106,6 +106,7 @@ module.exports = {
                             },
                             "generator": true,
                             "expression": false,
+                            "async": false,
                             "range": [
                                 31,
                                 38

--- a/tests/fixtures/ecma-features-mix/classes-and-generators/static-generators.result.js
+++ b/tests/fixtures/ecma-features-mix/classes-and-generators/static-generators.result.js
@@ -70,6 +70,7 @@ module.exports = {
                             },
                             "generator": true,
                             "expression": false,
+                            "async": false,
                             "range": [
                                 24,
                                 31

--- a/tests/fixtures/ecma-features-mix/defaultParams-and-arrowFunctions/default-param-arrow.result.js
+++ b/tests/fixtures/ecma-features-mix/defaultParams-and-arrowFunctions/default-param-arrow.result.js
@@ -88,6 +88,7 @@ module.exports = {
                             },
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "range": [
                                 6,
                                 13
@@ -139,6 +140,7 @@ module.exports = {
                 },
                 "generator": false,
                 "expression": false,
+                "async": false,
                 "range": [
                     0,
                     20

--- a/tests/fixtures/ecma-features-mix/defaultParams-and-arrowFunctions/default-param.result.js
+++ b/tests/fixtures/ecma-features-mix/defaultParams-and-arrowFunctions/default-param.result.js
@@ -118,6 +118,7 @@ module.exports = {
                 },
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "range": [
                     0,
                     14

--- a/tests/fixtures/ecma-features-mix/defaultParams-and-arrowFunctions/local-eval-multi.result.js
+++ b/tests/fixtures/ecma-features-mix/defaultParams-and-arrowFunctions/local-eval-multi.result.js
@@ -101,6 +101,7 @@ module.exports = {
                 },
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "range": [
                     0,
                     20

--- a/tests/fixtures/ecma-features-mix/defaultParams-and-arrowFunctions/local-eval.result.js
+++ b/tests/fixtures/ecma-features-mix/defaultParams-and-arrowFunctions/local-eval.result.js
@@ -83,6 +83,7 @@ module.exports = {
                 },
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "range": [
                     0,
                     17

--- a/tests/fixtures/ecma-features-mix/defaultParams-and-arrowFunctions/yield-default-param.result.js
+++ b/tests/fixtures/ecma-features-mix/defaultParams-and-arrowFunctions/yield-default-param.result.js
@@ -105,6 +105,7 @@ module.exports = {
                             },
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "range": [
                                 16,
                                 33
@@ -153,6 +154,7 @@ module.exports = {
             },
             "generator": true,
             "expression": false,
+            "async": false,
             "range": [
                 0,
                 35

--- a/tests/fixtures/ecma-features-mix/destructuring-and-arrowFunctions/arrow-param-array.result.js
+++ b/tests/fixtures/ecma-features-mix/destructuring-and-arrowFunctions/arrow-param-array.result.js
@@ -65,6 +65,7 @@ module.exports = {
                 },
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "range": [
                     0,
                     10

--- a/tests/fixtures/ecma-features-mix/destructuring-and-arrowFunctions/arrow-param-nested-array.result.js
+++ b/tests/fixtures/ecma-features-mix/destructuring-and-arrowFunctions/arrow-param-nested-array.result.js
@@ -102,6 +102,7 @@ module.exports = {
                 },
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "range": [
                     0,
                     15

--- a/tests/fixtures/ecma-features-mix/destructuring-and-arrowFunctions/arrow-param-nested-object-named.result.js
+++ b/tests/fixtures/ecma-features-mix/destructuring-and-arrowFunctions/arrow-param-nested-object-named.result.js
@@ -219,6 +219,7 @@ module.exports = {
                 },
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "range": [
                     0,
                     27

--- a/tests/fixtures/ecma-features-mix/destructuring-and-arrowFunctions/arrow-param-nested-object.result.js
+++ b/tests/fixtures/ecma-features-mix/destructuring-and-arrowFunctions/arrow-param-nested-object.result.js
@@ -219,6 +219,7 @@ module.exports = {
                 },
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "range": [
                     0,
                     17

--- a/tests/fixtures/ecma-features-mix/destructuring-and-arrowFunctions/arrow-param-object.result.js
+++ b/tests/fixtures/ecma-features-mix/destructuring-and-arrowFunctions/arrow-param-object.result.js
@@ -104,6 +104,7 @@ module.exports = {
                 },
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "range": [
                     0,
                     10

--- a/tests/fixtures/ecma-features-mix/destructuring-and-arrowFunctions/param-defaults-array.result.js
+++ b/tests/fixtures/ecma-features-mix/destructuring-and-arrowFunctions/param-defaults-array.result.js
@@ -101,6 +101,7 @@ module.exports = {
                 },
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "range": [
                     0,
                     15

--- a/tests/fixtures/ecma-features-mix/destructuring-and-arrowFunctions/param-defaults-object-nested.result.js
+++ b/tests/fixtures/ecma-features-mix/destructuring-and-arrowFunctions/param-defaults-object-nested.result.js
@@ -328,6 +328,7 @@ module.exports = {
                 },
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "range": [
                     0,
                     35

--- a/tests/fixtures/ecma-features-mix/destructuring-and-arrowFunctions/param-defaults-object.result.js
+++ b/tests/fixtures/ecma-features-mix/destructuring-and-arrowFunctions/param-defaults-object.result.js
@@ -140,6 +140,7 @@ module.exports = {
                 },
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "range": [
                     0,
                     15

--- a/tests/fixtures/ecma-features-mix/destructuring-and-defaultParams/param-array.result.js
+++ b/tests/fixtures/ecma-features-mix/destructuring-and-defaultParams/param-array.result.js
@@ -135,6 +135,7 @@ module.exports = {
             },
             "generator": false,
             "expression": false,
+            "async": false,
             "range": [
                 0,
                 24

--- a/tests/fixtures/ecma-features-mix/destructuring-and-defaultParams/param-object-short.result.js
+++ b/tests/fixtures/ecma-features-mix/destructuring-and-defaultParams/param-object-short.result.js
@@ -221,6 +221,7 @@ module.exports = {
                             },
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "range": [
                                 3,
                                 21

--- a/tests/fixtures/ecma-features-mix/destructuring-and-defaultParams/param-object-wrapped.result.js
+++ b/tests/fixtures/ecma-features-mix/destructuring-and-defaultParams/param-object-wrapped.result.js
@@ -108,6 +108,7 @@ module.exports = {
                         rest: null,
                         generator: false,
                         expression: false,
+                        async: false,
                         range: [5, 31],
                         loc: {
                             start: { line: 1, column: 5 },

--- a/tests/fixtures/ecma-features-mix/destructuring-and-defaultParams/param-object.result.js
+++ b/tests/fixtures/ecma-features-mix/destructuring-and-defaultParams/param-object.result.js
@@ -219,6 +219,7 @@ module.exports = {
                     },
                     "generator": false,
                     "expression": false,
+                    "async": false,
                     "range": [
                         4,
                         30

--- a/tests/fixtures/ecma-features-mix/destructuring-and-spread/destructuring-param.result.js
+++ b/tests/fixtures/ecma-features-mix/destructuring-and-spread/destructuring-param.result.js
@@ -152,6 +152,7 @@ module.exports = {
       },
       "generator": false,
       "expression": false,
+      "async": false,
       "range": [
         0,
         30

--- a/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-defaultParams/default-params.result.js
+++ b/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-defaultParams/default-params.result.js
@@ -162,6 +162,7 @@ module.exports = {
                                     },
                                     "generator": false,
                                     "expression": false,
+                                    "async": false,
                                     "range": [
                                         29,
                                         40
@@ -313,6 +314,7 @@ module.exports = {
                                     },
                                     "generator": false,
                                     "expression": false,
+                                    "async": false,
                                     "range": [
                                         46,
                                         60
@@ -482,6 +484,7 @@ module.exports = {
                                     },
                                     "generator": false,
                                     "expression": false,
+                                    "async": false,
                                     "range": [
                                         68,
                                         85

--- a/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-destructuring/array-destructuring.result.js
+++ b/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-destructuring/array-destructuring.result.js
@@ -106,6 +106,7 @@ module.exports = {
                             },
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "range": [
                                 4,
                                 16

--- a/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-generators/generator-object-literal-method.result.js
+++ b/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-generators/generator-object-literal-method.result.js
@@ -125,6 +125,7 @@ module.exports = {
                                     },
                                     "generator": true,
                                     "expression": false,
+                                    "async": false,
                                     "range": [
                                         16,
                                         31

--- a/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-objectLiteralComputedProperties/computed-method-property.result.js
+++ b/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-objectLiteralComputedProperties/computed-method-property.result.js
@@ -107,6 +107,7 @@ module.exports = {
                                     },
                                     "generator": false,
                                     "expression": false,
+                                    "async": false,
                                     "range": [
                                         19,
                                         49

--- a/tests/fixtures/ecma-features-mix/restParams-and-arrowFunctions/arrow-rest-multi.result.js
+++ b/tests/fixtures/ecma-features-mix/restParams-and-arrowFunctions/arrow-rest-multi.result.js
@@ -81,6 +81,7 @@ module.exports = {
                 },
                 "generator": false,
                 "expression": false,
+                "async": false,
                 "range": [
                     0,
                     15

--- a/tests/fixtures/ecma-features-mix/restParams-and-arrowFunctions/arrow-rest.result.js
+++ b/tests/fixtures/ecma-features-mix/restParams-and-arrowFunctions/arrow-rest.result.js
@@ -63,6 +63,7 @@ module.exports = {
                 },
                 "generator": false,
                 "expression": false,
+                "async": false,
                 "range": [
                     0,
                     12

--- a/tests/fixtures/ecma-features-mix/restParams-and-arrowFunctions/destructured-arrow-array.result.js
+++ b/tests/fixtures/ecma-features-mix/restParams-and-arrowFunctions/destructured-arrow-array.result.js
@@ -139,6 +139,7 @@ module.exports = {
                 },
                 "generator": false,
                 "expression": false,
+                "async": false,
                 "range": [
                     0,
                     19

--- a/tests/fixtures/ecma-features-mix/restParams-and-arrowFunctions/destructured-arrow-multi.result.js
+++ b/tests/fixtures/ecma-features-mix/restParams-and-arrowFunctions/destructured-arrow-multi.result.js
@@ -251,6 +251,7 @@ module.exports = {
                 },
                 "generator": false,
                 "expression": false,
+                "async": false,
                 "range": [
                     0,
                     33

--- a/tests/fixtures/ecma-features-mix/restParams-and-arrowFunctions/destructured-arrow-object.result.js
+++ b/tests/fixtures/ecma-features-mix/restParams-and-arrowFunctions/destructured-arrow-object.result.js
@@ -176,6 +176,7 @@ module.exports = {
                 },
                 "generator": false,
                 "expression": false,
+                "async": false,
                 "range": [
                     0,
                     27

--- a/tests/fixtures/ecma-features-mix/templateStrings-and-jsx/template-strings-in-jsx-complex.result.js
+++ b/tests/fixtures/ecma-features-mix/templateStrings-and-jsx/template-strings-in-jsx-complex.result.js
@@ -931,6 +931,7 @@ module.exports = {
                                             },
                                             "generator": false,
                                             "expression": false,
+                                            "async": false,
                                             "range": [
                                                 86,
                                                 257

--- a/tests/fixtures/ecma-features/arrowFunctions/as-param-with-params.result.js
+++ b/tests/fixtures/ecma-features/arrowFunctions/as-param-with-params.result.js
@@ -85,6 +85,7 @@ module.exports = {
                         "id": null,
                         "generator": false,
                         "expression": false,
+                        "async": false,
                         "params": [
                             {
                                 "type": "Identifier",

--- a/tests/fixtures/ecma-features/arrowFunctions/as-param.result.js
+++ b/tests/fixtures/ecma-features/arrowFunctions/as-param.result.js
@@ -85,6 +85,7 @@ module.exports = {
                         "id": null,
                         "generator": false,
                         "expression": false,
+                        "async": false,
                         "params": [],
                         "body": {
                             "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/arrowFunctions/basic.result.js
+++ b/tests/fixtures/ecma-features/arrowFunctions/basic.result.js
@@ -50,6 +50,7 @@ module.exports = {
                 "id": null,
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "params": [],
                 "body": {
                     "type": "Literal",

--- a/tests/fixtures/ecma-features/arrowFunctions/block-body-not-object.result.js
+++ b/tests/fixtures/ecma-features/arrowFunctions/block-body-not-object.result.js
@@ -50,6 +50,7 @@ module.exports = {
                 "id": null,
                 "generator": false,
                 "expression": false,
+                "async": false,
                 "params": [
                     {
                         "type": "Identifier",

--- a/tests/fixtures/ecma-features/arrowFunctions/block-body.result.js
+++ b/tests/fixtures/ecma-features/arrowFunctions/block-body.result.js
@@ -50,6 +50,7 @@ module.exports = {
                 "id": null,
                 "generator": false,
                 "expression": false,
+                "async": false,
                 "params": [
                     {
                         "type": "Identifier",

--- a/tests/fixtures/ecma-features/arrowFunctions/expression.result.js
+++ b/tests/fixtures/ecma-features/arrowFunctions/expression.result.js
@@ -50,6 +50,7 @@ module.exports = {
                 "id": null,
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "params": [
                     {
                         "type": "Identifier",

--- a/tests/fixtures/ecma-features/arrowFunctions/iife.result.js
+++ b/tests/fixtures/ecma-features/arrowFunctions/iife.result.js
@@ -50,6 +50,7 @@ module.exports = {
                 "id": null,
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "params": [
                     {
                         "type": "Identifier",

--- a/tests/fixtures/ecma-features/arrowFunctions/multiple-params.result.js
+++ b/tests/fixtures/ecma-features/arrowFunctions/multiple-params.result.js
@@ -50,6 +50,7 @@ module.exports = {
                 "id": null,
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "params": [
                     {
                         "type": "Identifier",

--- a/tests/fixtures/ecma-features/arrowFunctions/no-auto-return.result.js
+++ b/tests/fixtures/ecma-features/arrowFunctions/no-auto-return.result.js
@@ -50,6 +50,7 @@ module.exports = {
                 "id": null,
                 "generator": false,
                 "expression": false,
+                "async": false,
                 "params": [
                     {
                         "type": "Identifier",

--- a/tests/fixtures/ecma-features/arrowFunctions/not-strict-arguments.result.js
+++ b/tests/fixtures/ecma-features/arrowFunctions/not-strict-arguments.result.js
@@ -50,6 +50,7 @@ module.exports = {
                 "id": null,
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "params": [
                     {
                         "type": "Identifier",

--- a/tests/fixtures/ecma-features/arrowFunctions/not-strict-eval-params.result.js
+++ b/tests/fixtures/ecma-features/arrowFunctions/not-strict-eval-params.result.js
@@ -50,6 +50,7 @@ module.exports = {
                 "id": null,
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "params": [
                     {
                         "type": "Identifier",

--- a/tests/fixtures/ecma-features/arrowFunctions/not-strict-eval.result.js
+++ b/tests/fixtures/ecma-features/arrowFunctions/not-strict-eval.result.js
@@ -50,6 +50,7 @@ module.exports = {
                 "id": null,
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "params": [
                     {
                         "type": "Identifier",

--- a/tests/fixtures/ecma-features/arrowFunctions/not-strict-octal.result.js
+++ b/tests/fixtures/ecma-features/arrowFunctions/not-strict-octal.result.js
@@ -50,6 +50,7 @@ module.exports = {
                 "id": null,
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "params": [
                     {
                         "type": "Identifier",

--- a/tests/fixtures/ecma-features/arrowFunctions/return-arrow-function.result.js
+++ b/tests/fixtures/ecma-features/arrowFunctions/return-arrow-function.result.js
@@ -50,6 +50,7 @@ module.exports = {
                 "id": null,
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "params": [
                     {
                         "type": "Identifier",
@@ -89,6 +90,7 @@ module.exports = {
                     "id": null,
                     "generator": false,
                     "expression": true,
+                    "async": false,
                     "params": [
                         {
                             "type": "Identifier",

--- a/tests/fixtures/ecma-features/arrowFunctions/return-sequence.result.js
+++ b/tests/fixtures/ecma-features/arrowFunctions/return-sequence.result.js
@@ -50,6 +50,7 @@ module.exports = {
                 "id": null,
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "params": [
                     {
                         "type": "Identifier",
@@ -89,6 +90,7 @@ module.exports = {
                     "id": null,
                     "generator": false,
                     "expression": true,
+                    "async": false,
                     "params": [
                         {
                             "type": "Identifier",

--- a/tests/fixtures/ecma-features/arrowFunctions/single-param-parens.result.js
+++ b/tests/fixtures/ecma-features/arrowFunctions/single-param-parens.result.js
@@ -50,6 +50,7 @@ module.exports = {
                 "id": null,
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "params": [
                     {
                         "type": "Identifier",

--- a/tests/fixtures/ecma-features/arrowFunctions/single-param-return-identifier.result.js
+++ b/tests/fixtures/ecma-features/arrowFunctions/single-param-return-identifier.result.js
@@ -50,6 +50,7 @@ module.exports = {
                 "id": null,
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "params": [
                     {
                         "type": "Identifier",

--- a/tests/fixtures/ecma-features/arrowFunctions/single-param.result.js
+++ b/tests/fixtures/ecma-features/arrowFunctions/single-param.result.js
@@ -50,6 +50,7 @@ module.exports = {
                 "id": null,
                 "generator": false,
                 "expression": true,
+                "async": false,
                 "params": [
                     {
                         "type": "Identifier",

--- a/tests/fixtures/ecma-features/classes/class-accessor-properties.result.js
+++ b/tests/fixtures/ecma-features/classes/class-accessor-properties.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [
@@ -170,6 +171,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/ecma-features/classes/class-computed-static-method.result.js
+++ b/tests/fixtures/ecma-features/classes/class-computed-static-method.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/ecma-features/classes/class-method-named-prototype.result.js
+++ b/tests/fixtures/ecma-features/classes/class-method-named-prototype.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/ecma-features/classes/class-method-named-static.result.js
+++ b/tests/fixtures/ecma-features/classes/class-method-named-static.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/ecma-features/classes/class-method-named-with-space.result.js
+++ b/tests/fixtures/ecma-features/classes/class-method-named-with-space.result.js
@@ -1,0 +1,320 @@
+module.exports = {
+    "type": "Program",
+    "range": [
+        0,
+        25
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 25
+        }
+    },
+    "body": [
+        {
+            "type": "ClassDeclaration",
+            "range": [
+                0,
+                25
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 25
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    6,
+                    7
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 7
+                    }
+                },
+                "name": "A"
+            },
+            "body": {
+                "type": "ClassBody",
+                "body": [
+                    {
+                        "type": "MethodDefinition",
+                        "range": [
+                            9,
+                            24
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 9
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 24
+                            }
+                        },
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                9,
+                                18
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 9
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 18
+                                }
+                            },
+                            "name": "withSpace"
+                        },
+                        "value": {
+                            "type": "FunctionExpression",
+                            "id": null,
+                            "generator": false,
+                            "expression": false,
+                            "body": {
+                                "type": "BlockStatement",
+                                "range": [
+                                    22,
+                                    24
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 22
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 24
+                                    }
+                                },
+                                "body": []
+                            },
+                            "range": [
+                                19,
+                                24
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 18
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 24
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": false,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": []
+                    }
+                ],
+                "range": [
+                    8,
+                    25
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 25
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "class",
+            "range": [
+                0,
+                5
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "A",
+            "range": [
+                6,
+                7
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 6
+                },
+                "end": {
+                    "line": 1,
+                    "column": 7
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                8,
+                9
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 8
+                },
+                "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "withSpace",
+            "range": [
+                9,
+                18
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                19,
+                20
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 19
+                },
+                "end": {
+                    "line": 1,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                20,
+                21
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 20
+                },
+                "end": {
+                    "line": 1,
+                    "column": 21
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                22,
+                23
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 22
+                },
+                "end": {
+                    "line": 1,
+                    "column": 23
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                23,
+                24
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 23
+                },
+                "end": {
+                    "line": 1,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                24,
+                25
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 24
+                },
+                "end": {
+                    "line": 1,
+                    "column": 25
+                }
+            }
+        }
+    ]
+};

--- a/tests/fixtures/ecma-features/classes/class-method-named-with-space.result.js
+++ b/tests/fixtures/ecma-features/classes/class-method-named-with-space.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/ecma-features/classes/class-method-named-with-space.src.js
+++ b/tests/fixtures/ecma-features/classes/class-method-named-with-space.src.js
@@ -1,0 +1,1 @@
+class A {withSpace () {}}

--- a/tests/fixtures/ecma-features/classes/class-one-method-super.result.js
+++ b/tests/fixtures/ecma-features/classes/class-one-method-super.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/ecma-features/classes/class-one-method.result.js
+++ b/tests/fixtures/ecma-features/classes/class-one-method.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/ecma-features/classes/class-static-method-named-prototype.result.js
+++ b/tests/fixtures/ecma-features/classes/class-static-method-named-prototype.result.js
@@ -92,6 +92,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/ecma-features/classes/class-static-method-named-static.result.js
+++ b/tests/fixtures/ecma-features/classes/class-static-method-named-static.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/ecma-features/classes/class-static-method.result.js
+++ b/tests/fixtures/ecma-features/classes/class-static-method.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/ecma-features/classes/class-static-methods-and-accessor-properties.result.js
+++ b/tests/fixtures/ecma-features/classes/class-static-methods-and-accessor-properties.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [
@@ -170,6 +171,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [
@@ -249,6 +251,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/ecma-features/classes/class-two-computed-static-methods.result.js
+++ b/tests/fixtures/ecma-features/classes/class-two-computed-static-methods.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [
@@ -170,6 +171,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/ecma-features/classes/class-two-methods-computed-constructor.result.js
+++ b/tests/fixtures/ecma-features/classes/class-two-methods-computed-constructor.result.js
@@ -92,6 +92,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [
@@ -172,6 +173,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/ecma-features/classes/class-two-methods-semi.result.js
+++ b/tests/fixtures/ecma-features/classes/class-two-methods-semi.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [
@@ -170,6 +171,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/ecma-features/classes/class-two-methods-three-semi.result.js
+++ b/tests/fixtures/ecma-features/classes/class-two-methods-three-semi.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [
@@ -170,6 +171,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/ecma-features/classes/class-two-methods-two-semi.result.js
+++ b/tests/fixtures/ecma-features/classes/class-two-methods-two-semi.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [
@@ -170,6 +171,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/ecma-features/classes/class-two-methods.result.js
+++ b/tests/fixtures/ecma-features/classes/class-two-methods.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [
@@ -170,6 +171,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/ecma-features/classes/class-two-static-methods-named-constructor.result.js
+++ b/tests/fixtures/ecma-features/classes/class-two-static-methods-named-constructor.result.js
@@ -126,6 +126,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "params": [],
                             "body": {
                                 "type": "BlockStatement",
@@ -204,6 +205,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "params": [],
                             "body": {
                                 "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/classes/class-with-constructor.result.js
+++ b/tests/fixtures/ecma-features/classes/class-with-constructor.result.js
@@ -126,6 +126,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "params": [],
                             "body": {
                                 "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/defaultParams/declaration.result.js
+++ b/tests/fixtures/ecma-features/defaultParams/declaration.result.js
@@ -51,6 +51,7 @@ module.exports = {
             },
             "generator": false,
             "expression": false,
+            "async": false,
             "params": [
                 {
                     "type": "AssignmentPattern",

--- a/tests/fixtures/ecma-features/defaultParams/expression.result.js
+++ b/tests/fixtures/ecma-features/defaultParams/expression.result.js
@@ -85,6 +85,7 @@ module.exports = {
                     "id": null,
                     "generator": false,
                     "expression": false,
+                    "async": false,
                     "params": [
                         {
                             "type": "AssignmentPattern",

--- a/tests/fixtures/ecma-features/defaultParams/method.result.js
+++ b/tests/fixtures/ecma-features/defaultParams/method.result.js
@@ -139,6 +139,7 @@ module.exports = {
                                 "id": null,
                                 "generator": false,
                                 "expression": false,
+                                "async": false,
                                 "params": [
                                     {
                                         "type": "AssignmentPattern",

--- a/tests/fixtures/ecma-features/defaultParams/not-all-params.result.js
+++ b/tests/fixtures/ecma-features/defaultParams/not-all-params.result.js
@@ -85,6 +85,7 @@ module.exports = {
                         "id": null,
                         "generator": false,
                         "expression": false,
+                        "async": false,
                         "params": [
                             {
                                 "type": "Identifier",

--- a/tests/fixtures/ecma-features/destructuring/destructured-array-catch.result.js
+++ b/tests/fixtures/ecma-features/destructuring/destructured-array-catch.result.js
@@ -51,6 +51,7 @@ module.exports = {
             },
             "generator": false,
             "expression": false,
+            "async": false,
             "params": [
                 {
                     "type": "ObjectPattern",

--- a/tests/fixtures/ecma-features/destructuring/destructured-object-catch.result.js
+++ b/tests/fixtures/ecma-features/destructuring/destructured-object-catch.result.js
@@ -51,6 +51,7 @@ module.exports = {
             },
             "generator": false,
             "expression": false,
+            "async": false,
             "params": [
                 {
                     "type": "ObjectPattern",

--- a/tests/fixtures/ecma-features/destructuring/param-defaults-array.result.js
+++ b/tests/fixtures/ecma-features/destructuring/param-defaults-array.result.js
@@ -51,6 +51,7 @@ module.exports = {
             },
             "generator": false,
             "expression": false,
+            "async": false,
             "params": [
                 {
                     "type": "ArrayPattern",

--- a/tests/fixtures/ecma-features/destructuring/param-defaults-object-nested.result.js
+++ b/tests/fixtures/ecma-features/destructuring/param-defaults-object-nested.result.js
@@ -51,6 +51,7 @@ module.exports = {
             },
             "generator": false,
             "expression": false,
+            "async": false,
             "params": [
                 {
                     "type": "ObjectPattern",

--- a/tests/fixtures/ecma-features/destructuring/param-defaults-object.result.js
+++ b/tests/fixtures/ecma-features/destructuring/param-defaults-object.result.js
@@ -51,6 +51,7 @@ module.exports = {
             },
             "generator": false,
             "expression": false,
+            "async": false,
             "params": [
                 {
                     "type": "ObjectPattern",

--- a/tests/fixtures/ecma-features/destructuring/params-array-wrapped.result.js
+++ b/tests/fixtures/ecma-features/destructuring/params-array-wrapped.result.js
@@ -67,6 +67,7 @@ module.exports = {
                 },
                 "generator": false,
                 "expression": false,
+                "async": false,
                 "params": [
                     {
                         "type": "ArrayPattern",

--- a/tests/fixtures/ecma-features/destructuring/params-array.result.js
+++ b/tests/fixtures/ecma-features/destructuring/params-array.result.js
@@ -51,6 +51,7 @@ module.exports = {
             },
             "generator": false,
             "expression": false,
+            "async": false,
             "params": [
                 {
                     "type": "ArrayPattern",

--- a/tests/fixtures/ecma-features/destructuring/params-multi-object.result.js
+++ b/tests/fixtures/ecma-features/destructuring/params-multi-object.result.js
@@ -51,6 +51,7 @@ module.exports = {
             },
             "generator": false,
             "expression": false,
+            "async": false,
             "params": [
                 {
                     "type": "Identifier",

--- a/tests/fixtures/ecma-features/destructuring/params-nested-array.result.js
+++ b/tests/fixtures/ecma-features/destructuring/params-nested-array.result.js
@@ -51,6 +51,7 @@ module.exports = {
             },
             "generator": false,
             "expression": false,
+            "async": false,
             "params": [
                 {
                     "type": "ArrayPattern",

--- a/tests/fixtures/ecma-features/destructuring/params-nested-object.result.js
+++ b/tests/fixtures/ecma-features/destructuring/params-nested-object.result.js
@@ -51,6 +51,7 @@ module.exports = {
             },
             "generator": false,
             "expression": false,
+            "async": false,
             "params": [
                 {
                     "type": "ObjectPattern",

--- a/tests/fixtures/ecma-features/destructuring/params-object-wrapped.result.js
+++ b/tests/fixtures/ecma-features/destructuring/params-object-wrapped.result.js
@@ -67,6 +67,7 @@ module.exports = {
                 },
                 "generator": false,
                 "expression": false,
+                "async": false,
                 "params": [
                     {
                         "type": "ObjectPattern",

--- a/tests/fixtures/ecma-features/destructuring/params-object.result.js
+++ b/tests/fixtures/ecma-features/destructuring/params-object.result.js
@@ -51,6 +51,7 @@ module.exports = {
             },
             "generator": false,
             "expression": false,
+            "async": false,
             "params": [
                 {
                     "type": "ObjectPattern",

--- a/tests/fixtures/ecma-features/forOf/for-of-with-function-initializer.result.js
+++ b/tests/fixtures/ecma-features/forOf/for-of-with-function-initializer.result.js
@@ -101,6 +101,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "params": [],
                             "body": {
                                 "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/generators/anonymous-generator.result.js
+++ b/tests/fixtures/ecma-features/generators/anonymous-generator.result.js
@@ -50,6 +50,7 @@ module.exports = {
                 "id": null,
                 "generator": true,
                 "expression": false,
+                "async": false,
                 "params": [],
                 "body": {
                     "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/generators/double-yield.result.js
+++ b/tests/fixtures/ecma-features/generators/double-yield.result.js
@@ -50,6 +50,7 @@ module.exports = {
                 "id": null,
                 "generator": true,
                 "expression": false,
+                "async": false,
                 "params": [],
                 "body": {
                     "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/generators/empty-generator-declaration.result.js
+++ b/tests/fixtures/ecma-features/generators/empty-generator-declaration.result.js
@@ -51,6 +51,7 @@ module.exports = {
             },
             "generator": true,
             "expression": false,
+            "async": false,
             "params": [],
             "body": {
                 "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/generators/generator-declaration.result.js
+++ b/tests/fixtures/ecma-features/generators/generator-declaration.result.js
@@ -51,6 +51,7 @@ module.exports = {
             },
             "generator": true,
             "expression": false,
+            "async": false,
             "params": [],
             "body": {
                 "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/generators/yield-delegation.result.js
+++ b/tests/fixtures/ecma-features/generators/yield-delegation.result.js
@@ -50,6 +50,7 @@ module.exports = {
                 "id": null,
                 "generator": true,
                 "expression": false,
+                "async": false,
                 "params": [],
                 "body": {
                     "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/generators/yield-without-value-in-call.result.js
+++ b/tests/fixtures/ecma-features/generators/yield-without-value-in-call.result.js
@@ -50,6 +50,7 @@ module.exports = {
                 "id": null,
                 "generator": true,
                 "expression": false,
+                "async": false,
                 "params": [],
                 "body": {
                     "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/generators/yield-without-value-no-semi.result.js
+++ b/tests/fixtures/ecma-features/generators/yield-without-value-no-semi.result.js
@@ -50,6 +50,7 @@ module.exports = {
                 "id": null,
                 "generator": true,
                 "expression": false,
+                "async": false,
                 "params": [],
                 "body": {
                     "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/generators/yield-without-value.result.js
+++ b/tests/fixtures/ecma-features/generators/yield-without-value.result.js
@@ -50,6 +50,7 @@ module.exports = {
                 "id": null,
                 "generator": true,
                 "expression": false,
+                "async": false,
                 "params": [],
                 "body": {
                     "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/modules/export-default-function.result.js
+++ b/tests/fixtures/ecma-features/modules/export-default-function.result.js
@@ -50,6 +50,7 @@ module.exports = {
                 "id": null,
                 "generator": false,
                 "expression": false,
+                "async": false,
                 "params": [],
                 "body": {
                     "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/modules/export-default-named-function.result.js
+++ b/tests/fixtures/ecma-features/modules/export-default-named-function.result.js
@@ -67,6 +67,7 @@ module.exports = {
                 },
                 "generator": false,
                 "expression": false,
+                "async": false,
                 "params": [],
                 "body": {
                     "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/modules/export-function.result.js
+++ b/tests/fixtures/ecma-features/modules/export-function.result.js
@@ -67,6 +67,7 @@ module.exports = {
                 },
                 "generator": false,
                 "expression": false,
+                "async": false,
                 "params": [],
                 "body": {
                     "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/modules/export-var-anonymous-function.result.js
+++ b/tests/fixtures/ecma-features/modules/export-var-anonymous-function.result.js
@@ -101,6 +101,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "params": [],
                             "body": {
                                 "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/newTarget/simple-new-target.result.js
+++ b/tests/fixtures/ecma-features/newTarget/simple-new-target.result.js
@@ -51,6 +51,7 @@ module.exports = {
             },
             "generator": false,
             "expression": false,
+            "async": false,
             "params": [],
             "body": {
                 "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/objectLiteralComputedProperties/computed-getter-and-setter.result.js
+++ b/tests/fixtures/ecma-features/objectLiteralComputedProperties/computed-getter-and-setter.result.js
@@ -105,6 +105,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "params": [],
                             "body": {
                                 "type": "BlockStatement",
@@ -183,6 +184,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "params": [
                                 {
                                     "type": "Identifier",

--- a/tests/fixtures/ecma-features/objectLiteralComputedProperties/standalone-expression-with-method.result.js
+++ b/tests/fixtures/ecma-features/objectLiteralComputedProperties/standalone-expression-with-method.result.js
@@ -104,6 +104,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "params": [],
                             "body": {
                                 "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/objectLiteralShorthandMethods/method-property.result.js
+++ b/tests/fixtures/ecma-features/objectLiteralShorthandMethods/method-property.result.js
@@ -140,6 +140,7 @@ module.exports = {
                                     "id": null,
                                     "generator": false,
                                     "expression": false,
+                                    "async": false,
                                     "params": [],
                                     "body": {
                                         "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/objectLiteralShorthandMethods/simple-method-named-get.result.js
+++ b/tests/fixtures/ecma-features/objectLiteralShorthandMethods/simple-method-named-get.result.js
@@ -140,6 +140,7 @@ module.exports = {
                                 "id": null,
                                 "generator": false,
                                 "expression": false,
+                                "async": false,
                                 "params": [],
                                 "body": {
                                     "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/objectLiteralShorthandMethods/simple-method-named-set.result.js
+++ b/tests/fixtures/ecma-features/objectLiteralShorthandMethods/simple-method-named-set.result.js
@@ -140,6 +140,7 @@ module.exports = {
                                 "id": null,
                                 "generator": false,
                                 "expression": false,
+                                "async": false,
                                 "params": [],
                                 "body": {
                                     "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/objectLiteralShorthandMethods/simple-method-with-argument.result.js
+++ b/tests/fixtures/ecma-features/objectLiteralShorthandMethods/simple-method-with-argument.result.js
@@ -140,6 +140,7 @@ module.exports = {
                                 "id": null,
                                 "generator": false,
                                 "expression": false,
+                                "async": false,
                                 "params": [
                                     {
                                         "type": "Identifier",

--- a/tests/fixtures/ecma-features/objectLiteralShorthandMethods/simple-method-with-string-name.result.js
+++ b/tests/fixtures/ecma-features/objectLiteralShorthandMethods/simple-method-with-string-name.result.js
@@ -141,6 +141,7 @@ module.exports = {
                                 "id": null,
                                 "generator": false,
                                 "expression": false,
+                                "async": false,
                                 "params": [],
                                 "body": {
                                     "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/objectLiteralShorthandMethods/simple-method.result.js
+++ b/tests/fixtures/ecma-features/objectLiteralShorthandMethods/simple-method.result.js
@@ -140,6 +140,7 @@ module.exports = {
                                 "id": null,
                                 "generator": false,
                                 "expression": false,
+                                "async": false,
                                 "params": [],
                                 "body": {
                                     "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/objectLiteralShorthandMethods/string-name-method-property.result.js
+++ b/tests/fixtures/ecma-features/objectLiteralShorthandMethods/string-name-method-property.result.js
@@ -141,6 +141,7 @@ module.exports = {
                                     "id": null,
                                     "generator": false,
                                     "expression": false,
+                                    "async": false,
                                     "params": [],
                                     "body": {
                                         "type": "BlockStatement",

--- a/tests/fixtures/ecma-features/restParams/basic-rest.result.js
+++ b/tests/fixtures/ecma-features/restParams/basic-rest.result.js
@@ -51,6 +51,7 @@ module.exports = {
             },
             "generator": false,
             "expression": false,
+            "async": false,
             "params": [
                 {
                     "type": "Identifier",

--- a/tests/fixtures/ecma-features/restParams/func-expression-multi.result.js
+++ b/tests/fixtures/ecma-features/restParams/func-expression-multi.result.js
@@ -85,6 +85,7 @@ module.exports = {
                         "id": null,
                         "generator": false,
                         "expression": false,
+                        "async": false,
                         "params": [
                             {
                                 "type": "Identifier",

--- a/tests/fixtures/ecma-features/restParams/func-expression.result.js
+++ b/tests/fixtures/ecma-features/restParams/func-expression.result.js
@@ -85,6 +85,7 @@ module.exports = {
                         "id": null,
                         "generator": false,
                         "expression": false,
+                        "async": false,
                         "params": [
                             {
                                 "type": "RestElement",

--- a/tests/fixtures/ecma-features/restParams/single-rest.result.js
+++ b/tests/fixtures/ecma-features/restParams/single-rest.result.js
@@ -51,6 +51,7 @@ module.exports = {
             },
             "generator": false,
             "expression": false,
+            "async": false,
             "params": [
                 {
                     "type": "RestElement",

--- a/tests/fixtures/ecma-features/templateStrings/tagged-template-string.result.js
+++ b/tests/fixtures/ecma-features/templateStrings/tagged-template-string.result.js
@@ -51,6 +51,7 @@ module.exports = {
             },
             "generator": false,
             "expression": false,
+            "async": false,
             "params": [],
             "body": {
                 "type": "BlockStatement",

--- a/tests/fixtures/typescript/basics/abstract-class-with-abstract-method.result.js
+++ b/tests/fixtures/typescript/basics/abstract-class-with-abstract-method.result.js
@@ -93,6 +93,7 @@ module.exports = {
                                 "id": null,
                                 "generator": false,
                                 "expression": false,
+                                "async": false,
                                 "body": null,
                                 "range": [
                                     64,

--- a/tests/fixtures/typescript/basics/arrow-function-with-type-parameters.result.js
+++ b/tests/fixtures/typescript/basics/arrow-function-with-type-parameters.result.js
@@ -176,6 +176,7 @@ module.exports = {
                     ]
                 },
                 "expression": false,
+                "async": false,
                 "returnType": {
                     "type": "TypeAnnotation",
                     "loc": {

--- a/tests/fixtures/typescript/basics/class-with-accessibility-modifiers.result.js
+++ b/tests/fixtures/typescript/basics/class-with-accessibility-modifiers.result.js
@@ -261,7 +261,7 @@ module.exports = {
                                 ]
                             },
                             "range": [
-                                81,
+                                82,
                                 111
                             ],
                             "loc": {
@@ -447,7 +447,7 @@ module.exports = {
                                 ]
                             },
                             "range": [
-                                130,
+                                131,
                                 171
                             ],
                             "loc": {

--- a/tests/fixtures/typescript/basics/class-with-accessibility-modifiers.result.js
+++ b/tests/fixtures/typescript/basics/class-with-accessibility-modifiers.result.js
@@ -171,6 +171,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [
@@ -321,6 +322,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/typescript/basics/declare-function.result.js
+++ b/tests/fixtures/typescript/basics/declare-function.result.js
@@ -51,6 +51,7 @@ module.exports = {
             },
             "generator": false,
             "expression": false,
+            "async": false,
             "params": [
                 {
                     "type": "Identifier",

--- a/tests/fixtures/typescript/basics/function-with-await.result.js
+++ b/tests/fixtures/typescript/basics/function-with-await.result.js
@@ -1,0 +1,349 @@
+module.exports = {
+    "type": "Program",
+    "body": [
+        {
+            "type": "FunctionDeclaration",
+            "expression": false,
+            "generator": false,
+            "async": true,
+            "id": {
+                "type": "Identifier",
+                "name": "hope",
+                "loc": {
+                    "end": {
+                        "column": 19,
+                        "line": 1
+                    },
+                    "start": {
+                        "column": 15,
+                        "line": 1
+                    }
+                },
+                "range": [
+                    15,
+                    19
+                ]
+            },
+            "params": [
+                {
+                    "loc": {
+                        "end": {
+                            "column": 26,
+                            "line": 1
+                        },
+                        "start": {
+                            "column": 20,
+                            "line": 1
+                        }
+                    },
+                    "name": "future",
+                    "range": [
+                        20,
+                        26
+                    ],
+                    "type": "Identifier"
+                }
+            ],
+            "body": {
+                "type": "BlockStatement",
+                "body": [
+                    {
+                        "type": "ExpressionStatement",
+                        "expression": {
+                            "type": "AwaitExpression",
+                            "expression": {
+                                "type": "Identifier",
+                                "loc": {
+                                    "end": {
+                                        "column": 16,
+                                        "line": 2
+                                    },
+                                    "start": {
+                                        "column": 10,
+                                        "line": 2
+                                    }
+                                },
+                                "name": "future",
+                                "range": [
+                                    40,
+                                    46
+                                ]
+                            },
+                            "loc": {
+                                "end": {
+                                    "column": 16,
+                                    "line": 2
+                                },
+                                "start": {
+                                    "column": 4,
+                                    "line": 2
+                                }
+                            },
+                            "range": [
+                                34,
+                                46
+                            ]
+                        },
+                        "loc": {
+                            "end": {
+                                "column": 17,
+                                "line": 2
+                            },
+                            "start": {
+                                "column": 4,
+                                "line": 2
+                            }
+                        },
+                        "range": [
+                            34,
+                            47
+                        ]
+                    }
+                ],
+                "loc": {
+                    "end": {
+                        "column": 1,
+                        "line": 3
+                    },
+                    "start": {
+                        "column": 28,
+                        "line": 1
+                    }
+                },
+                "range": [
+                    28,
+                    49
+                ]
+            },
+            "loc": {
+                "end": {
+                    "column": 1,
+                    "line": 3
+                },
+                "start": {
+                    "column": 0,
+                    "line": 1
+                }
+            },
+            "range": [
+                0,
+                49
+            ]
+        }
+    ],
+    "loc": {
+        "end": {
+            "column": 1,
+            "line": 3
+        },
+        "start": {
+            "column": 0,
+            "line": 1
+        }
+    },
+    "range": [
+        0,
+        49
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Identifier",
+            "value": "async",
+            "loc": {
+                "end": {
+                    "column": 5,
+                    "line": 1
+                },
+                "start": {
+                    "column": 0,
+                    "line": 1
+                }
+            },
+            "range": [
+                0,
+                5
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "function",
+            "loc": {
+                "end": {
+                    "column": 14,
+                    "line": 1
+                },
+                "start": {
+                    "column": 6,
+                    "line": 1
+                }
+            },
+            "range": [
+                6,
+                14
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "hope",
+            "loc": {
+                "end": {
+                    "column": 19,
+                    "line": 1
+                },
+                "start": {
+                    "column": 15,
+                    "line": 1
+                }
+            },
+            "range": [
+                15,
+                19
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "end": {
+                    "column": 20,
+                    "line": 1
+                },
+                "start": {
+                    "column": 19,
+                    "line": 1
+                }
+            },
+            "range": [
+                19,
+                20
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "future",
+            "loc": {
+                "end": {
+                    "column": 26,
+                    "line": 1
+                },
+                "start": {
+                    "column": 20,
+                    "line": 1
+                }
+            },
+            "range": [
+                20,
+                26
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "end": {
+                    "column": 27,
+                    "line": 1
+                },
+                "start": {
+                    "column": 26,
+                    "line": 1
+                }
+            },
+            "range": [
+                26,
+                27
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "end": {
+                    "column": 29,
+                    "line": 1
+                },
+                "start": {
+                    "column": 28,
+                    "line": 1
+                }
+            },
+            "range": [
+                28,
+                29
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "await",
+            "loc": {
+                "end": {
+                    "column": 9,
+                    "line": 2
+                },
+                "start": {
+                    "column": 4,
+                    "line": 2
+                }
+            },
+            "range": [
+                34,
+                39
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "future",
+            "loc": {
+                "end": {
+                    "column": 16,
+                    "line": 2
+                },
+                "start": {
+                    "column": 10,
+                    "line": 2
+                }
+            },
+            "range": [
+                40,
+                46
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "end": {
+                    "column": 17,
+                    "line": 2
+                },
+                "start": {
+                    "column": 16,
+                    "line": 2
+                }
+            },
+            "range": [
+                46,
+                47
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "end": {
+                    "column": 1,
+                    "line": 3
+                },
+                "start": {
+                    "column": 0,
+                    "line": 3
+                }
+            },
+            "range": [
+                48,
+                49
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/typescript/basics/function-with-await.src.ts
+++ b/tests/fixtures/typescript/basics/function-with-await.src.ts
@@ -1,0 +1,3 @@
+async function hope(future) {
+    await future;
+}

--- a/tests/fixtures/typescript/basics/function-with-type-parameters.result.js
+++ b/tests/fixtures/typescript/basics/function-with-type-parameters.result.js
@@ -51,6 +51,7 @@ module.exports = {
             },
             "generator": false,
             "expression": false,
+            "async": false,
             "params": [
                 {
                     "type": "Identifier",

--- a/tests/fixtures/typescript/basics/function-with-types.result.js
+++ b/tests/fixtures/typescript/basics/function-with-types.result.js
@@ -51,6 +51,7 @@ module.exports = {
             },
             "generator": false,
             "expression": false,
+            "async": false,
             "params": [
                 {
                     "type": "Identifier",

--- a/tests/fixtures/typescript/basics/non-null-assertion-operator.result.js
+++ b/tests/fixtures/typescript/basics/non-null-assertion-operator.result.js
@@ -51,6 +51,7 @@ module.exports = {
             },
             "generator": false,
             "expression": false,
+            "async": false,
             "params": [
                 {
                     "type": "Identifier",

--- a/tests/fixtures/typescript/decorators/accessor-decorators/accessor-decorator-factory-instance-member.result.js
+++ b/tests/fixtures/typescript/decorators/accessor-decorators/accessor-decorator-factory-instance-member.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/typescript/decorators/accessor-decorators/accessor-decorator-factory-static-member.result.js
+++ b/tests/fixtures/typescript/decorators/accessor-decorators/accessor-decorator-factory-static-member.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/typescript/decorators/accessor-decorators/accessor-decorator-instance-member.result.js
+++ b/tests/fixtures/typescript/decorators/accessor-decorators/accessor-decorator-instance-member.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/typescript/decorators/accessor-decorators/accessor-decorator-static-member.result.js
+++ b/tests/fixtures/typescript/decorators/accessor-decorators/accessor-decorator-static-member.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/typescript/decorators/method-decorators/method-decorator-factory-instance-member.result.js
+++ b/tests/fixtures/typescript/decorators/method-decorators/method-decorator-factory-instance-member.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/typescript/decorators/method-decorators/method-decorator-factory-static-member.result.js
+++ b/tests/fixtures/typescript/decorators/method-decorators/method-decorator-factory-static-member.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/typescript/decorators/method-decorators/method-decorator-instance-member.result.js
+++ b/tests/fixtures/typescript/decorators/method-decorators/method-decorator-instance-member.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/typescript/decorators/method-decorators/method-decorator-static-member.result.js
+++ b/tests/fixtures/typescript/decorators/method-decorators/method-decorator-static-member.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-constructor.result.js
+++ b/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-constructor.result.js
@@ -220,6 +220,7 @@ module.exports = {
                             ],
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-decorator-instance-member.result.js
+++ b/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-decorator-instance-member.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-decorator-static-member.result.js
+++ b/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-decorator-static-member.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-instance-member.result.js
+++ b/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-instance-member.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-static-member.result.js
+++ b/tests/fixtures/typescript/decorators/parameter-decorators/parameter-decorator-static-member.result.js
@@ -91,6 +91,7 @@ module.exports = {
                             "id": null,
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "body": {
                                 "type": "BlockStatement",
                                 "range": [

--- a/tests/fixtures/typescript/namespaces-and-modules/declare-namespace-with-exported-function.result.js
+++ b/tests/fixtures/typescript/namespaces-and-modules/declare-namespace-with-exported-function.result.js
@@ -123,6 +123,7 @@ module.exports = {
                             },
                             "generator": false,
                             "expression": false,
+                            "async": false,
                             "params": [
                                 {
                                     "type": "Identifier",


### PR DESCRIPTION
Async functions mark all variables as constants since the flags are not being read correctly. This patch uses the builtin typescript utilities functions to determine the variable declaration type.

Some tests are broken and I will need to add tests for this new case. Just looking for feedback.