### PR TITLE
Add note about babylon AST

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TypeScript ESLint Parser (Experimental)
 
-A parser that converts TypeScript into an [ESTree](https://github.com/estree/estree)-compatible form so it can be used in ESLint. The goal is to allow TypeScript files to be parsed by ESLint (though not necessarily pass all ESLint rules).
+A parser that converts TypeScript into an [ESTree](https://github.com/estree/estree)-compatible form (specifically, the [babylon AST](https://github.com/babel/babylon/blob/master/ast/spec.md)) so it can be used in ESLint. The goal is to allow TypeScript files to be parsed by ESLint (though not necessarily pass all ESLint rules).
 
 **Important:** This parser is still in the very early stages and is considered experimental. There are likely a lot of bugs. You should not rely on this in a production environment yet.
 


### PR DESCRIPTION
When trying to add nodes converting from typescript `ts.SyntaxKind.EnumDeclaration`s to "ESTree" I was looking at the [`VariableDeclaration`/`VariableDeclarator`](https://github.com/eslint/typescript-eslint-parser/blob/bfb1506c48b625871ffeb67dbec7941d460f8941/lib/ast-converter.js#L944-L965) conversions and it took me a bit to realize they were [babylon AST](https://github.com/babel/babylon/blob/master/ast/spec.md#variabledeclaration) instead of [ESTree](https://github.com/estree/estree/blob/master/es2015.md#variabledeclaration).