### PR TITLE
Fix: Convert MetaProperty (new.target) nodes correcly (fixes #194)

### DIFF
--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -1819,23 +1819,27 @@ module.exports = function(ast, extra) {
                 break;
 
             case SyntaxKind.NewExpression:
-
-                // new.target
-                if (node.expression.kind === SyntaxKind.PropertyAccessExpression) {
-                    assign(result, {
-                        type: "MetaProperty",
-                        meta: convertChild(node.expression.name),
-                        property: convertChild(node.expression.propertyName)
-                    });
-                } else {
-                    assign(result, {
-                        type: "NewExpression",
-                        callee: convertChild(node.expression),
-                        arguments: (node.arguments) ? node.arguments.map(convertChild) : []
-                    });
-                }
+                assign(result, {
+                    type: "NewExpression",
+                    callee: convertChild(node.expression),
+                    arguments: (node.arguments) ? node.arguments.map(convertChild) : []
+                });
                 break;
 
+            case SyntaxKind.MetaProperty:
+                var newToken = convertToken(node.getFirstToken(), ast);
+
+                assign(result, {
+                    type: "MetaProperty",
+                    meta: {
+                        type: "Identifier",
+                        range: newToken.range,
+                        loc: newToken.loc,
+                        name: "new"
+                    },
+                    property: convertChild(node.name)
+                });
+                break;
 
 
             // Literals

--- a/tests/fixtures/basics/new-with-member-expression.result.js
+++ b/tests/fixtures/basics/new-with-member-expression.result.js
@@ -1,0 +1,237 @@
+module.exports = {
+    "type": "Program",
+    "range": [
+        0,
+        14
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 14
+        }
+    },
+    "body": [
+        {
+            "type": "ExpressionStatement",
+            "range": [
+                0,
+                14
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            },
+            "expression": {
+                "type": "NewExpression",
+                "range": [
+                    0,
+                    13
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 13
+                    }
+                },
+                "callee": {
+                    "type": "MemberExpression",
+                    "range": [
+                        4,
+                        11
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 11
+                        }
+                    },
+                    "object": {
+                        "type": "Identifier",
+                        "range": [
+                            4,
+                            7
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 7
+                            }
+                        },
+                        "name": "foo"
+                    },
+                    "property": {
+                        "type": "Identifier",
+                        "range": [
+                            8,
+                            11
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 8
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 11
+                            }
+                        },
+                        "name": "bar"
+                    },
+                    "computed": false
+                },
+                "arguments": []
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "new",
+            "range": [
+                0,
+                3
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 3
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "range": [
+                4,
+                7
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 4
+                },
+                "end": {
+                    "line": 1,
+                    "column": 7
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "range": [
+                7,
+                8
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 7
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "range": [
+                8,
+                11
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 8
+                },
+                "end": {
+                    "line": 1,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                11,
+                12
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 11
+                },
+                "end": {
+                    "line": 1,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                12,
+                13
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 12
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                13,
+                14
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            }
+        }
+    ]
+};

--- a/tests/fixtures/basics/new-with-member-expression.src.js
+++ b/tests/fixtures/basics/new-with-member-expression.src.js
@@ -1,0 +1,1 @@
+new foo.bar();

--- a/tests/lib/ecma-features.js
+++ b/tests/lib/ecma-features.js
@@ -41,7 +41,7 @@ var testFiles = shelljs.find(FIXTURES_DIR).filter(function(filename) {
 }).map(function(filename) {
     return filename.substring(FIXTURES_DIR.length - 1, filename.length - 7);  // strip off ".src.js"
 }).filter(function(filename) {
-    return !(/error\-|invalid\-|globalReturn|experimental|newTarget/.test(filename));
+    return !(/error\-|invalid\-|globalReturn|experimental/.test(filename));
 });
 
 // var moduleTestFiles = testFiles.filter(function(filename) {


### PR DESCRIPTION
The MetaProperty node was added a couple of months ago into typescript. I think it landed in 2.2.
https://github.com/Microsoft/TypeScript/pull/12783

I have to create a identifier node for 'new' since it is not part of the typescript metaproperty node.