### PR TITLE
Fix: Set root to true in eslintrc (fixes #211)

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,3 +1,5 @@
+root: true
+
 env:
     node: true
 


### PR DESCRIPTION
This fixes an issue when an eslintrc config file is in the parent directory that typescript-eslint-parser is installed too.