### PR TITLE
Fix: Label abstract function expression nodes (fixes #80)

### DIFF
--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -868,7 +868,6 @@ module.exports = function(ast, extra) {
             // Declarations
 
             case SyntaxKind.FunctionDeclaration:
-
                 var functionDeclarationType = "FunctionDeclaration";
                 if (node.modifiers && node.modifiers.length) {
                     var isDeclareFunction = node.modifiers.some(function(modifier) {
@@ -1134,6 +1133,7 @@ module.exports = function(ast, extra) {
                         });
                         if (isAbstractMethod) {
                             methodDefinitionType = "TSAbstractMethodDefinition";
+                            method.type = "TSAbstractFunctionExpression";
                         }
                     }
 

--- a/tests/fixtures/typescript/basics/abstract-class-with-abstract-method.result.js
+++ b/tests/fixtures/typescript/basics/abstract-class-with-abstract-method.result.js
@@ -89,7 +89,7 @@ module.exports = {
                                 "name": "createSocket"
                             },
                             "value": {
-                                "type": "FunctionExpression",
+                                "type": "TSAbstractFunctionExpression",
                                 "id": null,
                                 "generator": false,
                                 "expression": false,


### PR DESCRIPTION
In newer versions of TypeScript the FunctionExpression node contains a null body when they are abstract methods. This will cause some rules to fail as they expect FunctionExpression to have a body and is defined that way in the ESTree spec.