### PR TITLE
Chore: Remove before_script from .travis.yml (fixes #231)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,5 @@ node_js:
     - "0.12"
     - 4
     - 6
-before_script:
-    - npm install -g npm-install-peers
-    - npm-install-peers
 after_success:
     - npm run coveralls


### PR DESCRIPTION
We recently open up the TypeScript peerDependency requirement of this project to allow for easier experimentation of bleeding edge versions.

We have the TypeScript devDependency as a way of specifying the version of TS that this parser officially supports, but we never removed the build step which installs all peerDependencies, and so the devDependency is not being used.

Because TypeScript just released a new stable version (2.3), the build is currently failing because we have not updated the parser to support it yet.