### PR TITLE
New: Mark optional parameters (fixes #186)

### DIFF
--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -752,6 +752,14 @@ module.exports = function(ast, extra) {
                     type: "Identifier",
                     name: ts.unescapeIdentifier(node.text)
                 });
+                if (node.parent.questionToken && (
+                    SyntaxKind.Parameter === node.parent.kind ||
+                    SyntaxKind.PropertyDeclaration === node.parent.kind ||
+                    SyntaxKind.PropertySignature === node.parent.kind ||
+                    SyntaxKind.MethodSignature === node.parent.kind
+                )) {
+                    result.optional = true;
+                }
                 break;
 
             case SyntaxKind.WithStatement:

--- a/tests/fixtures/typescript/basics/class-with-optional-properties.result.js
+++ b/tests/fixtures/typescript/basics/class-with-optional-properties.result.js
@@ -1,0 +1,526 @@
+module.exports = {
+    "body": [
+        {
+            "body": {
+                "body": [
+                    {
+                        "accessibility": null,
+                        "computed": false,
+                        "decorators": [],
+                        "key": {
+                            "loc": {
+                                "end": {
+                                    "column": 5,
+                                    "line": 2
+                                },
+                                "start": {
+                                    "column": 2,
+                                    "line": 2
+                                }
+                            },
+                            "name": "foo",
+                            "optional": true,
+                            "range": [
+                                14,
+                                17
+                            ],
+                            "type": "Identifier"
+                        },
+                        "loc": {
+                            "end": {
+                                "column": 7,
+                                "line": 2
+                            },
+                            "start": {
+                                "column": 2,
+                                "line": 2
+                            }
+                        },
+                        "range": [
+                            14,
+                            19
+                        ],
+                        "static": false,
+                        "type": "ClassProperty",
+                        "value": null
+                    },
+                    {
+                        "accessibility": null,
+                        "computed": false,
+                        "decorators": [],
+                        "key": {
+                            "loc": {
+                                "end": {
+                                    "column": 5,
+                                    "line": 3
+                                },
+                                "start": {
+                                    "column": 2,
+                                    "line": 3
+                                }
+                            },
+                            "name": "bar",
+                            "optional": true,
+                            "range": [
+                                22,
+                                25
+                            ],
+                            "type": "Identifier"
+                        },
+                        "loc": {
+                            "end": {
+                                "column": 16,
+                                "line": 3
+                            },
+                            "start": {
+                                "column": 2,
+                                "line": 3
+                            }
+                        },
+                        "range": [
+                            22,
+                            36
+                        ],
+                        "static": false,
+                        "type": "ClassProperty",
+                        "value": null
+                    },
+                    {
+                        "accessibility": "private",
+                        "computed": false,
+                        "decorators": [],
+                        "key": {
+                            "loc": {
+                                "end": {
+                                    "column": 13,
+                                    "line": 4
+                                },
+                                "start": {
+                                    "column": 10,
+                                    "line": 4
+                                }
+                            },
+                            "name": "baz",
+                            "optional": true,
+                            "range": [
+                                47,
+                                50
+                            ],
+                            "type": "Identifier"
+                        },
+                        "loc": {
+                            "end": {
+                                "column": 24,
+                                "line": 4
+                            },
+                            "start": {
+                                "column": 2,
+                                "line": 4
+                            }
+                        },
+                        "range": [
+                            39,
+                            61
+                        ],
+                        "static": false,
+                        "type": "ClassProperty",
+                        "value": null
+                    }
+                ],
+                "loc": {
+                    "end": {
+                        "column": 1,
+                        "line": 5
+                    },
+                    "start": {
+                        "column": 10,
+                        "line": 1
+                    }
+                },
+                "range": [
+                    10,
+                    63
+                ],
+                "type": "ClassBody"
+            },
+            "decorators": [],
+            "id": {
+                "loc": {
+                    "end": {
+                        "column": 9,
+                        "line": 1
+                    },
+                    "start": {
+                        "column": 6,
+                        "line": 1
+                    }
+                },
+                "name": "Foo",
+                "range": [
+                    6,
+                    9
+                ],
+                "type": "Identifier"
+            },
+            "implements": [],
+            "loc": {
+                "end": {
+                    "column": 1,
+                    "line": 5
+                },
+                "start": {
+                    "column": 0,
+                    "line": 1
+                }
+            },
+            "range": [
+                0,
+                63
+            ],
+            "superClass": null,
+            "type": "ClassDeclaration"
+        }
+    ],
+    "loc": {
+        "end": {
+            "column": 1,
+            "line": 5
+        },
+        "start": {
+            "column": 0,
+            "line": 1
+        }
+    },
+    "range": [
+        0,
+        63
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "loc": {
+                "end": {
+                    "column": 5,
+                    "line": 1
+                },
+                "start": {
+                    "column": 0,
+                    "line": 1
+                }
+            },
+            "range": [
+                0,
+                5
+            ],
+            "type": "Keyword",
+            "value": "class"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 9,
+                    "line": 1
+                },
+                "start": {
+                    "column": 6,
+                    "line": 1
+                }
+            },
+            "range": [
+                6,
+                9
+            ],
+            "type": "Identifier",
+            "value": "Foo"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 11,
+                    "line": 1
+                },
+                "start": {
+                    "column": 10,
+                    "line": 1
+                }
+            },
+            "range": [
+                10,
+                11
+            ],
+            "type": "Punctuator",
+            "value": "{"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 5,
+                    "line": 2
+                },
+                "start": {
+                    "column": 2,
+                    "line": 2
+                }
+            },
+            "range": [
+                14,
+                17
+            ],
+            "type": "Identifier",
+            "value": "foo"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 6,
+                    "line": 2
+                },
+                "start": {
+                    "column": 5,
+                    "line": 2
+                }
+            },
+            "range": [
+                17,
+                18
+            ],
+            "type": "Punctuator",
+            "value": "?"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 7,
+                    "line": 2
+                },
+                "start": {
+                    "column": 6,
+                    "line": 2
+                }
+            },
+            "range": [
+                18,
+                19
+            ],
+            "type": "Punctuator",
+            "value": ";"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 5,
+                    "line": 3
+                },
+                "start": {
+                    "column": 2,
+                    "line": 3
+                }
+            },
+            "range": [
+                22,
+                25
+            ],
+            "type": "Identifier",
+            "value": "bar"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 6,
+                    "line": 3
+                },
+                "start": {
+                    "column": 5,
+                    "line": 3
+                }
+            },
+            "range": [
+                25,
+                26
+            ],
+            "type": "Punctuator",
+            "value": "?"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 8,
+                    "line": 3
+                },
+                "start": {
+                    "column": 7,
+                    "line": 3
+                }
+            },
+            "range": [
+                27,
+                28
+            ],
+            "type": "Punctuator",
+            "value": ":"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 15,
+                    "line": 3
+                },
+                "start": {
+                    "column": 9,
+                    "line": 3
+                }
+            },
+            "range": [
+                29,
+                35
+            ],
+            "type": "Identifier",
+            "value": "string"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 16,
+                    "line": 3
+                },
+                "start": {
+                    "column": 15,
+                    "line": 3
+                }
+            },
+            "range": [
+                35,
+                36
+            ],
+            "type": "Punctuator",
+            "value": ";"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 9,
+                    "line": 4
+                },
+                "start": {
+                    "column": 2,
+                    "line": 4
+                }
+            },
+            "range": [
+                39,
+                46
+            ],
+            "type": "Keyword",
+            "value": "private"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 13,
+                    "line": 4
+                },
+                "start": {
+                    "column": 10,
+                    "line": 4
+                }
+            },
+            "range": [
+                47,
+                50
+            ],
+            "type": "Identifier",
+            "value": "baz"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 14,
+                    "line": 4
+                },
+                "start": {
+                    "column": 13,
+                    "line": 4
+                }
+            },
+            "range": [
+                50,
+                51
+            ],
+            "type": "Punctuator",
+            "value": "?"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 16,
+                    "line": 4
+                },
+                "start": {
+                    "column": 15,
+                    "line": 4
+                }
+            },
+            "range": [
+                52,
+                53
+            ],
+            "type": "Punctuator",
+            "value": ":"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 23,
+                    "line": 4
+                },
+                "start": {
+                    "column": 17,
+                    "line": 4
+                }
+            },
+            "range": [
+                54,
+                60
+            ],
+            "type": "Identifier",
+            "value": "string"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 24,
+                    "line": 4
+                },
+                "start": {
+                    "column": 23,
+                    "line": 4
+                }
+            },
+            "range": [
+                60,
+                61
+            ],
+            "type": "Punctuator",
+            "value": ";"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 1,
+                    "line": 5
+                },
+                "start": {
+                    "column": 0,
+                    "line": 5
+                }
+            },
+            "range": [
+                62,
+                63
+            ],
+            "type": "Punctuator",
+            "value": "}"
+        }
+    ],
+    "type": "Program"
+};

