### PR TITLE
Fix: Add start and end propert to tokens (fixes #172)

### DIFF
--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -410,6 +410,8 @@ function convertToken(token, ast) {
         newToken = {
             type: getTokenType(token),
             value: value,
+            start: start,
+            end: token.end,
             range: [start, token.end],
             loc: getLoc(token, ast)
         };

--- a/tests/lib/attach-comments.js
+++ b/tests/lib/attach-comments.js
@@ -34,7 +34,8 @@ var assert = require("chai").assert,
     leche = require("leche"),
     path = require("path"),
     parser = require("../../parser"),
-    shelljs = require("shelljs");
+    shelljs = require("shelljs"),
+    tester = require("./tester");
 
 //------------------------------------------------------------------------------
 // Setup
@@ -47,15 +48,6 @@ var testFiles = shelljs.find(FIXTURES_DIR).filter(function(filename) {
 }).map(function(filename) {
     return filename.substring(FIXTURES_DIR.length - 1, filename.length - 7);  // strip off ".src.js"
 });
-
-/**
- * Returns a raw copy of the given AST
- * @param  {object} ast the AST object
- * @returns {object}     copy of the AST object
- */
-function getRaw(ast) {
-    return JSON.parse(JSON.stringify(ast));
-}
 
 //------------------------------------------------------------------------------
 // Tests
@@ -84,7 +76,7 @@ describe("attachComment: true", function() {
 
             try {
                 result = parser.parse(code, config);
-                result = getRaw(result);
+                result = tester.getRaw(result);
             } catch (ex) {
 
                 // format of error isn't exactly the same, just check if it's expected

--- a/tests/lib/basics.js
+++ b/tests/lib/basics.js
@@ -15,7 +15,8 @@ var assert = require("chai").assert,
     leche = require("leche"),
     path = require("path"),
     parser = require("../../parser"),
-    shelljs = require("shelljs");
+    shelljs = require("shelljs"),
+    tester = require("./tester");
 
 //------------------------------------------------------------------------------
 // Setup
@@ -28,15 +29,6 @@ var testFiles = shelljs.find(FIXTURES_DIR).filter(function(filename) {
 }).map(function(filename) {
     return filename.substring(FIXTURES_DIR.length - 1, filename.length - 7);  // strip off ".src.js"
 });
-
-/**
- * Returns a raw copy of the given AST
- * @param  {object} ast the AST object
- * @returns {object}     copy of the AST object
- */
-function getRaw(ast) {
-    return JSON.parse(JSON.stringify(ast));
-}
 
 //------------------------------------------------------------------------------
 // Tests
@@ -66,7 +58,7 @@ describe("basics", function() {
 
             try {
                 result = parser.parse(code, config);
-                result = getRaw(result);
+                result = tester.getRaw(result);
             } catch (ex) {
 
                 // format of error isn't exactly the same, just check if it's expected

--- a/tests/lib/ecma-features.js
+++ b/tests/lib/ecma-features.js
@@ -15,7 +15,8 @@ var assert = require("chai").assert,
     leche = require("leche"),
     path = require("path"),
     parser = require("../../parser"),
-    shelljs = require("shelljs");
+    shelljs = require("shelljs"),
+    tester = require("./tester");
 
 //------------------------------------------------------------------------------
 // Setup
@@ -58,15 +59,6 @@ var testFiles = shelljs.find(FIXTURES_DIR).filter(function(filename) {
 // console.dir(moduleTestFiles);
 // return;
 
-/**
- * Returns a raw copy of the given AST
- * @param  {object} ast the AST object
- * @returns {object}     copy of the AST object
- */
-function getRaw(ast) {
-    return JSON.parse(JSON.stringify(ast));
-}
-
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
@@ -97,7 +89,7 @@ describe("ecmaFeatures", function() {
 
             try {
                 result = parser.parse(code, config);
-                result = getRaw(result);
+                result = tester.getRaw(result);
             } catch (ex) {
 
                 // format of error isn't exactly the same, just check if it's expected

--- a/tests/lib/parse.js
+++ b/tests/lib/parse.js
@@ -12,20 +12,8 @@
 //------------------------------------------------------------------------------
 
 var assert = require("chai").assert,
-    parser = require("../../parser");
-
-//------------------------------------------------------------------------------
-// Helpers
-//------------------------------------------------------------------------------
-
-/**
- * Returns a raw copy of the given AST
- * @param  {object} ast the AST object
- * @returns {object}     copy of the AST object
- */
-function getRaw(ast) {
-    return JSON.parse(JSON.stringify(ast));
-}
+    parser = require("../../parser"),
+    tester = require("./tester");
 
 //------------------------------------------------------------------------------
 // Tests
@@ -68,7 +56,7 @@ describe("parse()", function() {
                 loc: true
             });
 
-            assert.deepEqual(getRaw(ast), require("../fixtures/parse/all-pieces.json"));
+            assert.deepEqual(tester.getRaw(ast), require("../fixtures/parse/all-pieces.json"));
         });
 
     });

--- a/tests/lib/tester.js
+++ b/tests/lib/tester.js
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview Tools for running test cases
+ * @author Nicholas C. Zakas
+ * @copyright jQuery Foundation and other contributors, https://jquery.org/
+ * MIT License
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+//   Private
+//--------------------------------------------------------------------------------
+
+/**
+ * Returns a raw copy of the given AST
+ * @param  {object} ast the AST object
+ * @returns {object}     copy of the AST object
+ */
+function getRaw(ast) {
+    return JSON.parse(JSON.stringify(ast, function(key, value) {
+        if ((key === "start" || key === "end") && typeof value === "number") {
+            return undefined; // eslint-disable-line no-undefined
+        }
+
+        return value;
+    }));
+}
+
+module.exports = {
+    getRaw: getRaw
+};

--- a/tests/lib/typescript.js
+++ b/tests/lib/typescript.js
@@ -15,7 +15,8 @@ var assert = require("chai").assert,
     leche = require("leche"),
     path = require("path"),
     parser = require("../../parser"),
-    shelljs = require("shelljs");
+    shelljs = require("shelljs"),
+    tester = require("./tester");
 
 //------------------------------------------------------------------------------
 // Setup
@@ -28,15 +29,6 @@ var testFiles = shelljs.find(FIXTURES_DIR).filter(function(filename) {
 }).map(function(filename) {
     return filename.substring(FIXTURES_DIR.length - 1, filename.length - 7);  // strip off ".src.ts"
 });
-
-/**
- * Returns a raw copy of the given AST
- * @param  {object} ast the AST object
- * @returns {object}     copy of the AST object
- */
-function getRaw(ast) {
-    return JSON.parse(JSON.stringify(ast));
-}
 
 //------------------------------------------------------------------------------
 // Tests
@@ -66,7 +58,7 @@ describe("typescript", function() {
 
             try {
                 result = parser.parse(code, config);
-                result = getRaw(result);
+                result = tester.getRaw(result);
             } catch (ex) {
 
                 // format of error isn't exactly the same, just check if it's expected


### PR DESCRIPTION
Some eslint plugins except tokens to have start and end properties
instead of range. This commit adds those properties and modifies
the tests to ignore start and end property.