### PR TITLE
New: Store type parameter constraints (fixes #188)

### DIFF
--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -636,7 +636,10 @@ module.exports = function(ast, extra) {
                             typeParameter.end
                         ],
                         loc: getLocFor(typeParameterStart, typeParameter.end, ast),
-                        name: typeParameter.name.text
+                        name: typeParameter.name.text,
+                        constraint: (typeParameter.constraint)
+                            ? convertTypeAnnotation(typeParameter.constraint)
+                            : null
                     };
                 })
             };

--- a/tests/fixtures/typescript/basics/arrow-function-with-type-parameters.result.js
+++ b/tests/fixtures/typescript/basics/arrow-function-with-type-parameters.result.js
@@ -262,7 +262,8 @@ module.exports = {
                                     "column": 2
                                 }
                             },
-                            "name": "X"
+                            "name": "X",
+                            "constraint": null
                         }
                     ]
                 }

--- a/tests/fixtures/typescript/basics/function-with-type-parameters-with-constraint.result.js
+++ b/tests/fixtures/typescript/basics/function-with-type-parameters-with-constraint.result.js
@@ -1,0 +1,670 @@
+module.exports = {
+    "body": [
+        {
+            "async": false,
+            "body": {
+                "body": [
+                    {
+                        "argument": {
+                            "loc": {
+                                "end": {
+                                    "column": 12,
+                                    "line": 2
+                                },
+                                "start": {
+                                    "column": 11,
+                                    "line": 2
+                                }
+                            },
+                            "name": "b",
+                            "range": [
+                                47,
+                                48
+                            ],
+                            "type": "Identifier"
+                        },
+                        "loc": {
+                            "end": {
+                                "column": 13,
+                                "line": 2
+                            },
+                            "start": {
+                                "column": 4,
+                                "line": 2
+                            }
+                        },
+                        "range": [
+                            40,
+                            49
+                        ],
+                        "type": "ReturnStatement"
+                    }
+                ],
+                "loc": {
+                    "end": {
+                        "column": 1,
+                        "line": 3
+                    },
+                    "start": {
+                        "column": 34,
+                        "line": 1
+                    }
+                },
+                "range": [
+                    34,
+                    51
+                ],
+                "type": "BlockStatement"
+            },
+            "expression": false,
+            "generator": false,
+            "id": {
+                "loc": {
+                    "end": {
+                        "column": 10,
+                        "line": 1
+                    },
+                    "start": {
+                        "column": 9,
+                        "line": 1
+                    }
+                },
+                "name": "a",
+                "range": [
+                    9,
+                    10
+                ],
+                "type": "Identifier"
+            },
+            "loc": {
+                "end": {
+                    "column": 1,
+                    "line": 3
+                },
+                "start": {
+                    "column": 0,
+                    "line": 1
+                }
+            },
+            "params": [
+                {
+                    "loc": {
+                        "end": {
+                            "column": 26,
+                            "line": 1
+                        },
+                        "start": {
+                            "column": 25,
+                            "line": 1
+                        }
+                    },
+                    "name": "b",
+                    "range": [
+                        25,
+                        26
+                    ],
+                    "type": "Identifier",
+                    "typeAnnotation": {
+                        "loc": {
+                            "end": {
+                                "column": 29,
+                                "line": 1
+                            },
+                            "start": {
+                                "column": 28,
+                                "line": 1
+                            }
+                        },
+                        "range": [
+                            28,
+                            29
+                        ],
+                        "type": "TypeAnnotation",
+                        "typeAnnotation": {
+                            "loc": {
+                                "end": {
+                                    "column": 29,
+                                    "line": 1
+                                },
+                                "start": {
+                                    "column": 28,
+                                    "line": 1
+                                }
+                            },
+                            "range": [
+                                28,
+                                29
+                            ],
+                            "type": "TSTypeReference",
+                            "typeName": {
+                                "loc": {
+                                    "end": {
+                                        "column": 29,
+                                        "line": 1
+                                    },
+                                    "start": {
+                                        "column": 28,
+                                        "line": 1
+                                    }
+                                },
+                                "name": "X",
+                                "range": [
+                                    28,
+                                    29
+                                ],
+                                "type": "Identifier"
+                            }
+                        }
+                    }
+                }
+            ],
+            "range": [
+                0,
+                51
+            ],
+            "returnType": {
+                "loc": {
+                    "end": {
+                        "column": 33,
+                        "line": 1
+                    },
+                    "start": {
+                        "column": 32,
+                        "line": 1
+                    }
+                },
+                "range": [
+                    32,
+                    33
+                ],
+                "type": "TypeAnnotation",
+                "typeAnnotation": {
+                    "loc": {
+                        "end": {
+                            "column": 33,
+                            "line": 1
+                        },
+                        "start": {
+                            "column": 32,
+                            "line": 1
+                        }
+                    },
+                    "range": [
+                        32,
+                        33
+                    ],
+                    "type": "TSTypeReference",
+                    "typeName": {
+                        "loc": {
+                            "end": {
+                                "column": 33,
+                                "line": 1
+                            },
+                            "start": {
+                                "column": 32,
+                                "line": 1
+                            }
+                        },
+                        "name": "X",
+                        "range": [
+                            32,
+                            33
+                        ],
+                        "type": "Identifier"
+                    }
+                }
+            },
+            "type": "FunctionDeclaration",
+            "typeParameters": {
+                "loc": {
+                    "end": {
+                        "column": 24,
+                        "line": 1
+                    },
+                    "start": {
+                        "column": 10,
+                        "line": 1
+                    }
+                },
+                "params": [
+                    {
+                        "constraint": {
+                            "loc": {
+                                "end": {
+                                    "column": 23,
+                                    "line": 1
+                                },
+                                "start": {
+                                    "column": 21,
+                                    "line": 1
+                                }
+                            },
+                            "range": [
+                                21,
+                                23
+                            ],
+                            "type": "TypeAnnotation",
+                            "typeAnnotation": {
+                                "loc": {
+                                    "end": {
+                                        "column": 23,
+                                        "line": 1
+                                    },
+                                    "start": {
+                                        "column": 21,
+                                        "line": 1
+                                    }
+                                },
+                                "members": [],
+                                "range": [
+                                    21,
+                                    23
+                                ],
+                                "type": "TSTypeLiteral"
+                            }
+                        },
+                        "loc": {
+                            "end": {
+                                "column": 23,
+                                "line": 1
+                            },
+                            "start": {
+                                "column": 11,
+                                "line": 1
+                            }
+                        },
+                        "name": "X",
+                        "range": [
+                            11,
+                            23
+                        ],
+                        "type": "TypeParameter"
+                    }
+                ],
+                "range": [
+                    10,
+                    24
+                ],
+                "type": "TypeParameterDeclaration"
+            }
+        }
+    ],
+    "loc": {
+        "end": {
+            "column": 1,
+            "line": 3
+        },
+        "start": {
+            "column": 0,
+            "line": 1
+        }
+    },
+    "range": [
+        0,
+        51
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "loc": {
+                "end": {
+                    "column": 8,
+                    "line": 1
+                },
+                "start": {
+                    "column": 0,
+                    "line": 1
+                }
+            },
+            "range": [
+                0,
+                8
+            ],
+            "type": "Keyword",
+            "value": "function"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 10,
+                    "line": 1
+                },
+                "start": {
+                    "column": 9,
+                    "line": 1
+                }
+            },
+            "range": [
+                9,
+                10
+            ],
+            "type": "Identifier",
+            "value": "a"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 11,
+                    "line": 1
+                },
+                "start": {
+                    "column": 10,
+                    "line": 1
+                }
+            },
+            "range": [
+                10,
+                11
+            ],
+            "type": "Punctuator",
+            "value": "<"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 12,
+                    "line": 1
+                },
+                "start": {
+                    "column": 11,
+                    "line": 1
+                }
+            },
+            "range": [
+                11,
+                12
+            ],
+            "type": "Identifier",
+            "value": "X"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 20,
+                    "line": 1
+                },
+                "start": {
+                    "column": 13,
+                    "line": 1
+                }
+            },
+            "range": [
+                13,
+                20
+            ],
+            "type": "Keyword",
+            "value": "extends"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 22,
+                    "line": 1
+                },
+                "start": {
+                    "column": 21,
+                    "line": 1
+                }
+            },
+            "range": [
+                21,
+                22
+            ],
+            "type": "Punctuator",
+            "value": "{"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 23,
+                    "line": 1
+                },
+                "start": {
+                    "column": 22,
+                    "line": 1
+                }
+            },
+            "range": [
+                22,
+                23
+            ],
+            "type": "Punctuator",
+            "value": "}"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 24,
+                    "line": 1
+                },
+                "start": {
+                    "column": 23,
+                    "line": 1
+                }
+            },
+            "range": [
+                23,
+                24
+            ],
+            "type": "Punctuator",
+            "value": ">"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 25,
+                    "line": 1
+                },
+                "start": {
+                    "column": 24,
+                    "line": 1
+                }
+            },
+            "range": [
+                24,
+                25
+            ],
+            "type": "Punctuator",
+            "value": "("
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 26,
+                    "line": 1
+                },
+                "start": {
+                    "column": 25,
+                    "line": 1
+                }
+            },
+            "range": [
+                25,
+                26
+            ],
+            "type": "Identifier",
+            "value": "b"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 27,
+                    "line": 1
+                },
+                "start": {
+                    "column": 26,
+                    "line": 1
+                }
+            },
+            "range": [
+                26,
+                27
+            ],
+            "type": "Punctuator",
+            "value": ":"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 29,
+                    "line": 1
+                },
+                "start": {
+                    "column": 28,
+                    "line": 1
+                }
+            },
+            "range": [
+                28,
+                29
+            ],
+            "type": "Identifier",
+            "value": "X"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 30,
+                    "line": 1
+                },
+                "start": {
+                    "column": 29,
+                    "line": 1
+                }
+            },
+            "range": [
+                29,
+                30
+            ],
+            "type": "Punctuator",
+            "value": ")"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 31,
+                    "line": 1
+                },
+                "start": {
+                    "column": 30,
+                    "line": 1
+                }
+            },
+            "range": [
+                30,
+                31
+            ],
+            "type": "Punctuator",
+            "value": ":"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 33,
+                    "line": 1
+                },
+                "start": {
+                    "column": 32,
+                    "line": 1
+                }
+            },
+            "range": [
+                32,
+                33
+            ],
+            "type": "Identifier",
+            "value": "X"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 35,
+                    "line": 1
+                },
+                "start": {
+                    "column": 34,
+                    "line": 1
+                }
+            },
+            "range": [
+                34,
+                35
+            ],
+            "type": "Punctuator",
+            "value": "{"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 10,
+                    "line": 2
+                },
+                "start": {
+                    "column": 4,
+                    "line": 2
+                }
+            },
+            "range": [
+                40,
+                46
+            ],
+            "type": "Keyword",
+            "value": "return"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 12,
+                    "line": 2
+                },
+                "start": {
+                    "column": 11,
+                    "line": 2
+                }
+            },
+            "range": [
+                47,
+                48
+            ],
+            "type": "Identifier",
+            "value": "b"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 13,
+                    "line": 2
+                },
+                "start": {
+                    "column": 12,
+                    "line": 2
+                }
+            },
+            "range": [
+                48,
+                49
+            ],
+            "type": "Punctuator",
+            "value": ";"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 1,
+                    "line": 3
+                },
+                "start": {
+                    "column": 0,
+                    "line": 3
+                }
+            },
+            "range": [
+                50,
+                51
+            ],
+            "type": "Punctuator",
+            "value": "}"
+        }
+    ],
+    "type": "Program"
+};

