### PR TITLE
Breaking: Normalzie type parameters (fixes #197)

### DIFF
--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -709,6 +709,14 @@ module.exports = function(ast, extra) {
             }).forEach(function(key) {
                 if (key === "type") {
                     result.typeAnnotation = (node.type) ? convertTypeAnnotation(node.type) : null;
+                } else if (key === "typeArguments") {
+                    result.typeParameters = (node.typeArguments)
+                        ? convertTypeArgumentsToTypeParameters(node.typeArguments)
+                        : null;
+                } else if (key === "typeParameters") {
+                    result.typeParameters = (node.typeParameters)
+                        ? convertTSTypeParametersToTypeParametersDeclaration(node.typeParameters)
+                        : null;
                 } else {
                     if (Array.isArray(node[key])) {
                         result[key] = node[key].map(convertChild);

--- a/tests/fixtures/typescript/basics/abstract-class-with-abstract-method.result.js
+++ b/tests/fixtures/typescript/basics/abstract-class-with-abstract-method.result.js
@@ -159,25 +159,60 @@ module.exports = {
                                             },
                                             "name": "Promise"
                                         },
-                                        "typeArguments": [
-                                            {
-                                                "type": "TSStringKeyword",
-                                                "range": [
-                                                    76,
-                                                    82
-                                                ],
-                                                "loc": {
-                                                    "start": {
-                                                        "line": 2,
-                                                        "column": 37
-                                                    },
-                                                    "end": {
-                                                        "line": 2,
-                                                        "column": 43
-                                                    }
+                                        "typeParameters": {
+                                            "loc": {
+                                                "end": {
+                                                    "column": 44,
+                                                    "line": 2
+                                                },
+                                                "start": {
+                                                    "column": 36,
+                                                    "line": 2
                                                 }
-                                            }
-                                        ]
+                                            },
+                                            "params": [
+                                                {
+                                                    "id": {
+                                                        "loc": {
+                                                            "end": {
+                                                                "column": 43,
+                                                                "line": 2
+                                                            },
+                                                            "start": {
+                                                                "column": 37,
+                                                                "line": 2
+                                                            }
+                                                        },
+                                                        "range": [
+                                                            76,
+                                                            82
+                                                        ],
+                                                        "type": "TSStringKeyword"
+                                                    },
+                                                    "loc": {
+                                                        "end": {
+                                                            "column": 43,
+                                                            "line": 2
+                                                        },
+                                                        "start": {
+                                                            "column": 37,
+                                                            "line": 2
+                                                        }
+                                                    },
+                                                    "range": [
+                                                        76,
+                                                        82
+                                                    ],
+                                                    "type": "GenericTypeAnnotation",
+                                                    "typeParameters": null
+                                                }
+                                            ],
+                                            "range": [
+                                                75,
+                                                83
+                                            ],
+                                            "type": "TypeParameterInstantiation"
+                                        }
                                     }
                                 },
                                 "params": []

--- a/tests/fixtures/typescript/basics/abstract-class-with-optional-method.result.js
+++ b/tests/fixtures/typescript/basics/abstract-class-with-optional-method.result.js
@@ -97,25 +97,6 @@ module.exports = {
                                             75
                                         ],
                                         "type": "TSTypeReference",
-                                        "typeArguments": [
-                                            {
-                                                "loc": {
-                                                    "end": {
-                                                        "column": 35,
-                                                        "line": 2
-                                                    },
-                                                    "start": {
-                                                        "column": 29,
-                                                        "line": 2
-                                                    }
-                                                },
-                                                "range": [
-                                                    68,
-                                                    74
-                                                ],
-                                                "type": "TSStringKeyword"
-                                            }
-                                        ],
                                         "typeName": {
                                             "loc": {
                                                 "end": {
@@ -133,6 +114,60 @@ module.exports = {
                                                 67
                                             ],
                                             "type": "Identifier"
+                                        },
+                                        "typeParameters": {
+                                            "loc": {
+                                                "end": {
+                                                    "column": 36,
+                                                    "line": 2
+                                                },
+                                                "start": {
+                                                    "column": 28,
+                                                    "line": 2
+                                                }
+                                            },
+                                            "params": [
+                                                {
+                                                    "id": {
+                                                        "loc": {
+                                                            "end": {
+                                                                "column": 35,
+                                                                "line": 2
+                                                            },
+                                                            "start": {
+                                                                "column": 29,
+                                                                "line": 2
+                                                            }
+                                                        },
+                                                        "range": [
+                                                            68,
+                                                            74
+                                                        ],
+                                                        "type": "TSStringKeyword"
+                                                    },
+                                                    "loc": {
+                                                        "end": {
+                                                            "column": 35,
+                                                            "line": 2
+                                                        },
+                                                        "start": {
+                                                            "column": 29,
+                                                            "line": 2
+                                                        }
+                                                    },
+                                                    "range": [
+                                                        68,
+                                                        74
+                                                    ],
+                                                    "type": "GenericTypeAnnotation",
+                                                    "typeParameters": null
+                                                }
+                                            ],
+                                            "range": [
+                                                67,
+                                                75
+                                            ],
+                                            "type": "TypeParameterInstantiation"
                                         }
                                     }
                                 },

--- a/tests/fixtures/typescript/basics/class-with-mixin.result.js
+++ b/tests/fixtures/typescript/basics/class-with-mixin.result.js
@@ -300,26 +300,61 @@ module.exports = {
                                     },
                                     "name": "Constructor"
                                 },
-                                "typeArguments": [
-                                    {
-                                        "type": "TSTypeLiteral",
-                                        "range": [
-                                            33,
-                                            35
-                                        ],
-                                        "loc": {
-                                            "start": {
-                                                "line": 1,
-                                                "column": 33
-                                            },
-                                            "end": {
-                                                "line": 1,
-                                                "column": 35
-                                            }
+                                "typeParameters": {
+                                    "loc": {
+                                        "end": {
+                                            "column": 36,
+                                            "line": 1
                                         },
-                                        "members": []
-                                    }
-                                ]
+                                        "start": {
+                                            "column": 32,
+                                            "line": 1
+                                        }
+                                    },
+                                    "params": [
+                                        {
+                                            "id": {
+                                                "loc": {
+                                                    "end": {
+                                                        "column": 35,
+                                                        "line": 1
+                                                    },
+                                                    "start": {
+                                                        "column": 33,
+                                                        "line": 1
+                                                    }
+                                                },
+                                                "members": [],
+                                                "range": [
+                                                    33,
+                                                    35
+                                                ],
+                                                "type": "TSTypeLiteral"
+                                            },
+                                            "loc": {
+                                                "end": {
+                                                    "column": 35,
+                                                    "line": 1
+                                                },
+                                                "start": {
+                                                    "column": 33,
+                                                    "line": 1
+                                                }
+                                            },
+                                            "range": [
+                                                33,
+                                                35
+                                            ],
+                                            "type": "GenericTypeAnnotation",
+                                            "typeParameters": null
+                                        }
+                                    ],
+                                    "range": [
+                                        32,
+                                        36
+                                    ],
+                                    "type": "TypeParameterInstantiation"
+                                }
                             }
                         }
                     }
