### PR TITLE
Chore: Add tests for object spread and async generator

### DIFF
--- a/tests/fixtures/ecma-features/experimentalAsyncIteration/async-generators.result.js
+++ b/tests/fixtures/ecma-features/experimentalAsyncIteration/async-generators.result.js
@@ -1,0 +1,223 @@
+module.exports = {
+    "type": "Program",
+    "range": [
+        0,
+        26
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 3,
+            "column": 1
+        }
+    },
+    "body": [
+        {
+            "type": "FunctionDeclaration",
+            "range": [
+                0,
+                26
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 1
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    16,
+                    19
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 16
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 19
+                    }
+                },
+                "name": "foo"
+            },
+            "generator": true,
+            "expression": false,
+            "async": true,
+            "params": [],
+            "body": {
+                "type": "BlockStatement",
+                "range": [
+                    22,
+                    26
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 22
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 1
+                    }
+                },
+                "body": []
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Identifier",
+            "value": "async",
+            "range": [
+                0,
+                5
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "function",
+            "range": [
+                6,
+                14
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 6
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "*",
+            "range": [
+                14,
+                15
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 14
+                },
+                "end": {
+                    "line": 1,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "range": [
+                16,
+                19
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 16
+                },
+                "end": {
+                    "line": 1,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                19,
+                20
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 19
+                },
+                "end": {
+                    "line": 1,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                20,
+                21
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 20
+                },
+                "end": {
+                    "line": 1,
+                    "column": 21
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                22,
+                23
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 22
+                },
+                "end": {
+                    "line": 1,
+                    "column": 23
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                25,
+                26
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 1
+                }
+            }
+        }
+    ]
+};

--- a/tests/fixtures/ecma-features/experimentalAsyncIteration/async-generators.src.js
+++ b/tests/fixtures/ecma-features/experimentalAsyncIteration/async-generators.src.js
@@ -1,0 +1,3 @@
+async function* foo() {
+
+}

--- a/tests/fixtures/ecma-features/experimentalObjectRestSpread/property-spread.result.js
+++ b/tests/fixtures/ecma-features/experimentalObjectRestSpread/property-spread.result.js
@@ -326,7 +326,7 @@ module.exports = {
                                 "kind": "init"
                             },
                             {
-                                "type": "ExperimentalSpreadProperty",
+                                "type": "SpreadElement",
                                 "loc": {
                                     "start": {
                                         "line": 8,

--- a/tests/fixtures/ecma-features/experimentalObjectRestSpread/single-spread.result.js
+++ b/tests/fixtures/ecma-features/experimentalObjectRestSpread/single-spread.result.js
@@ -326,7 +326,7 @@ module.exports = {
                                 "kind": "init"
                             },
                             {
-                                "type": "ExperimentalSpreadProperty",
+                                "type": "SpreadElement",
                                 "loc": {
                                     "start": {
                                         "line": 8,

--- a/tests/fixtures/ecma-features/experimentalObjectRestSpread/two-spread.result.js
+++ b/tests/fixtures/ecma-features/experimentalObjectRestSpread/two-spread.result.js
@@ -269,7 +269,7 @@ module.exports = {
                                 "kind": "init"
                             },
                             {
-                                "type": "ExperimentalSpreadProperty",
+                                "type": "SpreadElement",
                                 "loc": {
                                     "start": {
                                         "line": 7,
@@ -304,7 +304,7 @@ module.exports = {
                                 }
                             },
                             {
-                                "type": "ExperimentalSpreadProperty",
+                                "type": "SpreadElement",
                                 "loc": {
                                     "start": {
                                         "line": 8,

--- a/tests/lib/ecma-features.js
+++ b/tests/lib/ecma-features.js
@@ -41,7 +41,7 @@ var testFiles = shelljs.find(FIXTURES_DIR).filter(function(filename) {
 }).map(function(filename) {
     return filename.substring(FIXTURES_DIR.length - 1, filename.length - 7);  // strip off ".src.js"
 }).filter(function(filename) {
-    return !(/error\-|invalid\-|globalReturn|experimental/.test(filename));
+    return !(/error\-|invalid\-|globalReturn/.test(filename));
 });
 
 // var moduleTestFiles = testFiles.filter(function(filename) {


### PR DESCRIPTION
I noticed we were missing test for object spread. Async generator support was added in typescript 2.3