### PR TITLE
Fix: Create body for multiple call signatures (fixes #92)

### DIFF
--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -1095,6 +1095,12 @@ module.exports = function(ast, extra) {
                     method.returnType = convertTypeAnnotation(node.type);
                 }
 
+                if (!method.body) {
+                    method.body = {
+                        type: "EmptyFunctionStatement"
+                    };
+                }
+
                 if (parent.kind === SyntaxKind.ObjectLiteralExpression) {
 
                     method.params = node.parameters.map(convertChild);


### PR DESCRIPTION
An attempt to fix the multiple call signatures exception by creating a body with the type of 'EmptyFunctionStatement'. Still need to add tests.

@JamesHenry What are your thoughts?