### PR TITLE
Chore: Wrap any parameter with modifers, not just in constructors

### DIFF
--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -1217,20 +1217,6 @@ module.exports = function(ast, extra) {
                                 return convertChild(d.expression);
                             }) : [];
 
-                            if (param.modifiers) {
-                                return {
-                                    type: "TSParameterProperty",
-                                    range: [param.getStart(), param.end],
-                                    loc: getLoc(param, ast),
-                                    accessibility: getTSNodeAccessibility(param),
-                                    isReadonly: param.modifiers.some(function(modifier) {
-                                        return modifier.kind === SyntaxKind.ReadonlyKeyword;
-                                    }),
-                                    parameter: convertedParam,
-                                    decorators: decorators
-                                };
-                            }
-
                             return assign(convertedParam, {
                                 decorators: decorators
                             });
@@ -1499,17 +1485,27 @@ module.exports = function(ast, extra) {
                         right: convertChild(node.initializer)
                     });
                 } else {
-                    var convertedParameter = convert(node.name, parent);
-                    if (node.type) {
-                        convertedParameter.typeAnnotation = convertTypeAnnotation(node.type);
-                    }
-                    return convertedParameter;
+                    parameter = convert(node.name, parent);
+                    result = parameter;
                 }
 
                 if (node.type) {
                     assign(parameter, {
                         typeAnnotation: convertTypeAnnotation(node.type)
                     });
+                }
+
+                if (node.modifiers) {
+                    return {
+                        type: "TSParameterProperty",
+                        range: [node.getStart(), node.end],
+                        loc: getLoc(node, ast),
+                        accessibility: getTSNodeAccessibility(node),
+                        isReadonly: node.modifiers.some(function(modifier) {
+                            return modifier.kind === SyntaxKind.ReadonlyKeyword;
+                        }),
+                        parameter: result
+                    };
                 }
 
                 break;

