### PR TITLE
Fix: Await node should have argument property (fixes #160)

### DIFF
--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -1355,7 +1355,7 @@ module.exports = function(ast, extra) {
             case SyntaxKind.AwaitExpression:
                 assign(result, {
                     type: "AwaitExpression",
-                    expression: convertChild(node.expression)
+                    argument: convertChild(node.expression)
                 });
                 break;
 

--- a/tests/fixtures/typescript/basics/function-with-await.result.js
+++ b/tests/fixtures/typescript/basics/function-with-await.result.js
@@ -51,7 +51,7 @@ module.exports = {
                         "type": "ExpressionStatement",
                         "expression": {
                             "type": "AwaitExpression",
-                            "expression": {
+                            "argument": {
                                 "type": "Identifier",
                                 "loc": {
                                     "end": {


### PR DESCRIPTION
The await node should have an argument property instead
of an expression property to be a valid estree node.

https://github.com/estree/estree/blob/master/es2017.md