--- a/tests/fixtures/typescript/basics/function-with-type-parameters-with-constraint.src.ts
+++ b/tests/fixtures/typescript/basics/function-with-type-parameters-with-constraint.src.ts
@@ -1,0 +1,3 @@
+function a<X extends {}>(b: X): X {
+    return b;
+}

--- a/tests/fixtures/typescript/basics/function-with-type-parameters.result.js
+++ b/tests/fixtures/typescript/basics/function-with-type-parameters.result.js
@@ -263,7 +263,8 @@ module.exports = {
                                 "column": 12
                             }
                         },
-                        "name": "X"
+                        "name": "X",
+                        "constraint": null
                     }
                 ]
             }

--- a/tests/fixtures/typescript/basics/type-alias-declaration-with-constrained-type-parameter.result.js
+++ b/tests/fixtures/typescript/basics/type-alias-declaration-with-constrained-type-parameter.result.js
@@ -1,0 +1,545 @@
+module.exports = {
+    "body": [
+        {
+            "declarations": [
+                {
+                    "id": {
+                        "loc": {
+                            "end": {
+                                "column": 11,
+                                "line": 1
+                            },
+                            "start": {
+                                "column": 5,
+                                "line": 1
+                            }
+                        },
+                        "name": "Result",
+                        "range": [
+                            5,
+                            11
+                        ],
+                        "type": "Identifier"
+                    },
+                    "init": {
+                        "loc": {
+                            "end": {
+                                "column": 48,
+                                "line": 1
+                            },
+                            "start": {
+                                "column": 28,
+                                "line": 1
+                            }
+                        },
+                        "range": [
+                            28,
+                            48
+                        ],
+                        "type": "TSUnionType",
+                        "types": [
+                            {
+                                "loc": {
+                                    "end": {
+                                        "column": 38,
+                                        "line": 1
+                                    },
+                                    "start": {
+                                        "column": 28,
+                                        "line": 1
+                                    }
+                                },
+                                "range": [
+                                    28,
+                                    38
+                                ],
+                                "type": "TSTypeReference",
+                                "typeArguments": [
+                                    {
+                                        "loc": {
+                                            "end": {
+                                                "column": 37,
+                                                "line": 1
+                                            },
+                                            "start": {
+                                                "column": 36,
+                                                "line": 1
+                                            }
+                                        },
+                                        "range": [
+                                            36,
+                                            37
+                                        ],
+                                        "type": "TSTypeReference",
+                                        "typeName": {
+                                            "loc": {
+                                                "end": {
+                                                    "column": 37,
+                                                    "line": 1
+                                                },
+                                                "start": {
+                                                    "column": 36,
+                                                    "line": 1
+                                                }
+                                            },
+                                            "name": "T",
+                                            "range": [
+                                                36,
+                                                37
+                                            ],
+                                            "type": "Identifier"
+                                        }
+                                    }
+                                ],
+                                "typeName": {
+                                    "loc": {
+                                        "end": {
+                                            "column": 35,
+                                            "line": 1
+                                        },
+                                        "start": {
+                                            "column": 28,
+                                            "line": 1
+                                        }
+                                    },
+                                    "name": "Success",
+                                    "range": [
+                                        28,
+                                        35
+                                    ],
+                                    "type": "Identifier"
+                                }
+                            },
+                            {
+                                "loc": {
+                                    "end": {
+                                        "column": 48,
+                                        "line": 1
+                                    },
+                                    "start": {
+                                        "column": 41,
+                                        "line": 1
+                                    }
+                                },
+                                "range": [
+                                    41,
+                                    48
+                                ],
+                                "type": "TSTypeReference",
+                                "typeName": {
+                                    "loc": {
+                                        "end": {
+                                            "column": 48,
+                                            "line": 1
+                                        },
+                                        "start": {
+                                            "column": 41,
+                                            "line": 1
+                                        }
+                                    },
+                                    "name": "Failure",
+                                    "range": [
+                                        41,
+                                        48
+                                    ],
+                                    "type": "Identifier"
+                                }
+                            }
+                        ]
+                    },
+                    "loc": {
+                        "end": {
+                            "column": 48,
+                            "line": 1
+                        },
+                        "start": {
+                            "column": 5,
+                            "line": 1
+                        }
+                    },
+                    "range": [
+                        5,
+                        48
+                    ],
+                    "type": "VariableDeclarator",
+                    "typeParameters": {
+                        "loc": {
+                            "end": {
+                                "column": 25,
+                                "line": 1
+                            },
+                            "start": {
+                                "column": 11,
+                                "line": 1
+                            }
+                        },
+                        "params": [
+                            {
+                                "constraint": {
+                                    "loc": {
+                                        "end": {
+                                            "column": 24,
+                                            "line": 1
+                                        },
+                                        "start": {
+                                            "column": 22,
+                                            "line": 1
+                                        }
+                                    },
+                                    "range": [
+                                        22,
+                                        24
+                                    ],
+                                    "type": "TypeAnnotation",
+                                    "typeAnnotation": {
+                                        "loc": {
+                                            "end": {
+                                                "column": 24,
+                                                "line": 1
+                                            },
+                                            "start": {
+                                                "column": 22,
+                                                "line": 1
+                                            }
+                                        },
+                                        "members": [],
+                                        "range": [
+                                            22,
+                                            24
+                                        ],
+                                        "type": "TSTypeLiteral"
+                                    }
+                                },
+                                "loc": {
+                                    "end": {
+                                        "column": 24,
+                                        "line": 1
+                                    },
+                                    "start": {
+                                        "column": 12,
+                                        "line": 1
+                                    }
+                                },
+                                "name": "T",
+                                "range": [
+                                    12,
+                                    24
+                                ],
+                                "type": "TypeParameter"
+                            }
+                        ],
+                        "range": [
+                            11,
+                            25
+                        ],
+                        "type": "TypeParameterDeclaration"
+                    }
+                }
+            ],
+            "kind": "type",
+            "loc": {
+                "end": {
+                    "column": 48,
+                    "line": 1
+                },
+                "start": {
+                    "column": 0,
+                    "line": 1
+                }
+            },
+            "range": [
+                0,
+                48
+            ],
+            "type": "VariableDeclaration"
+        }
+    ],
+    "loc": {
+        "end": {
+            "column": 48,
+            "line": 1
+        },
+        "start": {
+            "column": 0,
+            "line": 1
+        }
+    },
+    "range": [
+        0,
+        48
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "loc": {
+                "end": {
+                    "column": 4,
+                    "line": 1
+                },
+                "start": {
+                    "column": 0,
+                    "line": 1
+                }
+            },
+            "range": [
+                0,
+                4
+            ],
+            "type": "Identifier",
+            "value": "type"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 11,
+                    "line": 1
+                },
+                "start": {
+                    "column": 5,
+                    "line": 1
+                }
+            },
+            "range": [
+                5,
+                11
+            ],
+            "type": "Identifier",
+            "value": "Result"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 12,
+                    "line": 1
+                },
+                "start": {
+                    "column": 11,
+                    "line": 1
+                }
+            },
+            "range": [
+                11,
+                12
+            ],
+            "type": "Punctuator",
+            "value": "<"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 13,
+                    "line": 1
+                },
+                "start": {
+                    "column": 12,
+                    "line": 1
+                }
+            },
+            "range": [
+                12,
+                13
+            ],
+            "type": "Identifier",
+            "value": "T"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 21,
+                    "line": 1
+                },
+                "start": {
+                    "column": 14,
+                    "line": 1
+                }
+            },
+            "range": [
+                14,
+                21
+            ],
+            "type": "Keyword",
+            "value": "extends"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 23,
+                    "line": 1
+                },
+                "start": {
+                    "column": 22,
+                    "line": 1
+                }
+            },
+            "range": [
+                22,
+                23
+            ],
+            "type": "Punctuator",
+            "value": "{"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 24,
+                    "line": 1
+                },
+                "start": {
+                    "column": 23,
+                    "line": 1
+                }
+            },
+            "range": [
+                23,
+                24
+            ],
+            "type": "Punctuator",
+            "value": "}"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 25,
+                    "line": 1
+                },
+                "start": {
+                    "column": 24,
+                    "line": 1
+                }
+            },
+            "range": [
+                24,
+                25
+            ],
+            "type": "Punctuator",
+            "value": ">"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 27,
+                    "line": 1
+                },
+                "start": {
+                    "column": 26,
+                    "line": 1
+                }
+            },
+            "range": [
+                26,
+                27
+            ],
+            "type": "Punctuator",
+            "value": "="
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 35,
+                    "line": 1
+                },
+                "start": {
+                    "column": 28,
+                    "line": 1
+                }
+            },
+            "range": [
+                28,
+                35
+            ],
+            "type": "Identifier",
+            "value": "Success"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 36,
+                    "line": 1
+                },
+                "start": {
+                    "column": 35,
+                    "line": 1
+                }
+            },
+            "range": [
+                35,
+                36
+            ],
+            "type": "Punctuator",
+            "value": "<"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 37,
+                    "line": 1
+                },
+                "start": {
+                    "column": 36,
+                    "line": 1
+                }
+            },
+            "range": [
+                36,
+                37
+            ],
+            "type": "Identifier",
+            "value": "T"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 38,
+                    "line": 1
+                },
+                "start": {
+                    "column": 37,
+                    "line": 1
+                }
+            },
+            "range": [
+                37,
+                38
+            ],
+            "type": "Punctuator",
+            "value": ">"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 40,
+                    "line": 1
+                },
+                "start": {
+                    "column": 39,
+                    "line": 1
+                }
+            },
+            "range": [
+                39,
+                40
+            ],
+            "type": "Punctuator",
+            "value": "|"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 48,
+                    "line": 1
+                },
+                "start": {
+                    "column": 41,
+                    "line": 1
+                }
+            },
+            "range": [
+                41,
+                48
+            ],
+            "type": "Identifier",
+            "value": "Failure"
+        }
+    ],
+    "type": "Program"
+};

--- a/tests/fixtures/typescript/basics/type-alias-declaration-with-constrained-type-parameter.src.ts
+++ b/tests/fixtures/typescript/basics/type-alias-declaration-with-constrained-type-parameter.src.ts
@@ -1,0 +1,1 @@
+type Result<T extends {}> = Success<T> | Failure

--- a/tests/fixtures/typescript/basics/type-alias-declaration.result.js
+++ b/tests/fixtures/typescript/basics/type-alias-declaration.result.js
@@ -226,7 +226,8 @@ module.exports = {
                                         "column": 13
                                     }
                                 },
-                                "name": "T"
+                                "name": "T",
+                                "constraint": null
                             }
                         ]
                     }


### PR DESCRIPTION
Note that Flow uses `bound` here instead of `constraint`. I decided to go with a different property because there is some differences between Flow and TS here, however I don't have anything against aligning and require the user to use other ways to distinguish Flow and TS.