--- a/tests/fixtures/typescript/basics/class-with-optional-properties.src.ts
+++ b/tests/fixtures/typescript/basics/class-with-optional-properties.src.ts
@@ -1,0 +1,5 @@
+class Foo {
+  foo?;
+  bar? : string;
+  private baz? : string;
+}

--- a/tests/fixtures/typescript/basics/function-with-object-type-with-optional-properties.result.js
+++ b/tests/fixtures/typescript/basics/function-with-object-type-with-optional-properties.result.js
@@ -1,0 +1,768 @@
+module.exports = {
+    "body": [
+        {
+            "async": false,
+            "body": {
+                "body": [],
+                "loc": {
+                    "end": {
+                        "column": 1,
+                        "line": 3
+                    },
+                    "start": {
+                        "column": 47,
+                        "line": 1
+                    }
+                },
+                "range": [
+                    47,
+                    51
+                ],
+                "type": "BlockStatement"
+            },
+            "expression": false,
+            "generator": false,
+            "id": {
+                "loc": {
+                    "end": {
+                        "column": 12,
+                        "line": 1
+                    },
+                    "start": {
+                        "column": 9,
+                        "line": 1
+                    }
+                },
+                "name": "foo",
+                "range": [
+                    9,
+                    12
+                ],
+                "type": "Identifier"
+            },
+            "loc": {
+                "end": {
+                    "column": 1,
+                    "line": 3
+                },
+                "start": {
+                    "column": 0,
+                    "line": 1
+                }
+            },
+            "params": [
+                {
+                    "loc": {
+                        "end": {
+                            "column": 23,
+                            "line": 1
+                        },
+                        "start": {
+                            "column": 13,
+                            "line": 1
+                        }
+                    },
+                    "properties": [
+                        {
+                            "computed": false,
+                            "key": {
+                                "loc": {
+                                    "end": {
+                                        "column": 17,
+                                        "line": 1
+                                    },
+                                    "start": {
+                                        "column": 14,
+                                        "line": 1
+                                    }
+                                },
+                                "name": "bar",
+                                "range": [
+                                    14,
+                                    17
+                                ],
+                                "type": "Identifier"
+                            },
+                            "kind": "init",
+                            "loc": {
+                                "end": {
+                                    "column": 17,
+                                    "line": 1
+                                },
+                                "start": {
+                                    "column": 14,
+                                    "line": 1
+                                }
+                            },
+                            "method": false,
+                            "range": [
+                                14,
+                                17
+                            ],
+                            "shorthand": true,
+                            "type": "Property",
+                            "value": {
+                                "loc": {
+                                    "end": {
+                                        "column": 17,
+                                        "line": 1
+                                    },
+                                    "start": {
+                                        "column": 14,
+                                        "line": 1
+                                    }
+                                },
+                                "name": "bar",
+                                "range": [
+                                    14,
+                                    17
+                                ],
+                                "type": "Identifier"
+                            }
+                        },
+                        {
+                            "computed": false,
+                            "key": {
+                                "loc": {
+                                    "end": {
+                                        "column": 22,
+                                        "line": 1
+                                    },
+                                    "start": {
+                                        "column": 19,
+                                        "line": 1
+                                    }
+                                },
+                                "name": "baz",
+                                "range": [
+                                    19,
+                                    22
+                                ],
+                                "type": "Identifier"
+                            },
+                            "kind": "init",
+                            "loc": {
+                                "end": {
+                                    "column": 22,
+                                    "line": 1
+                                },
+                                "start": {
+                                    "column": 19,
+                                    "line": 1
+                                }
+                            },
+                            "method": false,
+                            "range": [
+                                19,
+                                22
+                            ],
+                            "shorthand": true,
+                            "type": "Property",
+                            "value": {
+                                "loc": {
+                                    "end": {
+                                        "column": 22,
+                                        "line": 1
+                                    },
+                                    "start": {
+                                        "column": 19,
+                                        "line": 1
+                                    }
+                                },
+                                "name": "baz",
+                                "range": [
+                                    19,
+                                    22
+                                ],
+                                "type": "Identifier"
+                            }
+                        }
+                    ],
+                    "range": [
+                        13,
+                        23
+                    ],
+                    "type": "ObjectPattern",
+                    "typeAnnotation": {
+                        "loc": {
+                            "end": {
+                                "column": 45,
+                                "line": 1
+                            },
+                            "start": {
+                                "column": 25,
+                                "line": 1
+                            }
+                        },
+                        "range": [
+                            25,
+                            45
+                        ],
+                        "type": "TypeAnnotation",
+                        "typeAnnotation": {
+                            "loc": {
+                                "end": {
+                                    "column": 45,
+                                    "line": 1
+                                },
+                                "start": {
+                                    "column": 25,
+                                    "line": 1
+                                }
+                            },
+                            "members": [
+                                {
+                                    "loc": {
+                                        "end": {
+                                            "column": 39,
+                                            "line": 1
+                                        },
+                                        "start": {
+                                            "column": 26,
+                                            "line": 1
+                                        }
+                                    },
+                                    "name": {
+                                        "loc": {
+                                            "end": {
+                                                "column": 29,
+                                                "line": 1
+                                            },
+                                            "start": {
+                                                "column": 26,
+                                                "line": 1
+                                            }
+                                        },
+                                        "name": "bar",
+                                        "optional": true,
+                                        "range": [
+                                            26,
+                                            29
+                                        ],
+                                        "type": "Identifier"
+                                    },
+                                    "questionToken": {
+                                        "loc": {
+                                            "end": {
+                                                "column": 30,
+                                                "line": 1
+                                            },
+                                            "start": {
+                                                "column": 29,
+                                                "line": 1
+                                            }
+                                        },
+                                        "range": [
+                                            29,
+                                            30
+                                        ],
+                                        "type": "TSQuestionToken"
+                                    },
+                                    "range": [
+                                        26,
+                                        39
+                                    ],
+                                    "type": "TSPropertySignature",
+                                    "typeAnnotation": {
+                                        "loc": {
+                                            "end": {
+                                                "column": 38,
+                                                "line": 1
+                                            },
+                                            "start": {
+                                                "column": 32,
+                                                "line": 1
+                                            }
+                                        },
+                                        "range": [
+                                            32,
+                                            38
+                                        ],
+                                        "type": "TypeAnnotation",
+                                        "typeAnnotation": {
+                                            "loc": {
+                                                "end": {
+                                                    "column": 38,
+                                                    "line": 1
+                                                },
+                                                "start": {
+                                                    "column": 32,
+                                                    "line": 1
+                                                }
+                                            },
+                                            "range": [
+                                                32,
+                                                38
+                                            ],
+                                            "type": "TSStringKeyword"
+                                        }
+                                    }
+                                },
+                                {
+                                    "loc": {
+                                        "end": {
+                                            "column": 44,
+                                            "line": 1
+                                        },
+                                        "start": {
+                                            "column": 40,
+                                            "line": 1
+                                        }
+                                    },
+                                    "name": {
+                                        "loc": {
+                                            "end": {
+                                                "column": 43,
+                                                "line": 1
+                                            },
+                                            "start": {
+                                                "column": 40,
+                                                "line": 1
+                                            }
+                                        },
+                                        "name": "baz",
+                                        "optional": true,
+                                        "range": [
+                                            40,
+                                            43
+                                        ],
+                                        "type": "Identifier"
+                                    },
+                                    "questionToken": {
+                                        "loc": {
+                                            "end": {
+                                                "column": 44,
+                                                "line": 1
+                                            },
+                                            "start": {
+                                                "column": 43,
+                                                "line": 1
+                                            }
+                                        },
+                                        "range": [
+                                            43,
+                                            44
+                                        ],
+                                        "type": "TSQuestionToken"
+                                    },
+                                    "range": [
+                                        40,
+                                        44
+                                    ],
+                                    "type": "TSPropertySignature",
+                                    "typeAnnotation": null
+                                }
+                            ],
+                            "range": [
+                                25,
+                                45
+                            ],
+                            "type": "TSTypeLiteral"
+                        }
+                    }
+                }
+            ],
+            "range": [
+                0,
+                51
+            ],
+            "type": "FunctionDeclaration"
+        }
+    ],
+    "loc": {
+        "end": {
+            "column": 1,
+            "line": 3
+        },
+        "start": {
+            "column": 0,
+            "line": 1
+        }
+    },
+    "range": [
+        0,
+        51
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "loc": {
+                "end": {
+                    "column": 8,
+                    "line": 1
+                },
+                "start": {
+                    "column": 0,
+                    "line": 1
+                }
+            },
+            "range": [
+                0,
+                8
+            ],
+            "type": "Keyword",
+            "value": "function"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 12,
+                    "line": 1
+                },
+                "start": {
+                    "column": 9,
+                    "line": 1
+                }
+            },
+            "range": [
+                9,
+                12
+            ],
+            "type": "Identifier",
+            "value": "foo"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 13,
+                    "line": 1
+                },
+                "start": {
+                    "column": 12,
+                    "line": 1
+                }
+            },
+            "range": [
+                12,
+                13
+            ],
+            "type": "Punctuator",
+            "value": "("
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 14,
+                    "line": 1
+                },
+                "start": {
+                    "column": 13,
+                    "line": 1
+                }
+            },
+            "range": [
+                13,
+                14
+            ],
+            "type": "Punctuator",
+            "value": "{"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 17,
+                    "line": 1
+                },
+                "start": {
+                    "column": 14,
+                    "line": 1
+                }
+            },
+            "range": [
+                14,
+                17
+            ],
+            "type": "Identifier",
+            "value": "bar"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 18,
+                    "line": 1
+                },
+                "start": {
+                    "column": 17,
+                    "line": 1
+                }
+            },
+            "range": [
+                17,
+                18
+            ],
+            "type": "Punctuator",
+            "value": ","
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 22,
+                    "line": 1
+                },
+                "start": {
+                    "column": 19,
+                    "line": 1
+                }
+            },
+            "range": [
+                19,
+                22
+            ],
+            "type": "Identifier",
+            "value": "baz"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 23,
+                    "line": 1
+                },
+                "start": {
+                    "column": 22,
+                    "line": 1
+                }
+            },
+            "range": [
+                22,
+                23
+            ],
+            "type": "Punctuator",
+            "value": "}"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 24,
+                    "line": 1
+                },
+                "start": {
+                    "column": 23,
+                    "line": 1
+                }
+            },
+            "range": [
+                23,
+                24
+            ],
+            "type": "Punctuator",
+            "value": ":"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 26,
+                    "line": 1
+                },
+                "start": {
+                    "column": 25,
+                    "line": 1
+                }
+            },
+            "range": [
+                25,
+                26
+            ],
+            "type": "Punctuator",
+            "value": "{"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 29,
+                    "line": 1
+                },
+                "start": {
+                    "column": 26,
+                    "line": 1
+                }
+            },
+            "range": [
+                26,
+                29
+            ],
+            "type": "Identifier",
+            "value": "bar"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 30,
+                    "line": 1
+                },
+                "start": {
+                    "column": 29,
+                    "line": 1
+                }
+            },
+            "range": [
+                29,
+                30
+            ],
+            "type": "Punctuator",
+            "value": "?"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 31,
+                    "line": 1
+                },
+                "start": {
+                    "column": 30,
+                    "line": 1
+                }
+            },
+            "range": [
+                30,
+                31
+            ],
+            "type": "Punctuator",
+            "value": ":"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 38,
+                    "line": 1
+                },
+                "start": {
+                    "column": 32,
+                    "line": 1
+                }
+            },
+            "range": [
+                32,
+                38
+            ],
+            "type": "Identifier",
+            "value": "string"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 39,
+                    "line": 1
+                },
+                "start": {
+                    "column": 38,
+                    "line": 1
+                }
+            },
+            "range": [
+                38,
+                39
+            ],
+            "type": "Punctuator",
+            "value": ","
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 43,
+                    "line": 1
+                },
+                "start": {
+                    "column": 40,
+                    "line": 1
+                }
+            },
+            "range": [
+                40,
+                43
+            ],
+            "type": "Identifier",
+            "value": "baz"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 44,
+                    "line": 1
+                },
+                "start": {
+                    "column": 43,
+                    "line": 1
+                }
+            },
+            "range": [
+                43,
+                44
+            ],
+            "type": "Punctuator",
+            "value": "?"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 45,
+                    "line": 1
+                },
+                "start": {
+                    "column": 44,
+                    "line": 1
+                }
+            },
+            "range": [
+                44,
+                45
+            ],
+            "type": "Punctuator",
+            "value": "}"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 46,
+                    "line": 1
+                },
+                "start": {
+                    "column": 45,
+                    "line": 1
+                }
+            },
+            "range": [
+                45,
+                46
+            ],
+            "type": "Punctuator",
+            "value": ")"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 48,
+                    "line": 1
+                },
+                "start": {
+                    "column": 47,
+                    "line": 1
+                }
+            },
+            "range": [
+                47,
+                48
+            ],
+            "type": "Punctuator",
+            "value": "{"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 1,
+                    "line": 3
+                },
+                "start": {
+                    "column": 0,
+                    "line": 3
+                }
+            },
+            "range": [
+                50,
+                51
+            ],
+            "type": "Punctuator",
+            "value": "}"
+        }
+    ],
+    "type": "Program"
+};