@@ -656,6 +691,7 @@ module.exports = {
             "declarations": [
                 {
                     "type": "VariableDeclarator",
+                    "typeParameters": null,
                     "id": {
                         "type": "Identifier",
                         "range": [
@@ -778,6 +814,7 @@ module.exports = {
                                 }
                             }
                         ],
+                        "typeParameters": null,
                         "typeAnnotation": {
                             "type": "TypeAnnotation",
                             "loc": {

--- a/tests/fixtures/typescript/basics/export-type-function-declaration.result.js
+++ b/tests/fixtures/typescript/basics/export-type-function-declaration.result.js
@@ -99,6 +99,7 @@ module.exports = {
                                     "column": 27
                                 }
                             },
+                            "typeParameters": null,
                             "parameters": [
                                 {
                                     "type": "Identifier",

--- a/tests/fixtures/typescript/basics/function-with-types-assignation.result.js
+++ b/tests/fixtures/typescript/basics/function-with-types-assignation.result.js
@@ -1,899 +1,936 @@
 module.exports = {
-  "type": "Program",
-  "range": [
-    0,
-    96
-  ],
-  "loc": {
-    "end": {
-      "line": 3,
-      "column": 1
-    },
-    "start": {
-      "line": 1,
-      "column": 0
-    }
-  },
-  "body": [
-    {
-      "async": false,
-      "body": {
-        "body": [
-          {
-            "argument": {
-              "type": "Identifier",
-              "range": [
-                89,
-                93
-              ],
-              "loc": {
-                "end": {
-                  "line": 2,
-                  "column": 13
-                },
-                "start": {
-                  "line": 2,
-                  "column": 9
-                }
-              },
-              "name": "name"
-            },
-            "type": "ReturnStatement",
-            "range": [
-              82,
-              94
-            ],
-            "loc": {
-              "end": {
-                "line": 2,
-                "column": 14
-              },
-              "start": {
-                "line": 2,
-                "column": 2
-              }
-            }
-          }
-        ],
-        "type": "BlockStatement",
-        "range": [
-          78,
-          96
-        ],
-        "loc": {
-          "end": {
+    "type": "Program",
+    "range": [
+        0,
+        96
+    ],
+    "loc": {
+        "end": {
             "line": 3,
             "column": 1
-          },
-          "start": {
-            "line": 1,
-            "column": 78
-          }
-        }
-      },
-      "expression": false,
-      "generator": false,
-      "id": {
-        "type": "Identifier",
-        "range": [
-          9,
-          16
-        ],
-        "loc": {
-          "end": {
-            "line": 1,
-            "column": 16
-          },
-          "start": {
-            "line": 1,
-            "column": 9
-          }
-        },
-        "name": "message"
-      },
-      "type": "FunctionDeclaration",
-      "range": [
-        0,
-        96
-      ],
-      "loc": {
-        "end": {
-          "line": 3,
-          "column": 1
         },
         "start": {
-          "line": 1,
-          "column": 0
+            "line": 1,
+            "column": 0
         }
-      },
-      "params": [
+    },
+    "body": [
         {
-          "loc": {
-            "end": {
-              "line": 1,
-              "column": 21
-            },
-            "start": {
-              "line": 1,
-              "column": 17
-            }
-          },
-          "name": "name",
-          "range": [
-            17,
-            21
-          ],
-          "type": "Identifier",
-          "typeAnnotation": {
-            "type": "TypeAnnotation",
-            "range": [
-              22,
-              28
-            ],
-            "loc": {
-              "end": {
-                "line": 1,
-                "column": 28
-              },
-              "start": {
-                "line": 1,
-                "column": 22
-              }
-            },
-            "typeAnnotation": {
-              "type": "TSStringKeyword",
-              "range": [
-                22,
-                28
-              ],
-              "loc": {
-                "end": {
-                  "line": 1,
-                  "column": 28
-                },
-                "start": {
-                  "line": 1,
-                  "column": 22
-                }
-              }
-            }
-          }
-        },
-        {
-          "type": "AssignmentPattern",
-          "range": [
-            30,
-            46
-          ],
-          "loc": {
-            "end": {
-              "line": 1,
-              "column": 46
-            },
-            "start": {
-              "line": 1,
-              "column": 30
-            }
-          },
-          "left": {
-            "type": "Identifier",
-            "range": [
-              30,
-              33
-            ],
-            "loc": {
-              "end": {
-                "line": 1,
-                "column": 33
-              },
-              "start": {
-                "line": 1,
-                "column": 30
-              }
-            },
-            "name": "age",
-            "typeAnnotation": {
-              "type": "TypeAnnotation",
-              "range": [
-                34,
-                40
-              ],
-              "loc": {
-                "end": {
-                  "line": 1,
-                  "column": 40
-                },
-                "start": {
-                  "line": 1,
-                  "column": 34
-                }
-              },
-              "typeAnnotation": {
-                "type": "TSNumberKeyword",
+            "async": false,
+            "body": {
+                "body": [
+                    {
+                        "argument": {
+                            "type": "Identifier",
+                            "range": [
+                                89,
+                                93
+                            ],
+                            "loc": {
+                                "end": {
+                                    "line": 2,
+                                    "column": 13
+                                },
+                                "start": {
+                                    "line": 2,
+                                    "column": 9
+                                }
+                            },
+                            "name": "name"
+                        },
+                        "type": "ReturnStatement",
+                        "range": [
+                            82,
+                            94
+                        ],
+                        "loc": {
+                            "end": {
+                                "line": 2,
+                                "column": 14
+                            },
+                            "start": {
+                                "line": 2,
+                                "column": 2
+                            }
+                        }
+                    }
+                ],
+                "type": "BlockStatement",
                 "range": [
-                  34,
-                  40
-                ],"loc": {
-                  "end": {
-                    "line": 1,
-                    "column": 40
-                  },
-                  "start": {
-                    "line": 1,
-                    "column": 34
-                  }
-                }
-              }
-            }
-          },
-          "right": {
-            "type": "Literal",
-            "range": [
-              43,
-              46
-            ],
-            "loc": {
-              "end": {
-                "line": 1,
-                "column": 46
-              },
-              "start": {
-                "line": 1,
-                "column": 43
-              }
-            },
-            "raw": "100",
-            "value": 100
-          }
-        },
-        {
-          "argument": {
-            "loc": {
-              "end": {
-                "line": 1,
-                "column": 55
-              },
-              "start": {
-                "line": 1,
-                "column": 51
-              }
-            },
-            "name": "args",
-            "range": [
-              51,
-              55
-            ],
-            "type": "Identifier",
-            "typeAnnotation": {
-              "loc": {
-                "end": {
-                  "line": 1,
-                  "column": 69
-                },
-                "start": {
-                  "line": 1,
-                  "column": 56
-                }
-              },
-              "range": [
-                56,
-                69
-              ],
-              "type": "TypeAnnotation",
-              "typeAnnotation": {
+                    78,
+                    96
+                ],
                 "loc": {
-                  "end": {
-                    "line": 1,
-                    "column": 69
-                  },
-                  "start": {
-                    "line": 1,
-                    "column": 56
-                  }
-                },
-                "range": [
-                  56,
-                  69
-                ],
-                "type": "TSTypeReference",
-                "typeArguments": [
-                  {
-                    "loc": {
-                      "end": {
-                        "line": 1,
-                        "column": 68
-                      },
-                      "start": {
-                        "line": 1,
-                        "column": 62
-                      }
-                    },
-                    "range": [
-                      62,
-                      68
-                    ],
-                    "type": "TSStringKeyword"
-                  }
-                ],
-                "typeName": {
-                  "loc": {
                     "end": {
-                      "line": 1,
-                      "column": 61
+                        "line": 3,
+                        "column": 1
                     },
                     "start": {
-                      "line": 1,
-                      "column": 56
+                        "line": 1,
+                        "column": 78
                     }
-                  },
-                  "name": "Array",
-                  "range": [
-                    56,
-                    61
-                  ],
-                  "type": "Identifier"
                 }
-              }
-            }
-          },
-          "loc": {
-            "end": {
-              "line": 1,
-              "column": 69
             },
-            "start": {
-              "line": 1,
-              "column": 48
-            }
-          },
-          "range": [
-            48,
-            69
-          ],
-          "type": "RestElement"
-        }
-      ],
-      "returnType": {
-        "type": "TypeAnnotation",
-        "range": [
-          71,
-          77
-        ],
-        "loc": {
-          "end": {
-            "line": 1,
-            "column": 77
-          },
-          "start": {
-            "line": 1,
-            "column": 71
-          }
-        },
-        "typeAnnotation": {
-          "type": "TSStringKeyword",
-          "range": [
-            71,
-            77
-          ],
-          "loc": {
-            "end": {
-              "line": 1,
-              "column": 77
+            "expression": false,
+            "generator": false,
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    9,
+                    16
+                ],
+                "loc": {
+                    "end": {
+                        "line": 1,
+                        "column": 16
+                    },
+                    "start": {
+                        "line": 1,
+                        "column": 9
+                    }
+                },
+                "name": "message"
             },
-            "start": {
-              "line": 1,
-              "column": 71
+            "type": "FunctionDeclaration",
+            "range": [
+                0,
+                96
+            ],
+            "loc": {
+                "end": {
+                    "line": 3,
+                    "column": 1
+                },
+                "start": {
+                    "line": 1,
+                    "column": 0
+                }
+            },
+            "params": [
+                {
+                    "loc": {
+                        "end": {
+                            "line": 1,
+                            "column": 21
+                        },
+                        "start": {
+                            "line": 1,
+                            "column": 17
+                        }
+                    },
+                    "name": "name",
+                    "range": [
+                        17,
+                        21
+                    ],
+                    "type": "Identifier",
+                    "typeAnnotation": {
+                        "type": "TypeAnnotation",
+                        "range": [
+                            22,
+                            28
+                        ],
+                        "loc": {
+                            "end": {
+                                "line": 1,
+                                "column": 28
+                            },
+                            "start": {
+                                "line": 1,
+                                "column": 22
+                            }
+                        },
+                        "typeAnnotation": {
+                            "type": "TSStringKeyword",
+                            "range": [
+                                22,
+                                28
+                            ],
+                            "loc": {
+                                "end": {
+                                    "line": 1,
+                                    "column": 28
+                                },
+                                "start": {
+                                    "line": 1,
+                                    "column": 22
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "AssignmentPattern",
+                    "range": [
+                        30,
+                        46
+                    ],
+                    "loc": {
+                        "end": {
+                            "line": 1,
+                            "column": 46
+                        },
+                        "start": {
+                            "line": 1,
+                            "column": 30
+                        }
+                    },
+                    "left": {
+                        "type": "Identifier",
+                        "range": [
+                            30,
+                            33
+                        ],
+                        "loc": {
+                            "end": {
+                                "line": 1,
+                                "column": 33
+                            },
+                            "start": {
+                                "line": 1,
+                                "column": 30
+                            }
+                        },
+                        "name": "age",
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "range": [
+                                34,
+                                40
+                            ],
+                            "loc": {
+                                "end": {
+                                    "line": 1,
+                                    "column": 40
+                                },
+                                "start": {
+                                    "line": 1,
+                                    "column": 34
+                                }
+                            },
+                            "typeAnnotation": {
+                                "type": "TSNumberKeyword",
+                                "range": [
+                                    34,
+                                    40
+                                ],
+                                "loc": {
+                                    "end": {
+                                        "line": 1,
+                                        "column": 40
+                                    },
+                                    "start": {
+                                        "line": 1,
+                                        "column": 34
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "right": {
+                        "type": "Literal",
+                        "range": [
+                            43,
+                            46
+                        ],
+                        "loc": {
+                            "end": {
+                                "line": 1,
+                                "column": 46
+                            },
+                            "start": {
+                                "line": 1,
+                                "column": 43
+                            }
+                        },
+                        "raw": "100",
+                        "value": 100
+                    }
+                },
+                {
+                    "argument": {
+                        "loc": {
+                            "end": {
+                                "line": 1,
+                                "column": 55
+                            },
+                            "start": {
+                                "line": 1,
+                                "column": 51
+                            }
+                        },
+                        "name": "args",
+                        "range": [
+                            51,
+                            55
+                        ],
+                        "type": "Identifier",
+                        "typeAnnotation": {
+                            "loc": {
+                                "end": {
+                                    "line": 1,
+                                    "column": 69
+                                },
+                                "start": {
+                                    "line": 1,
+                                    "column": 56
+                                }
+                            },
+                            "range": [
+                                56,
+                                69
+                            ],
+                            "type": "TypeAnnotation",
+                            "typeAnnotation": {
+                                "loc": {
+                                    "end": {
+                                        "line": 1,
+                                        "column": 69
+                                    },
+                                    "start": {
+                                        "line": 1,
+                                        "column": 56
+                                    }
+                                },
+                                "range": [
+                                    56,
+                                    69
+                                ],
+                                "type": "TSTypeReference",
+                                "typeName": {
+                                    "loc": {
+                                        "end": {
+                                            "line": 1,
+                                            "column": 61
+                                        },
+                                        "start": {
+                                            "line": 1,
+                                            "column": 56
+                                        }
+                                    },
+                                    "name": "Array",
+                                    "range": [
+                                        56,
+                                        61
+                                    ],
+                                    "type": "Identifier"
+                                },
+                                "typeParameters": {
+                                    "loc": {
+                                        "end": {
+                                            "column": 69,
+                                            "line": 1
+                                        },
+                                        "start": {
+                                            "column": 61,
+                                            "line": 1
+                                        }
+                                    },
+                                    "params": [
+                                        {
+                                            "id": {
+                                                "loc": {
+                                                    "end": {
+                                                        "column": 68,
+                                                        "line": 1
+                                                    },
+                                                    "start": {
+                                                        "column": 62,
+                                                        "line": 1
+                                                    }
+                                                },
+                                                "range": [
+                                                    62,
+                                                    68
+                                                ],
+                                                "type": "TSStringKeyword"
+                                            },
+
+                                            "loc": {
+                                                "end": {
+                                                    "column": 68,
+                                                    "line": 1
+                                                },
+                                                "start": {
+                                                    "column": 62,
+                                                    "line": 1
+                                                }
+                                            },
+                                            "range": [
+                                                62,
+                                                68
+                                            ],
+                                            "type": "GenericTypeAnnotation",
+                                            "typeParameters": null
+                                        }
+                                    ],
+                                    "range": [
+                                        61,
+                                        69
+                                    ],
+                                    "type": "TypeParameterInstantiation"
+                                }
+                            }
+                        }
+                    },
+                    "loc": {
+                        "end": {
+                            "line": 1,
+                            "column": 69
+                        },
+                        "start": {
+                            "line": 1,
+                            "column": 48
+                        }
+                    },
+                    "range": [
+                        48,
+                        69
+                    ],
+                    "type": "RestElement"
+                }
+            ],
+            "returnType": {
+                "type": "TypeAnnotation",
+                "range": [
+                    71,
+                    77
+                ],
+                "loc": {
+                    "end": {
+                        "line": 1,
+                        "column": 77
+                    },
+                    "start": {
+                        "line": 1,
+                        "column": 71
+                    }
+                },
+                "typeAnnotation": {
+                    "type": "TSStringKeyword",
+                    "range": [
+                        71,
+                        77
+                    ],
+                    "loc": {
+                        "end": {
+                            "line": 1,
+                            "column": 77
+                        },
+                        "start": {
+                            "line": 1,
+                            "column": 71
+                        }
+                    }
+                }
             }
-          }
         }
-      },
-    }
-  ],
-  "sourceType": "script",
-  "tokens": [
+    ],
+    "sourceType": "script",
+    "tokens": [
         {
-      "type": "Keyword",
-      "range": [
-        0,
-        8
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 8
+            "type": "Keyword",
+            "range": [
+                0,
+                8
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 8
+                },
+                "start": {
+                    "line": 1,
+                    "column": 0
+                }
+            },
+            "value": "function"
         },
-        "start": {
-          "line": 1,
-          "column": 0
-        }
-      },
-      "value": "function"
-    },
-    {
-      "type": "Identifier",
-      "range": [
-        9,
-        16
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 16
+        {
+            "type": "Identifier",
+            "range": [
+                9,
+                16
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 16
+                },
+                "start": {
+                    "line": 1,
+                    "column": 9
+                }
+            },
+            "value": "message"
         },
-        "start": {
-          "line": 1,
-          "column": 9
-        }
-      },
-      "value": "message"
-    },
-    {
-      "type": "Punctuator",
-      "range": [
-        16,
-        17
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 17
+        {
+            "type": "Punctuator",
+            "range": [
+                16,
+                17
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 17
+                },
+                "start": {
+                    "line": 1,
+                    "column": 16
+                }
+            },
+            "value": "("
         },
-        "start": {
-          "line": 1,
-          "column": 16
-        }
-      },
-      "value": "("
-    },
-    {
-      "type": "Identifier",
-      "range": [
-        17,
-        21
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 21
+        {
+            "type": "Identifier",
+            "range": [
+                17,
+                21
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 21
+                },
+                "start": {
+                    "line": 1,
+                    "column": 17
+                }
+            },
+            "value": "name"
         },
-        "start": {
-          "line": 1,
-          "column": 17
-        }
-      },
-      "value": "name"
-    },
-    {
-      "type": "Punctuator",
-      "range": [
-        21,
-        22
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 22
+        {
+            "type": "Punctuator",
+            "range": [
+                21,
+                22
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 22
+                },
+                "start": {
+                    "line": 1,
+                    "column": 21
+                }
+            },
+            "value": ":"
         },
-        "start": {
-          "line": 1,
-          "column": 21
-        }
-      },
-      "value": ":"
-    },
-    {
-      "type": "Identifier",
-      "range": [
-        22,
-        28
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 28
+        {
+            "type": "Identifier",
+            "range": [
+                22,
+                28
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 28
+                },
+                "start": {
+                    "line": 1,
+                    "column": 22
+                }
+            },
+            "value": "string"
         },
-        "start": {
-          "line": 1,
-          "column": 22
-        }
-      },
-      "value": "string"
-    },
-    {
-      "type": "Punctuator",
-      "range": [
-        28,
-        29
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 29
+        {
+            "type": "Punctuator",
+            "range": [
+                28,
+                29
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 29
+                },
+                "start": {
+                    "line": 1,
+                    "column": 28
+                }
+            },
+            "value": ","
         },
-        "start": {
-          "line": 1,
-          "column": 28
-        }
-      },
-      "value": ","
-    },
-    {
-      "type": "Identifier",
-      "range": [
-        30,
-        33
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 33
+        {
+            "type": "Identifier",
+            "range": [
+                30,
+                33
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 33
+                },
+                "start": {
+                    "line": 1,
+                    "column": 30
+                }
+            },
+            "value": "age"
         },
-        "start": {
-          "line": 1,
-          "column": 30
-        }
-      },
-      "value": "age"
-    },
-    {
-      "type": "Punctuator",
-      "range": [
-        33,
-        34
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 34
+        {
+            "type": "Punctuator",
+            "range": [
+                33,
+                34
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 34
+                },
+                "start": {
+                    "line": 1,
+                    "column": 33
+                }
+            },
+            "value": ":"
         },
-        "start": {
-          "line": 1,
-          "column": 33
-        }
-      },
-      "value": ":"
-    },
-    {
-      "type": "Identifier",
-      "range": [
-        34,
-        40
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 40
+        {
+            "type": "Identifier",
+            "range": [
+                34,
+                40
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 40
+                },
+                "start": {
+                    "line": 1,
+                    "column": 34
+                }
+            },
+            "value": "number"
         },
-        "start": {
-          "line": 1,
-          "column": 34
-        }
-      },
-      "value": "number"
-    },
-    {
-      "type": "Punctuator",
-      "range": [
-        41,
-        42
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 42
+        {
+            "type": "Punctuator",
+            "range": [
+                41,
+                42
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 42
+                },
+                "start": {
+                    "line": 1,
+                    "column": 41
+                }
+            },
+            "value": "="
         },
-        "start": {
-          "line": 1,
-          "column": 41
-        }
-      },
-      "value": "="
-    },
-    {
-      "type": "Numeric",
-      "range": [
-        43,
-        46
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 46
+        {
+            "type": "Numeric",
+            "range": [
+                43,
+                46
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 46
+                },
+                "start": {
+                    "line": 1,
+                    "column": 43
+                }
+            },
+            "value": "100"
         },
-        "start": {
-          "line": 1,
-          "column": 43
-        }
-      },
-      "value": "100"
-    },
-    {
-      "type": "Punctuator",
-      "range": [
-        46,
-        47
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 47
+        {
+            "type": "Punctuator",
+            "range": [
+                46,
+                47
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 47
+                },
+                "start": {
+                    "line": 1,
+                    "column": 46
+                }
+            },
+            "value": ","
         },
-        "start": {
-          "line": 1,
-          "column": 46
-        }
-      },
-      "value": ","
-    },
-    {
-      "type": "Punctuator",
-      "range": [
-        48,
-        51
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 51
+        {
+            "type": "Punctuator",
+            "range": [
+                48,
+                51
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 51
+                },
+                "start": {
+                    "line": 1,
+                    "column": 48
+                }
+            },
+            "value": "..."
         },
-        "start": {
-          "line": 1,
-          "column": 48
-        }
-      },
-      "value": "..."
-    },
-    {
-      "type": "Identifier",
-      "range": [
-        51,
-        55
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 55
+        {
+            "type": "Identifier",
+            "range": [
+                51,
+                55
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 55
+                },
+                "start": {
+                    "line": 1,
+                    "column": 51
+                }
+            },
+            "value": "args"
         },
-        "start": {
-          "line": 1,
-          "column": 51
-        }
-      },
-      "value": "args"
-    },
-    {
-      "type": "Punctuator",
-      "range": [
-        55,
-        56
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 56
+        {
+            "type": "Punctuator",
+            "range": [
+                55,
+                56
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 56
+                },
+                "start": {
+                    "line": 1,
+                    "column": 55
+                }
+            },
+            "value": ":"
         },
-        "start": {
-          "line": 1,
-          "column": 55
-        }
-      },
-      "value": ":"
-    },
-    {
-      "type": "Identifier",
-      "range": [
-        56,
-        61
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 61
+        {
+            "type": "Identifier",
+            "range": [
+                56,
+                61
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 61
+                },
+                "start": {
+                    "line": 1,
+                    "column": 56
+                }
+            },
+            "value": "Array"
         },
-        "start": {
-          "line": 1,
-          "column": 56
-        }
-      },
-      "value": "Array"
-    },
-    {
-      "type": "Punctuator",
-      "range": [
-        61,
-        62
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 62
+        {
+            "type": "Punctuator",
+            "range": [
+                61,
+                62
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 62
+                },
+                "start": {
+                    "line": 1,
+                    "column": 61
+                }
+            },
+            "value": "<"
         },
-        "start": {
-          "line": 1,
-          "column": 61
-        }
-      },
-      "value": "<"
-    },
-    {
-      "type": "Identifier",
-      "range": [
-        62,
-        68
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 68
+        {
+            "type": "Identifier",
+            "range": [
+                62,
+                68
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 68
+                },
+                "start": {
+                    "line": 1,
+                    "column": 62
+                }
+            },
+            "value": "string"
         },
-        "start": {
-          "line": 1,
-          "column": 62
-        }
-      },
-      "value": "string"
-    },
-    {
-      "type": "Punctuator",
-      "range": [
-        68,
-        69
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 69
+        {
+            "type": "Punctuator",
+            "range": [
+                68,
+                69
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 69
+                },
+                "start": {
+                    "line": 1,
+                    "column": 68
+                }
+            },
+            "value": ">"
         },
-        "start": {
-          "line": 1,
-          "column": 68
-        }
-      },
-      "value": ">"
-    },
-    {
-      "type": "Punctuator",
-      "range": [
-        69,
-        70
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 70
+        {
+            "type": "Punctuator",
+            "range": [
+                69,
+                70
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 70
+                },
+                "start": {
+                    "line": 1,
+                    "column": 69
+                }
+            },
+            "value": ")"
         },
-        "start": {
-          "line": 1,
-          "column": 69
-        }
-      },
-      "value": ")"
-    },
-    {
-      "type": "Punctuator",
-      "range": [
-        70,
-        71
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 71
+        {
+            "type": "Punctuator",
+            "range": [
+                70,
+                71
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 71
+                },
+                "start": {
+                    "line": 1,
+                    "column": 70
+                }
+            },
+            "value": ":"
         },
-        "start": {
-          "line": 1,
-          "column": 70
-        }
-      },
-      "value": ":"
-    },
-    {
-      "type": "Identifier",
-      "range": [
-        71,
-        77
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 77
+        {
+            "type": "Identifier",
+            "range": [
+                71,
+                77
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 77
+                },
+                "start": {
+                    "line": 1,
+                    "column": 71
+                }
+            },
+            "value": "string"
         },
-        "start": {
-          "line": 1,
-          "column": 71
-        }
-      },
-      "value": "string"
-    },
-    {
-      "type": "Punctuator",
-      "range": [
-        78,
-        79
-      ],
-      "loc": {
-        "end": {
-          "line": 1,
-          "column": 79
+        {
+            "type": "Punctuator",
+            "range": [
+                78,
+                79
+            ],
+            "loc": {
+                "end": {
+                    "line": 1,
+                    "column": 79
+                },
+                "start": {
+                    "line": 1,
+                    "column": 78
+                }
+            },
+            "value": "{"
         },
-        "start": {
-          "line": 1,
-          "column": 78
-        }
-      },
-      "value": "{"
-    },
-    {
-      "type": "Keyword",
-      "range": [
-        82,
-        88
-      ],
-      "loc": {
-        "end": {
-          "line": 2,
-          "column": 8
+        {
+            "type": "Keyword",
+            "range": [
+                82,
+                88
+            ],
+            "loc": {
+                "end": {
+                    "line": 2,
+                    "column": 8
+                },
+                "start": {
+                    "line": 2,
+                    "column": 2
+                }
+            },
+            "value": "return"
         },
-        "start": {
-          "line": 2,
-          "column": 2
-        }
-      },
-      "value": "return"
-    },
-    {
-      "type": "Identifier",
-      "range": [
-        89,
-        93
-      ],
-      "loc": {
-        "end": {
-          "line": 2,
-          "column": 13
+        {
+            "type": "Identifier",
+            "range": [
+                89,
+                93
+            ],
+            "loc": {
+                "end": {
+                    "line": 2,
+                    "column": 13
+                },
+                "start": {
+                    "line": 2,
+                    "column": 9
+                }
+            },
+            "value": "name"
         },
-        "start": {
-          "line": 2,
-          "column": 9
-        }
-      },
-      "value": "name"
-    },
-    {
-      "type": "Punctuator",
-      "range": [
-        93,
-        94
-      ],
-      "loc": {
-        "end": {
-          "line": 2,
-          "column": 14
+        {
+            "type": "Punctuator",
+            "range": [
+                93,
+                94
+            ],
+            "loc": {
+                "end": {
+                    "line": 2,
+                    "column": 14
+                },
+                "start": {
+                    "line": 2,
+                    "column": 13
+                }
+            },
+            "value": ";"
         },
-        "start": {
-          "line": 2,
-          "column": 13
+        {
+            "type": "Punctuator",
+            "range": [
+                95,
+                96
+            ],
+            "loc": {
+                "end": {
+                    "line": 3,
+                    "column": 1
+                },
+                "start": {
+                    "line": 3,
+                    "column": 0
+                }
+            },
+            "value": "}"
         }
-      },
-      "value": ";"
-    },
-    {
-      "type": "Punctuator",
-      "range": [
-        95,
-        96
-      ],
-      "loc": {
-        "end": {
-          "line": 3,
-          "column": 1
-        },
-        "start": {
-          "line": 3,
-          "column": 0
-        }
-      },
-      "value": "}"
-    }
-  ]
+    ]
 };

--- a/tests/fixtures/typescript/basics/interface-with-construct-signature-with-parameter-accessibility.result.js
+++ b/tests/fixtures/typescript/basics/interface-with-construct-signature-with-parameter-accessibility.result.js
@@ -36,6 +36,7 @@ module.exports = {
                 "body": [
                     {
                         "type": "TSConstructSignature",
+                        "typeParameters": null,
                         "range": [
                             21,
                             47

--- a/tests/fixtures/typescript/basics/interface-with-generic.result.js
+++ b/tests/fixtures/typescript/basics/interface-with-generic.result.js
@@ -1,0 +1,240 @@
+module.exports = {
+    "body": [
+        {
+            "body": {
+                "body": [],
+                "loc": {
+                    "end": {
+                        "column": 1,
+                        "line": 2
+                    },
+                    "start": {
+                        "column": 18,
+                        "line": 1
+                    }
+                },
+                "range": [
+                    18,
+                    21
+                ],
+                "type": "TSInterfaceBody"
+            },
+            "heritage": [],
+            "id": {
+                "loc": {
+                    "end": {
+                        "column": 14,
+                        "line": 1
+                    },
+                    "start": {
+                        "column": 10,
+                        "line": 1
+                    }
+                },
+                "name": "Test",
+                "range": [
+                    10,
+                    14
+                ],
+                "type": "Identifier"
+            },
+            "loc": {
+                "end": {
+                    "column": 1,
+                    "line": 2
+                },
+                "start": {
+                    "column": 0,
+                    "line": 1
+                }
+            },
+            "range": [
+                0,
+                21
+            ],
+            "type": "TSInterfaceDeclaration",
+            "typeParameters": {
+                "loc": {
+                    "end": {
+                        "column": 17,
+                        "line": 1
+                    },
+                    "start": {
+                        "column": 14,
+                        "line": 1
+                    }
+                },
+                "params": [
+                    {
+                        "constraint": null,
+                        "loc": {
+                            "end": {
+                                "column": 16,
+                                "line": 1
+                            },
+                            "start": {
+                                "column": 15,
+                                "line": 1
+                            }
+                        },
+                        "name": "T",
+                        "range": [
+                            15,
+                            16
+                        ],
+                        "type": "TypeParameter"
+                    }
+                ],
+                "range": [
+                    14,
+                    17
+                ],
+                "type": "TypeParameterDeclaration"
+            }
+        }
+    ],
+    "loc": {
+        "end": {
+            "column": 1,
+            "line": 2
+        },
+        "start": {
+            "column": 0,
+            "line": 1
+        }
+    },
+    "range": [
+        0,
+        21
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "loc": {
+                "end": {
+                    "column": 9,
+                    "line": 1
+                },
+                "start": {
+                    "column": 0,
+                    "line": 1
+                }
+            },
+            "range": [
+                0,
+                9
+            ],
+            "type": "Keyword",
+            "value": "interface"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 14,
+                    "line": 1
+                },
+                "start": {
+                    "column": 10,
+                    "line": 1
+                }
+            },
+            "range": [
+                10,
+                14
+            ],
+            "type": "Identifier",
+            "value": "Test"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 15,
+                    "line": 1
+                },
+                "start": {
+                    "column": 14,
+                    "line": 1
+                }
+            },
+            "range": [
+                14,
+                15
+            ],
+            "type": "Punctuator",
+            "value": "<"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 16,
+                    "line": 1
+                },
+                "start": {
+                    "column": 15,
+                    "line": 1
+                }
+            },
+            "range": [
+                15,
+                16
+            ],
+            "type": "Identifier",
+            "value": "T"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 17,
+                    "line": 1
+                },
+                "start": {
+                    "column": 16,
+                    "line": 1
+                }
+            },
+            "range": [
+                16,
+                17
+            ],
+            "type": "Punctuator",
+            "value": ">"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 19,
+                    "line": 1
+                },
+                "start": {
+                    "column": 18,
+                    "line": 1
+                }
+            },
+            "range": [
+                18,
+                19
+            ],
+            "type": "Punctuator",
+            "value": "{"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 1,
+                    "line": 2
+                },
+                "start": {
+                    "column": 0,
+                    "line": 2
+                }
+            },
+            "range": [
+                20,
+                21
+            ],
+            "type": "Punctuator",
+            "value": "}"
+        }
+    ],
+    "type": "Program"
+};