--- a/tests/fixtures/typescript/basics/interface-with-construct-signature-with-parameter-accessibility.result.js
+++ b/tests/fixtures/typescript/basics/interface-with-construct-signature-with-parameter-accessibility.result.js
@@ -1,0 +1,386 @@
+module.exports = {
+    "body": [
+        {
+            "loc": {
+                "end": {
+                    "column": 1,
+                    "line": 3
+                },
+                "start": {
+                    "column": 0,
+                    "line": 1
+                }
+            },
+            "members": [
+                {
+                    "loc": {
+                        "end": {
+                            "column": 30,
+                            "line": 2
+                        },
+                        "start": {
+                            "column": 4,
+                            "line": 2
+                        }
+                    },
+                    "parameters": [
+                        {
+                            "accessibility": "public",
+                            "isReadonly": false,
+                            "loc": {
+                                "end": {
+                                    "column": 17,
+                                    "line": 2
+                                },
+                                "start": {
+                                    "column": 9,
+                                    "line": 2
+                                }
+                            },
+                            "parameter": {
+                                "loc": {
+                                    "end": {
+                                        "column": 17,
+                                        "line": 2
+                                    },
+                                    "start": {
+                                        "column": 16,
+                                        "line": 2
+                                    }
+                                },
+                                "name": "x",
+                                "range": [
+                                    33,
+                                    34
+                                ],
+                                "type": "Identifier"
+                            },
+                            "range": [
+                                26,
+                                34
+                            ],
+                            "type": "TSParameterProperty"
+                        },
+                        {
+                            "accessibility": "private",
+                            "isReadonly": false,
+                            "loc": {
+                                "end": {
+                                    "column": 28,
+                                    "line": 2
+                                },
+                                "start": {
+                                    "column": 19,
+                                    "line": 2
+                                }
+                            },
+                            "parameter": {
+                                "loc": {
+                                    "end": {
+                                        "column": 28,
+                                        "line": 2
+                                    },
+                                    "start": {
+                                        "column": 27,
+                                        "line": 2
+                                    }
+                                },
+                                "name": "y",
+                                "range": [
+                                    44,
+                                    45
+                                ],
+                                "type": "Identifier"
+                            },
+                            "range": [
+                                36,
+                                45
+                            ],
+                            "type": "TSParameterProperty"
+                        }
+                    ],
+                    "range": [
+                        21,
+                        47
+                    ],
+                    "type": "TSConstructSignature"
+                }
+            ],
+            "name": {
+                "loc": {
+                    "end": {
+                        "column": 14,
+                        "line": 1
+                    },
+                    "start": {
+                        "column": 10,
+                        "line": 1
+                    }
+                },
+                "name": "Test",
+                "range": [
+                    10,
+                    14
+                ],
+                "type": "Identifier"
+            },
+            "range": [
+                0,
+                49
+            ],
+            "type": "TSInterfaceDeclaration"
+        }
+    ],
+    "loc": {
+        "end": {
+            "column": 1,
+            "line": 3
+        },
+        "start": {
+            "column": 0,
+            "line": 1
+        }
+    },
+    "range": [
+        0,
+        49
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "loc": {
+                "end": {
+                    "column": 9,
+                    "line": 1
+                },
+                "start": {
+                    "column": 0,
+                    "line": 1
+                }
+            },
+            "range": [
+                0,
+                9
+            ],
+            "type": "Keyword",
+            "value": "interface"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 14,
+                    "line": 1
+                },
+                "start": {
+                    "column": 10,
+                    "line": 1
+                }
+            },
+            "range": [
+                10,
+                14
+            ],
+            "type": "Identifier",
+            "value": "Test"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 16,
+                    "line": 1
+                },
+                "start": {
+                    "column": 15,
+                    "line": 1
+                }
+            },
+            "range": [
+                15,
+                16
+            ],
+            "type": "Punctuator",
+            "value": "{"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 7,
+                    "line": 2
+                },
+                "start": {
+                    "column": 4,
+                    "line": 2
+                }
+            },
+            "range": [
+                21,
+                24
+            ],
+            "type": "Keyword",
+            "value": "new"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 9,
+                    "line": 2
+                },
+                "start": {
+                    "column": 8,
+                    "line": 2
+                }
+            },
+            "range": [
+                25,
+                26
+            ],
+            "type": "Punctuator",
+            "value": "("
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 15,
+                    "line": 2
+                },
+                "start": {
+                    "column": 9,
+                    "line": 2
+                }
+            },
+            "range": [
+                26,
+                32
+            ],
+            "type": "Keyword",
+            "value": "public"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 17,
+                    "line": 2
+                },
+                "start": {
+                    "column": 16,
+                    "line": 2
+                }
+            },
+            "range": [
+                33,
+                34
+            ],
+            "type": "Identifier",
+            "value": "x"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 18,
+                    "line": 2
+                },
+                "start": {
+                    "column": 17,
+                    "line": 2
+                }
+            },
+            "range": [
+                34,
+                35
+            ],
+            "type": "Punctuator",
+            "value": ","
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 26,
+                    "line": 2
+                },
+                "start": {
+                    "column": 19,
+                    "line": 2
+                }
+            },
+            "range": [
+                36,
+                43
+            ],
+            "type": "Keyword",
+            "value": "private"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 28,
+                    "line": 2
+                },
+                "start": {
+                    "column": 27,
+                    "line": 2
+                }
+            },
+            "range": [
+                44,
+                45
+            ],
+            "type": "Identifier",
+            "value": "y"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 29,
+                    "line": 2
+                },
+                "start": {
+                    "column": 28,
+                    "line": 2
+                }
+            },
+            "range": [
+                45,
+                46
+            ],
+            "type": "Punctuator",
+            "value": ")"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 30,
+                    "line": 2
+                },
+                "start": {
+                    "column": 29,
+                    "line": 2
+                }
+            },
+            "range": [
+                46,
+                47
+            ],
+            "type": "Punctuator",
+            "value": ";"
+        },
+        {
+            "loc": {
+                "end": {
+                    "column": 1,
+                    "line": 3
+                },
+                "start": {
+                    "column": 0,
+                    "line": 3
+                }
+            },
+            "range": [
+                48,
+                49
+            ],
+            "type": "Punctuator",
+            "value": "}"
+        }
+    ],
+    "type": "Program"
+};

--- a/tests/fixtures/typescript/basics/interface-with-construct-signature-with-parameter-accessibility.src.ts
+++ b/tests/fixtures/typescript/basics/interface-with-construct-signature-with-parameter-accessibility.src.ts
@@ -1,0 +1,3 @@
+interface Test {
+    new (public x, private y);
+}


### PR DESCRIPTION
As pretter reprints the code from the AST, anything not in it will be gone.
So while
```
interface I {
    new (public x);
}
```
is invalid TypeScript, it's no good if pretter prints that as
```
interface I {
    new (x)
}
```
If you have your editor set up to format on save, the modifier will just
be gone and you'll never see the error from TypeScript and will therfore
consider it a bug.
Note that the code does not explicitly support this, I just moved the code
that supports this in constructor parameters so that it applies to any parameter.

As the code parses correctly with just missing information in the AST there
are no good way to know that the printed file will be different from the original.
So while there is no intention to support invalid TS it's easier to do that in this
case than to error.