--- a/tests/fixtures/typescript/basics/function-with-object-type-with-optional-properties.src.ts
+++ b/tests/fixtures/typescript/basics/function-with-object-type-with-optional-properties.src.ts
@@ -1,0 +1,3 @@
+function foo({bar, baz}: {bar?: string, baz?}) {
+
+}

--- a/tests/fixtures/typescript/basics/interface-with-optional-properties.result.js
+++ b/tests/fixtures/typescript/basics/interface-with-optional-properties.result.js
@@ -1,0 +1,813 @@
+module.exports = {
+    "body": [
+        {
+            "loc": {
+                "end": {
+                    "column": 1,
+                    "line": 5
+                },
+                "start": {
+                    "column": 0,
+                    "line": 1
+                }
+            },
+            "members": [
+                {
+                    "loc": {
+                        "end": {
+                            "column": 9,
+                            "line": 2
+                        },
+                        "start": {
+                            "column": 4,
+                            "line": 2
+                        }
+                    },
+                    "name": {
+                        "loc": {
+                            "end": {
+                                "column": 7,
+                                "line": 2
+                            },
+                            "start": {
+                                "column": 4,
+                                "line": 2
+                            }
+                        },
+                        "name": "foo",
+                        "optional": true,
+                        "range": [
+                            21,
+                            24
+                        ],
+                        "type": "Identifier"
+                    },
+                    "questionToken": {
+                        "loc": {
+                            "end": {
+                                "column": 8,
+                                "line": 2
+                            },
+                            "start": {
+                                "column": 7,
+                                "line": 2
+                            }
+                        },
+                        "range": [
+                            24,
+                            25
+                        ],
+                        "type": "TSQuestionToken"
+                    },
+                    "range": [
+                        21,
+                        26
+                    ],
+                    "type": "TSPropertySignature",
+                    "typeAnnotation": null
+                },
+                {
+                    "loc": {
+                        "end": {
+                            "column": 17,
+                            "line": 3
+                        },
+                        "start": {
+                            "column": 4,
+                            "line": 3
+                        }
+                    },
+                    "name": {
+                        "loc": {
+                            "end": {
+                                "column": 7,
+                                "line": 3
+                            },
+                            "start": {
+                                "column": 4,
+                                "line": 3
+                            }
+                        },
+                        "name": "bar",
+                        "optional": true,
+                        "range": [
+                            31,
+                            34
+                        ],
+                        "type": "Identifier"
+                    },
+                    "questionToken": {
+                        "loc": {
+                            "end": {
+                                "column": 8,
+                                "line": 3
+                            },
+                            "start": {
+                                "column": 7,
+                                "line": 3
+                            }
+                        },
+                        "range": [
+                            34,
+                            35
+                        ],
+                        "type": "TSQuestionToken"
+                    },
+                    "range": [
+                        31,
+                        44
+                    ],
+                    "type": "TSPropertySignature",
+                    "typeAnnotation": {
+                        "loc": {
+                            "end": {
+                                "column": 16,
+                                "line": 3
+                            },
+                            "start": {
+                                "column": 10,
+                                "line": 3
+                            }
+                        },
+                        "range": [
+                            37,
+                            43
+                        ],
+                        "type": "TypeAnnotation",
+                        "typeAnnotation": {
+                            "loc": {
+                                "end": {
+                                    "column": 16,
+                                    "line": 3
+                                },
+                                "start": {
+                                    "column": 10,
+                                    "line": 3
+                                }
+                            },
+                            "range": [
+                                37,
+                                43
+                            ],
+                            "type": "TSStringKeyword"
+                        }
+                    }
+                },
+                {
+                    "loc": {
+                        "end": {
+                            "column": 34,
+                            "line": 4
+                        },
+                        "start": {
+                            "column": 4,
+                            "line": 4
+                        }
+                    },
+                    "name": {
+                        "loc": {
+                            "end": {
+                                "column": 7,
+                                "line": 4
+                            },
+                            "start": {
+                                "column": 4,
+                                "line": 4
+                            }
+                        },
+                        "name": "baz",
+                        "optional": true,
+                        "range": [
+                            49,
+                            52
+                        ],
+                        "type": "Identifier"
+                    },
+                    "parameters": [
+                        {
+                            "loc": {
+                                "end": {
+                                    "column": 12,
+                                    "line": 4
+                                },
+                                "start": {
+                                    "column": 9,
+                                    "line": 4
+                                }
+                            },
+                            "name": "foo",
+                            "range": [
+                                54,
+                                57
+                            ],
+                            "type": "Identifier"
+                        },
+                        {
+                            "loc": {
+                                "end": {
+                                    "column": 17,
+                                    "line": 4
+                                },
+                                "start": {
+                                    "column": 14,
+                                    "line": 4
+                                }
+                            },
+                            "name": "bar",
+                            "optional": true,
+                            "range": [
+                                59,
+                                62
+                            ],
+                            "type": "Identifier",
+                            "typeAnnotation": {
+                                "loc": {
+                                    "end": {
+                                        "column": 26,
+                                        "line": 4
+                                    },
+                                    "start": {
+                                        "column": 20,
+                                        "line": 4
+                                    }
+                                },
+                                "range": [
+                                    65,
+                                    71
+                                ],
+                                "type": "TypeAnnotation",
+                                "typeAnnotation": {
+                                    "loc": {
+                                        "end": {
+                                            "column": 26,
+                                            "line": 4
+                                        },
+                                        "start": {
+                                            "column": 20,
+                                            "line": 4
+                                        }
+                                    },
+                                    "range": [
+                                        65,
+                                        71
+                                    ],
+                                    "type": "TSStringKeyword"
+                                }
+                            }
+                        },
+                        {
+                            "loc": {
+                                "end": {
+                                    "column": 31,
+                                    "line": 4
+                                },
+                                "start": {
+                                    "column": 28,
+                                    "line": 4
+                                }
+                            },
+                            "name": "baz",
+                            "optional": true,
+                            "range": [
+                                73,
+                                76
+                            ],
+                            "type": "Identifier"
+                        }
+                    ],
+                    "questionToken": {
+                        "loc": {
+                            "end": {
+                                "column": 8,
+                                "line": 4
+                            },
+                            "start": {
+                                "column": 7,
+                                "line": 4
+                            }
+                        },
+                        "range": [
+                            52,
+                            53
+                        ],
+                        "type": "TSQuestionToken"
+                    },
+                    "range": [
+                        49,
+                        79
+                    ],
+                    "type": "TSMethodSignature"
+                }
+            ],
+            "name": {
+                "loc": {
+                    "end": {
+                        "column": 14,
+                        "line": 1
+                    },
+                    "start": {
+                        "column": 10,
+                        "line": 1
+                    }
+                },
+                "name": "test",
+                "range": [
+                    10,
+                    14
+                ],
+                "type": "Identifier"
+            },
+            "range": [
+                0,
+                81
+            ],
+            "type": "TSInterfaceDeclaration"
+        }
+    ],
+    "loc": {
+        "end": {
+            "column": 1,
+            "line": 5
+        },
+        "start": {
+            "column": 0,
+            "line": 1
+        }
+    },
+    "range": [
+        0,
+        81
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "loc": {
+                "end": {
+                    "column": 9,
+                    "line": 1
+                },
+                "start": {
+                    "column": 0,
+                    "line": 1
+                }
+            },
+            "range": [
+                0,
+                9
+            ],
+            "type": "Keyword",
+            "value": "interface"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 14,
+                    "line": 1
+                },
+                "start": {
+                    "column": 10,
+                    "line": 1
+                }
+            },
+            "range": [
+                10,
+                14
+            ],
+            "type": "Identifier",
+            "value": "test"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 16,
+                    "line": 1
+                },
+                "start": {
+                    "column": 15,
+                    "line": 1
+                }
+            },
+            "range": [
+                15,
+                16
+            ],
+            "type": "Punctuator",
+            "value": "{"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 7,
+                    "line": 2
+                },
+                "start": {
+                    "column": 4,
+                    "line": 2
+                }
+            },
+            "range": [
+                21,
+                24
+            ],
+            "type": "Identifier",
+            "value": "foo"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 8,
+                    "line": 2
+                },
+                "start": {
+                    "column": 7,
+                    "line": 2
+                }
+            },
+            "range": [
+                24,
+                25
+            ],
+            "type": "Punctuator",
+            "value": "?"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 9,
+                    "line": 2
+                },
+                "start": {
+                    "column": 8,
+                    "line": 2
+                }
+            },
+            "range": [
+                25,
+                26
+            ],
+            "type": "Punctuator",
+            "value": ";"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 7,
+                    "line": 3
+                },
+                "start": {
+                    "column": 4,
+                    "line": 3
+                }
+            },
+            "range": [
+                31,
+                34
+            ],
+            "type": "Identifier",
+            "value": "bar"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 8,
+                    "line": 3
+                },
+                "start": {
+                    "column": 7,
+                    "line": 3
+                }
+            },
+            "range": [
+                34,
+                35
+            ],
+            "type": "Punctuator",
+            "value": "?"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 9,
+                    "line": 3
+                },
+                "start": {
+                    "column": 8,
+                    "line": 3
+                }
+            },
+            "range": [
+                35,
+                36
+            ],
+            "type": "Punctuator",
+            "value": ":"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 16,
+                    "line": 3
+                },
+                "start": {
+                    "column": 10,
+                    "line": 3
+                }
+            },
+            "range": [
+                37,
+                43
+            ],
+            "type": "Identifier",
+            "value": "string"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 17,
+                    "line": 3
+                },
+                "start": {
+                    "column": 16,
+                    "line": 3
+                }
+            },
+            "range": [
+                43,
+                44
+            ],
+            "type": "Punctuator",
+            "value": ";"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 7,
+                    "line": 4
+                },
+                "start": {
+                    "column": 4,
+                    "line": 4
+                }
+            },
+            "range": [
+                49,
+                52
+            ],
+            "type": "Identifier",
+            "value": "baz"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 8,
+                    "line": 4
+                },
+                "start": {
+                    "column": 7,
+                    "line": 4
+                }
+            },
+            "range": [
+                52,
+                53
+            ],
+            "type": "Punctuator",
+            "value": "?"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 9,
+                    "line": 4
+                },
+                "start": {
+                    "column": 8,
+                    "line": 4
+                }
+            },
+            "range": [
+                53,
+                54
+            ],
+            "type": "Punctuator",
+            "value": "("
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 12,
+                    "line": 4
+                },
+                "start": {
+                    "column": 9,
+                    "line": 4
+                }
+            },
+            "range": [
+                54,
+                57
+            ],
+            "type": "Identifier",
+            "value": "foo"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 13,
+                    "line": 4
+                },
+                "start": {
+                    "column": 12,
+                    "line": 4
+                }
+            },
+            "range": [
+                57,
+                58
+            ],
+            "type": "Punctuator",
+            "value": ","
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 17,
+                    "line": 4
+                },
+                "start": {
+                    "column": 14,
+                    "line": 4
+                }
+            },
+            "range": [
+                59,
+                62
+            ],
+            "type": "Identifier",
+            "value": "bar"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 18,
+                    "line": 4
+                },
+                "start": {
+                    "column": 17,
+                    "line": 4
+                }
+            },
+            "range": [
+                62,
+                63
+            ],
+            "type": "Punctuator",
+            "value": "?"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 19,
+                    "line": 4
+                },
+                "start": {
+                    "column": 18,
+                    "line": 4
+                }
+            },
+            "range": [
+                63,
+                64
+            ],
+            "type": "Punctuator",
+            "value": ":"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 26,
+                    "line": 4
+                },
+                "start": {
+                    "column": 20,
+                    "line": 4
+                }
+            },
+            "range": [
+                65,
+                71
+            ],
+            "type": "Identifier",
+            "value": "string"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 27,
+                    "line": 4
+                },
+                "start": {
+                    "column": 26,
+                    "line": 4
+                }
+            },
+            "range": [
+                71,
+                72
+            ],
+            "type": "Punctuator",
+            "value": ","
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 31,
+                    "line": 4
+                },
+                "start": {
+                    "column": 28,
+                    "line": 4
+                }
+            },
+            "range": [
+                73,
+                76
+            ],
+            "type": "Identifier",
+            "value": "baz"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 32,
+                    "line": 4
+                },
+                "start": {
+                    "column": 31,
+                    "line": 4
+                }
+            },
+            "range": [
+                76,
+                77
+            ],
+            "type": "Punctuator",
+            "value": "?"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 33,
+                    "line": 4
+                },
+                "start": {
+                    "column": 32,
+                    "line": 4
+                }
+            },
+            "range": [
+                77,
+                78
+            ],
+            "type": "Punctuator",
+            "value": ")"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 34,
+                    "line": 4
+                },
+                "start": {
+                    "column": 33,
+                    "line": 4
+                }
+            },
+            "range": [
+                78,
+                79
+            ],
+            "type": "Punctuator",
+            "value": ";"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 1,
+                    "line": 5
+                },
+                "start": {
+                    "column": 0,
+                    "line": 5
+                }
+            },
+            "range": [
+                80,
+                81
+            ],
+            "type": "Punctuator",
+            "value": "}"
+        }
+    ],
+    "type": "Program"
+};

--- a/tests/fixtures/typescript/basics/interface-with-optional-properties.src.ts
+++ b/tests/fixtures/typescript/basics/interface-with-optional-properties.src.ts
@@ -1,0 +1,5 @@
+interface test {
+    foo?;
+    bar?: string;
+    baz?(foo, bar?: string, baz?);
+}

--- a/tests/fixtures/typescript/basics/non-null-assertion-operator.result.js
+++ b/tests/fixtures/typescript/basics/non-null-assertion-operator.result.js
@@ -70,6 +70,7 @@ module.exports = {
                         }
                     },
                     "name": "e",
+                    "optional": true,
                     "typeAnnotation": {
                         "type": "TypeAnnotation",
                         "loc": {


### PR DESCRIPTION
I choose to avoid storing `optional: false` to avoid a giant mess of failing tests, as undefined is false the use case still works.