--- a/tests/fixtures/typescript/basics/interface-with-generic.src.ts
+++ b/tests/fixtures/typescript/basics/interface-with-generic.src.ts
@@ -1,0 +1,2 @@
+interface Test<T> {
+}

--- a/tests/fixtures/typescript/basics/interface-with-jsdoc.result.js
+++ b/tests/fixtures/typescript/basics/interface-with-jsdoc.result.js
@@ -36,6 +36,7 @@ module.exports = {
                 "body": [
                     {
                         "type": "TSMethodSignature",
+                        "typeParameters": null,
                         "range": [
                             76,
                             85

--- a/tests/fixtures/typescript/basics/interface-with-optional-properties.result.js
+++ b/tests/fixtures/typescript/basics/interface-with-optional-properties.result.js
@@ -177,6 +177,7 @@ module.exports = {
                     },
                     {
                         "type": "TSMethodSignature",
+                        "typeParameters": null,
                         "range": [
                             49,
                             79

--- a/tests/fixtures/typescript/basics/nested-type-arguments.result.js
+++ b/tests/fixtures/typescript/basics/nested-type-arguments.result.js
@@ -52,99 +52,168 @@ module.exports = {
                                     44
                                 ],
                                 "type": "TSTypeReference",
-                                "typeArguments": [
-                                    {
-                                        "loc": {
-                                            "end": {
-                                                "column": 43,
-                                                "line": 1
-                                            },
-                                            "start": {
-                                                "column": 23,
-                                                "line": 1
-                                            }
+                                "typeParameters": {
+                                    "loc": {
+                                        "end": {
+                                            "column": 44,
+                                            "line": 1
                                         },
-                                        "range": [
-                                            23,
-                                            43
-                                        ],
-                                        "type": "TSTypeReference",
-                                        "typeArguments": [
-                                            {
+                                        "start": {
+                                            "column": 22,
+                                            "line": 1
+                                        }
+                                    },
+                                    "params": [
+                                        {
+                                            "id": {
                                                 "loc": {
                                                     "end": {
-                                                        "column": 42,
+                                                        "column": 28,
                                                         "line": 1
                                                     },
                                                     "start": {
-                                                        "column": 29,
+                                                        "column": 23,
                                                         "line": 1
                                                     }
                                                 },
+                                                "name": "Array",
                                                 "range": [
-                                                    29,
-                                                    42
+                                                    23,
+                                                    28
                                                 ],
-                                                "type": "TSTypeReference",
-                                                "typeArguments": [
+                                                "type": "Identifier"
+                                            },
+                                            "loc": {
+                                                "end": {
+                                                    "column": 43,
+                                                    "line": 1
+                                                },
+                                                "start": {
+                                                    "column": 38,
+                                                    "line": 1
+                                                }
+                                            },
+                                            "range": [
+                                                38,
+                                                43
+                                            ],
+                                            "type": "GenericTypeAnnotation",
+                                            "typeParameters": {
+                                                "loc": {
+                                                    "end": {
+                                                        "column": 43,
+                                                        "line": 1
+                                                    },
+                                                    "start": {
+                                                        "column": 28,
+                                                        "line": 1
+                                                    }
+                                                },
+                                                "params": [
                                                     {
+                                                        "id": {
+                                                            "loc": {
+                                                                "end": {
+                                                                    "column": 34,
+                                                                    "line": 1
+                                                                },
+                                                                "start": {
+                                                                    "column": 29,
+                                                                    "line": 1
+                                                                }
+                                                            },
+                                                            "name": "Array",
+                                                            "range": [
+                                                                29,
+                                                                34
+                                                            ],
+                                                            "type": "Identifier"
+                                                        },
                                                         "loc": {
                                                             "end": {
-                                                                "column": 41,
+                                                                "column": 42,
                                                                 "line": 1
                                                             },
                                                             "start": {
-                                                                "column": 35,
+                                                                "column": 37,
                                                                 "line": 1
                                                             }
                                                         },
                                                         "range": [
-                                                            35,
-                                                            41
+                                                            37,
+                                                            42
                                                         ],
-                                                        "type": "TSStringKeyword"
+                                                        "type": "GenericTypeAnnotation",
+                                                        "typeParameters": {
+                                                            "loc": {
+                                                                "end": {
+                                                                    "column": 42,
+                                                                    "line": 1
+                                                                },
+                                                                "start": {
+                                                                    "column": 34,
+                                                                    "line": 1
+                                                                }
+                                                            },
+                                                            "params": [
+                                                                {
+                                                                    "id": {
+                                                                        "loc": {
+                                                                            "end": {
+                                                                                "column": 41,
+                                                                                "line": 1
+                                                                            },
+                                                                            "start": {
+                                                                                "column": 35,
+                                                                                "line": 1
+                                                                            }
+                                                                        },
+                                                                        "range": [
+                                                                            35,
+                                                                            41
+                                                                        ],
+                                                                        "type": "TSStringKeyword"
+                                                                    },
+                                                                    "loc": {
+                                                                        "end": {
+                                                                            "column": 41,
+                                                                            "line": 1
+                                                                        },
+                                                                        "start": {
+                                                                            "column": 35,
+                                                                            "line": 1
+                                                                        }
+                                                                    },
+                                                                    "range": [
+                                                                        35,
+                                                                        41
+                                                                    ],
+                                                                    "type": "GenericTypeAnnotation",
+                                                                    "typeParameters": null
+                                                                }
+                                                            ],
+                                                            "range": [
+                                                                34,
+                                                                42
+                                                            ],
+                                                            "type": "TypeParameterInstantiation"
+                                                        }
                                                     }
                                                 ],
-                                                "typeName": {
-                                                    "loc": {
-                                                        "end": {
-                                                            "column": 34,
-                                                            "line": 1
-                                                        },
-                                                        "start": {
-                                                            "column": 29,
-                                                            "line": 1
-                                                        }
-                                                    },
-                                                    "name": "Array",
-                                                    "range": [
-                                                        29,
-                                                        34
-                                                    ],
-                                                    "type": "Identifier"
-                                                }
+                                                "range": [
+                                                    28,
+                                                    43
+                                                ],
+                                                "type": "TypeParameterInstantiation"
                                             }
-                                        ],
-                                        "typeName": {
-                                            "loc": {
-                                                "end": {
-                                                    "column": 28,
-                                                    "line": 1
-                                                },
-                                                "start": {
-                                                    "column": 23,
-                                                    "line": 1
-                                                }
-                                            },
-                                            "name": "Array",
-                                            "range": [
-                                                23,
-                                                28
-                                            ],
-                                            "type": "Identifier"
                                         }
-                                    }
-                                ],
+                                    ],
+                                    "range": [
+                                        22,
+                                        44
+                                    ],
+                                    "type": "TypeParameterInstantiation"
+                                },
                                 "typeName": {
                                     "loc": {
                                         "end": {

--- a/tests/fixtures/typescript/basics/type-alias-declaration-with-constrained-type-parameter.result.js
+++ b/tests/fixtures/typescript/basics/type-alias-declaration-with-constrained-type-parameter.result.js
@@ -54,43 +54,6 @@ module.exports = {
                                     38
                                 ],
                                 "type": "TSTypeReference",
-                                "typeArguments": [
-                                    {
-                                        "loc": {
-                                            "end": {
-                                                "column": 37,
-                                                "line": 1
-                                            },
-                                            "start": {
-                                                "column": 36,
-                                                "line": 1
-                                            }
-                                        },
-                                        "range": [
-                                            36,
-                                            37
-                                        ],
-                                        "type": "TSTypeReference",
-                                        "typeName": {
-                                            "loc": {
-                                                "end": {
-                                                    "column": 37,
-                                                    "line": 1
-                                                },
-                                                "start": {
-                                                    "column": 36,
-                                                    "line": 1
-                                                }
-                                            },
-                                            "name": "T",
-                                            "range": [
-                                                36,
-                                                37
-                                            ],
-                                            "type": "Identifier"
-                                        }
-                                    }
-                                ],
                                 "typeName": {
                                     "loc": {
                                         "end": {
@@ -108,6 +71,61 @@ module.exports = {
                                         35
                                     ],
                                     "type": "Identifier"
+                                },
+                                "typeParameters": {
+                                    "type": "TypeParameterInstantiation",
+                                    "range": [
+                                        35,
+                                        38
+                                    ],
+                                    "loc": {
+                                        "end": {
+                                            "column": 38,
+                                            "line": 1
+                                        },
+                                        "start": {
+                                            "column": 35,
+                                            "line": 1
+                                        }
+                                    },
+                                    "params": [
+                                        {
+                                            "loc": {
+                                                "end": {
+                                                    "column": 37,
+                                                    "line": 1
+                                                },
+                                                "start": {
+                                                    "column": 36,
+                                                    "line": 1
+                                                }
+                                            },
+                                            "range": [
+                                                36,
+                                                37
+                                            ],
+                                            "id": {
+                                                "loc": {
+                                                    "end": {
+                                                        "column": 37,
+                                                        "line": 1
+                                                    },
+                                                    "start": {
+                                                        "column": 36,
+                                                        "line": 1
+                                                    }
+                                                },
+                                                "name": "T",
+                                                "range": [
+                                                    36,
+                                                    37
+                                                ],
+                                                "type": "Identifier"
+                                            },
+                                            "type": "GenericTypeAnnotation",
+                                            "typeParameters": null
+                                        }
+                                    ]
                                 }
                             },
                             {

--- a/tests/fixtures/typescript/basics/type-alias-declaration.result.js
+++ b/tests/fixtures/typescript/basics/type-alias-declaration.result.js
@@ -104,43 +104,61 @@ module.exports = {
                                     },
                                     "name": "Success"
                                 },
-                                "typeArguments": [
-                                    {
-                                        "type": "TSTypeReference",
-                                        "range": [
-                                            25,
-                                            26
-                                        ],
-                                        "loc": {
-                                            "start": {
-                                                "line": 1,
-                                                "column": 25
-                                            },
-                                            "end": {
-                                                "line": 1,
-                                                "column": 26
-                                            }
+                                "typeParameters": {
+                                    "loc": {
+                                        "end": {
+                                            "column": 27,
+                                            "line": 1
                                         },
-                                        "typeName": {
-                                            "type": "Identifier",
+                                        "start": {
+                                            "column": 24,
+                                            "line": 1
+                                        }
+                                    },
+                                    "range": [
+                                        24,
+                                        27
+                                    ],
+                                    "params": [
+                                        {
+                                            "loc": {
+                                                "end": {
+                                                    "column": 26,
+                                                    "line": 1
+                                                },
+                                                "start": {
+                                                    "column": 25,
+                                                    "line": 1
+                                                }
+                                            },
                                             "range": [
                                                 25,
                                                 26
                                             ],
-                                            "loc": {
-                                                "start": {
-                                                    "line": 1,
-                                                    "column": 25
+                                            "id": {
+                                                "loc": {
+                                                    "end": {
+                                                        "column": 26,
+                                                        "line": 1
+                                                    },
+                                                    "start": {
+                                                        "column": 25,
+                                                        "line": 1
+                                                    }
                                                 },
-                                                "end": {
-                                                    "line": 1,
-                                                    "column": 26
-                                                }
+                                                "name": "T",
+                                                "range": [
+                                                    25,
+                                                    26
+                                                ],
+                                                "type": "Identifier"
                                             },
-                                            "name": "T"
+                                            "type": "GenericTypeAnnotation",
+                                            "typeParameters": null
                                         }
-                                    }
-                                ]
+                                    ],
+                                    "type": "TypeParameterInstantiation"
+                                }
                             },
                             {
                                 "type": "TSTypeReference",

--- a/tests/fixtures/typescript/basics/typed-this.result.js
+++ b/tests/fixtures/typescript/basics/typed-this.result.js
@@ -275,7 +275,8 @@ module.exports = {
                                                     }
                                                 }
                                             }
-                                        }
+                                        },
+                                        "typeParameters": null
                                     }
                                 }
                             }
@@ -313,7 +314,8 @@ module.exports = {
                                     }
                                 }
                             }
-                        }
+                        },
+                        "typeParameters": null
                     }
                 ],
                 "range": [

--- a/tests/fixtures/typescript/namespaces-and-modules/declare-namespace-with-exported-function.result.js
+++ b/tests/fixtures/typescript/namespaces-and-modules/declare-namespace-with-exported-function.result.js
@@ -229,25 +229,61 @@ module.exports = {
                                         },
                                         "name": "Selection"
                                     },
-                                    "typeArguments": [
-                                        {
-                                            "type": "TSAnyKeyword",
-                                            "range": [
-                                                77,
-                                                80
-                                            ],
-                                            "loc": {
-                                                "start": {
-                                                    "line": 2,
-                                                    "column": 54
-                                                },
-                                                "end": {
-                                                    "line": 2,
-                                                    "column": 57
-                                                }
+                                    "typeParameters": {
+                                        "loc": {
+                                            "end": {
+                                                "column": 58,
+                                                "line": 2
+                                            },
+                                            "start": {
+                                                "column": 53,
+                                                "line": 2
                                             }
-                                        }
-                                    ]
+                                        },
+                                        "params": [
+                                            {
+                                                "id": {
+                                                    "loc": {
+                                                        "end": {
+                                                            "column": 57,
+                                                            "line": 2
+                                                        },
+                                                        "start": {
+                                                            "column": 54,
+                                                            "line": 2
+                                                        }
+                                                    },
+                                                    "range": [
+                                                        77,
+                                                        80
+                                                    ],
+                                                    "type": "TSAnyKeyword"
+                                                },
+
+                                                "loc": {
+                                                    "end": {
+                                                        "column": 57,
+                                                        "line": 2
+                                                    },
+                                                    "start": {
+                                                        "column": 54,
+                                                        "line": 2
+                                                    }
+                                                },
+                                                "range": [
+                                                    77,
+                                                    80
+                                                ],
+                                                "type": "GenericTypeAnnotation",
+                                                "typeParameters": null
+                                            }
+                                        ],
+                                        "range": [
+                                            76,
+                                            81
+                                        ],
+                                        "type": "TypeParameterInstantiation"
+                                    }
                                 }
                             }
                         },


### PR DESCRIPTION
The `deeplyCopy` function does a great job of supporting strange TS nodes however I run in to a few where it would have been nice if it had normalized type arguments and type parameters just as for "supported" nodes.
The nodes in question are
For type arguments:
- TSConstructorType
- TSFunctionType
- TSTypeReference

For type parameters:
- TSCallSignature
- TSConstructSignature

Now this do break some tests because previously such nodes were outputted as they appeared in the TypeScript AST and is therefore a breaking change. If this actually breaks anyone though is harder to tell, as far as I understand there aren't many TS specific Eslint rules around which could have been using these props. I have not updated any tests yet so you can see the breakage in the Travis logs.

Alternatives for doing this:
1. Specifically support these nodes.
  TypeScript have a lot of strange syntax so it's a risk that there are more types than the above listed. Specifically supporting these nodes would limit the impact on today unknown types. This would however likely plan out in me opening PRs to support these unknown nodes when I found them.
2. Not doing this at all.
  The `deeplyCopy` function already outputs enough to support these nodes without any change in `typescript-eslint-parser` however that would require prettier to support both formats as supported nodes already are normalized.