### PR TITLE
Fix: Create body for abstract methods (fixes #80)

### DIFF
--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -1134,6 +1134,9 @@ module.exports = function(ast, extra) {
                         });
                         if (isAbstractMethod) {
                             methodDefinitionType = "TSAbstractMethodDefinition";
+                            method.body = {
+                                type: "AbstractStatement"
+                            };
                         }
                     }
 


### PR DESCRIPTION
An attempt to fix the abstract class method exception by creating a body with the type of 'AbstractStatement'. Still need to add tests.

@JamesHenry What are your thoughts?