### PR TITLE
New: Add type annotation to class properties (fixes  #190)

### DIFF
--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -1082,7 +1082,8 @@ module.exports = function(ast, extra) {
                     accessibility: getTSNodeAccessibility(node),
                     decorators: (node.decorators) ? node.decorators.map(function(d) {
                         return convertChild(d.expression);
-                    }) : []
+                    }) : [],
+                    typeAnnotation: (node.type) ? convertTypeAnnotation(node.type) : null
                 });
                 break;
 

--- a/tests/fixtures/typescript/basics/class-with-accessibility-modifiers.result.js
+++ b/tests/fixtures/typescript/basics/class-with-accessibility-modifiers.result.js
@@ -90,7 +90,41 @@ module.exports = {
                         "computed": false,
                         "static": false,
                         "accessibility": "private",
-                        "decorators": []
+                        "decorators": [],
+                        "typeAnnotation": {
+                            "loc": {
+                                "end": {
+                                    "column": 22,
+                                    "line": 2
+                                },
+                                "start": {
+                                    "column": 16,
+                                    "line": 2
+                                }
+                            },
+                            "range": [
+                                28,
+                                34
+                            ],
+                            "type": "TypeAnnotation",
+                            "typeAnnotation": {
+                                "loc": {
+                                    "end": {
+                                        "column": 22,
+                                        "line": 2
+                                    },
+                                    "start": {
+                                        "column": 16,
+                                        "line": 2
+                                    }
+                                },
+                                "range": [
+                                    28,
+                                    34
+                                ],
+                                "type": "TSStringKeyword"
+                            }
+                        }
                     },
                     {
                         "type": "ClassProperty",
@@ -130,7 +164,42 @@ module.exports = {
                         "computed": false,
                         "static": true,
                         "accessibility": "public",
-                        "decorators": []
+                        "decorators": [],
+                        "typeAnnotation": {
+                            "loc": {
+                                "end": {
+                                    "column": 28,
+                                    "line": 3
+                                },
+                                "start": {
+                                    "column": 22,
+                                    "line": 3
+                                }
+                            },
+                            "range": [
+                                58,
+                                64
+                            ],
+                            "type": "TypeAnnotation",
+                            "typeAnnotation": {
+                                "loc": {
+                                    "end": {
+                                        "column": 28,
+                                        "line": 3
+                                    },
+                                    "start": {
+                                        "column": 22,
+                                        "line": 3
+                                    }
+                                },
+                                "range": [
+                                    58,
+                                    64
+                                ],
+                                "type": "TSNumberKeyword"
+                            }
+                        }
+
                     },
                     {
                         "type": "MethodDefinition",

--- a/tests/fixtures/typescript/decorators/property-decorators/property-decorator-factory-instance-member.result.js
+++ b/tests/fixtures/typescript/decorators/property-decorators/property-decorator-factory-instance-member.result.js
@@ -127,7 +127,8 @@ module.exports = {
                                 },
                                 "arguments": []
                             }
-                        ]
+                        ],
+                        "typeAnnotation": null
                     },
                     {
                         "type": "ClassProperty",
@@ -239,7 +240,8 @@ module.exports = {
                                 },
                                 "arguments": []
                             }
-                        ]
+                        ],
+                        "typeAnnotation": null
                     }
                 ],
                 "range": [

--- a/tests/fixtures/typescript/decorators/property-decorators/property-decorator-factory-static-member.result.js
+++ b/tests/fixtures/typescript/decorators/property-decorators/property-decorator-factory-static-member.result.js
@@ -147,7 +147,8 @@ module.exports = {
                                     }
                                 ]
                             }
-                        ]
+                        ],
+                        "typeAnnotation": null
                     },
                     {
                         "type": "ClassProperty",
@@ -244,7 +245,8 @@ module.exports = {
                                     }
                                 ]
                             }
-                        ]
+                        ],
+                        "typeAnnotation": null
                     }
                 ],
                 "range": [

--- a/tests/fixtures/typescript/decorators/property-decorators/property-decorator-instance-member.result.js
+++ b/tests/fixtures/typescript/decorators/property-decorators/property-decorator-instance-member.result.js
@@ -109,7 +109,8 @@ module.exports = {
                                 },
                                 "name": "foo"
                             }
-                        ]
+                        ],
+                        "typeAnnotation": null
                     },
                     {
                         "type": "ClassProperty",
@@ -168,7 +169,8 @@ module.exports = {
                                 },
                                 "name": "bar"
                             }
-                        ]
+                        ],
+                        "typeAnnotation": null
                     }
                 ],
                 "range": [

--- a/tests/fixtures/typescript/decorators/property-decorators/property-decorator-static-member.result.js
+++ b/tests/fixtures/typescript/decorators/property-decorators/property-decorator-static-member.result.js
@@ -109,7 +109,8 @@ module.exports = {
                                 },
                                 "name": "baz"
                             }
-                        ]
+                        ],
+                        "typeAnnotation": null
                     },
                     {
                         "type": "ClassProperty",
@@ -168,7 +169,8 @@ module.exports = {
                                 },
                                 "name": "qux"
                             }
-                        ]
+                        ],
+                        "typeAnnotation": null
                     }
                 ],
                 "range": [


### PR DESCRIPTION
Type information is preserved for interface properties and object type literals, seems to just be missing on class properties.