### PR TITLE
Update: Open TS peerDependency, warn non-supported version (fixes #167)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,13 @@ A parser that converts TypeScript into an [ESTree](https://github.com/estree/est
 
 ## Supported TypeScript Version
 
-The version of TypeScript supported by this parser is `~2.2.1`. This is reflected in the `peerDependency` requirement within the package.json file.
+We will always endeavor to support the latest stable version of TypeScript.
 
-**Please ensure that you are using this version before submitting any issues.**
+The version of TypeScript currently supported by this parser is `~2.2.1`. This is reflected in the `devDependency` requirement within the package.json file, and it is what the tests will be run against. We have an open `peerDependency` requirement in order to allow for experimentation on newer/beta versions of TypeScript.
+
+If you use a non-supported version of TypeScript, the parser will log a warning to the console.
+
+**Please ensure that you are using a supported version before submitting any issues/bug reports.**
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -52,9 +52,10 @@
   },
   "dependencies": {
     "lodash.unescape": "4.0.0",
-    "object-assign": "^4.0.1"
+    "object-assign": "^4.0.1",
+    "semver": "^4.3.6"
   },
   "peerDependencies": {
-    "typescript": "~2.2.1"
+    "typescript": "*"
   }
 }

--- a/parser.js
+++ b/parser.js
@@ -9,7 +9,27 @@
 "use strict";
 
 var astNodeTypes = require("./lib/ast-node-types"),
-    ts = require("typescript");
+    ts = require("typescript"),
+    semver = require("semver");
+
+var SUPPORTED_TYPESCRIPT_VERSIONS = require("./package.json").devDependencies.typescript;
+var ACTIVE_TYPESCRIPT_VERSION = ts.version;
+
+var isRunningSupportedTypeScriptVersion = semver.satisfies(ACTIVE_TYPESCRIPT_VERSION, SUPPORTED_TYPESCRIPT_VERSIONS);
+
+if (!isRunningSupportedTypeScriptVersion) {
+    var border = "=============";
+    var versionWarning = [
+        border,
+        "WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-eslint-parser.",
+        "You may find that it works just fine, or you may not.",
+        "SUPPORTED TYPESCRIPT VERSIONS: " + SUPPORTED_TYPESCRIPT_VERSIONS,
+        "YOUR TYPESCRIPT VERSION: " + ACTIVE_TYPESCRIPT_VERSION,
+        "Please only submit bug reports when using the officially supported version.",
+        border
+    ];
+    console.warn(versionWarning.join("\n\n"));
+}
 
 var extra;
 


### PR DESCRIPTION
This would be one way to address https://github.com/eslint/typescript-eslint-parser/issues/167

Still not sure how I feel about it, but thought I would stick a working example on a branch and look for feedback.

@soda0289 @eslint/eslint-team 