### PR TITLE
Fix: Optimize convertTokens, treat JsxText as token (fixes #70)

### DIFF
--- a/tests/lib/ecma-features.js
+++ b/tests/lib/ecma-features.js
@@ -28,7 +28,6 @@ var filesWithOutsandingTSIssues = [
     "jsx/embedded-tags", // https://github.com/Microsoft/TypeScript/issues/7410
     "jsx/namespaced-attribute-and-value-inserted", // https://github.com/Microsoft/TypeScript/issues/7411
     "jsx/namespaced-name-and-attribute", // https://github.com/Microsoft/TypeScript/issues/7411
-    "jsx/test-content", // https://github.com/Microsoft/TypeScript/issues/7471
     "jsx/multiple-blank-spaces"
 ];
 


### PR DESCRIPTION
**UPDATE**: I was able to use this PR to work around the long-standing issue with JsxText nodes outlined in #70 

The test case: `jsx/test-content` has been enabled.

------------

Based on feedback from the TypeScript team here: https://github.com/Microsoft/TypeScript/issues/13519#issuecomment-274662665

I will be looking into refactoring remaining occurrences of `ts.findNextToken` in future too