### PR TITLE
Fix: Support superTypeParameters (fixes #242)

### DIFF
--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -1550,6 +1550,9 @@ module.exports = function(ast, extra) {
 
                 if (hasExtends) {
                     superClass = heritageClauses.shift();
+                    if (superClass.types[0] && superClass.types[0].typeArguments) {
+                        result.superTypeParameters = convertTypeArgumentsToTypeParameters(superClass.types[0].typeArguments);
+                    }
                 }
 
                 hasImplements = heritageClauses.length > 0;

--- a/tests/fixtures/typescript/basics/class-with-extends-generic-multiple.result.js
+++ b/tests/fixtures/typescript/basics/class-with-extends-generic-multiple.result.js
@@ -1,0 +1,563 @@
+module.exports = {
+    "type": "Program",
+    "range": [
+        0,
+        45
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 3,
+            "column": 1
+        }
+    },
+    "body": [
+        {
+            "type": "ClassDeclaration",
+            "range": [
+                0,
+                45
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 1
+                }
+            },
+            "typeParameters": {
+                "type": "TypeParameterDeclaration",
+                "range": [
+                    9,
+                    22
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 9
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 22
+                    }
+                },
+                "params": [
+                    {
+                        "type": "TypeParameter",
+                        "range": [
+                            10,
+                            21
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 10
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 21
+                            }
+                        },
+                        "name": "A",
+                        "constraint": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 20
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 21
+                                }
+                            },
+                            "range": [
+                                20,
+                                21
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSTypeReference",
+                                "range": [
+                                    20,
+                                    21
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 20
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 21
+                                    }
+                                },
+                                "typeName": {
+                                    "type": "Identifier",
+                                    "range": [
+                                        20,
+                                        21
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 1,
+                                            "column": 20
+                                        },
+                                        "end": {
+                                            "line": 1,
+                                            "column": 21
+                                        }
+                                    },
+                                    "name": "B"
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
+            "superTypeParameters": {
+                "type": "TypeParameterInstantiation",
+                "range": [
+                    34,
+                    40
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 34
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 40
+                    }
+                },
+                "params": [
+                    {
+                        "type": "GenericTypeAnnotation",
+                        "range": [
+                            35,
+                            36
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 35
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 36
+                            }
+                        },
+                        "id": {
+                            "type": "Identifier",
+                            "range": [
+                                35,
+                                36
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 35
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 36
+                                }
+                            },
+                            "name": "C"
+                        },
+                        "typeParameters": null
+                    },
+                    {
+                        "type": "GenericTypeAnnotation",
+                        "range": [
+                            38,
+                            39
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 38
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 39
+                            }
+                        },
+                        "id": {
+                            "type": "Identifier",
+                            "range": [
+                                38,
+                                39
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 38
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 39
+                                }
+                            },
+                            "name": "D"
+                        },
+                        "typeParameters": null
+                    }
+                ]
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    6,
+                    9
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 9
+                    }
+                },
+                "name": "Foo"
+            },
+            "body": {
+                "type": "ClassBody",
+                "body": [],
+                "range": [
+                    41,
+                    45
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 41
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 1
+                    }
+                }
+            },
+            "superClass": {
+                "type": "Identifier",
+                "range": [
+                    31,
+                    34
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 31
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 34
+                    }
+                },
+                "name": "Bar"
+            },
+            "implements": [],
+            "decorators": []
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "class",
+            "range": [
+                0,
+                5
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Foo",
+            "range": [
+                6,
+                9
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 6
+                },
+                "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "<",
+            "range": [
+                9,
+                10
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "A",
+            "range": [
+                10,
+                11
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 10
+                },
+                "end": {
+                    "line": 1,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "extends",
+            "range": [
+                12,
+                19
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 12
+                },
+                "end": {
+                    "line": 1,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "B",
+            "range": [
+                20,
+                21
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 20
+                },
+                "end": {
+                    "line": 1,
+                    "column": 21
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ">",
+            "range": [
+                21,
+                22
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 21
+                },
+                "end": {
+                    "line": 1,
+                    "column": 22
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "extends",
+            "range": [
+                23,
+                30
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 23
+                },
+                "end": {
+                    "line": 1,
+                    "column": 30
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Bar",
+            "range": [
+                31,
+                34
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 31
+                },
+                "end": {
+                    "line": 1,
+                    "column": 34
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "<",
+            "range": [
+                34,
+                35
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 34
+                },
+                "end": {
+                    "line": 1,
+                    "column": 35
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "C",
+            "range": [
+                35,
+                36
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 35
+                },
+                "end": {
+                    "line": 1,
+                    "column": 36
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "range": [
+                36,
+                37
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 36
+                },
+                "end": {
+                    "line": 1,
+                    "column": 37
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "D",
+            "range": [
+                38,
+                39
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 38
+                },
+                "end": {
+                    "line": 1,
+                    "column": 39
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ">",
+            "range": [
+                39,
+                40
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 39
+                },
+                "end": {
+                    "line": 1,
+                    "column": 40
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                41,
+                42
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 41
+                },
+                "end": {
+                    "line": 1,
+                    "column": 42
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                44,
+                45
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 1
+                }
+            }
+        }
+    ]
+};

--- a/tests/fixtures/typescript/basics/class-with-extends-generic-multiple.src.ts
+++ b/tests/fixtures/typescript/basics/class-with-extends-generic-multiple.src.ts
@@ -1,0 +1,3 @@
+class Foo<A extends B> extends Bar<C, D> {
+
+}

--- a/tests/fixtures/typescript/basics/class-with-extends-generic.result.js
+++ b/tests/fixtures/typescript/basics/class-with-extends-generic.result.js
@@ -1,0 +1,404 @@
+module.exports = {
+    "type": "Program",
+    "range": [
+        0,
+        32
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 3,
+            "column": 1
+        }
+    },
+    "body": [
+        {
+            "type": "ClassDeclaration",
+            "range": [
+                0,
+                32
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 1
+                }
+            },
+            "typeParameters": {
+                "type": "TypeParameterDeclaration",
+                "range": [
+                    9,
+                    12
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 9
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 12
+                    }
+                },
+                "params": [
+                    {
+                        "type": "TypeParameter",
+                        "range": [
+                            10,
+                            11
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 10
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 11
+                            }
+                        },
+                        "name": "A",
+                        "constraint": null
+                    }
+                ]
+            },
+            "superTypeParameters": {
+                "type": "TypeParameterInstantiation",
+                "range": [
+                    24,
+                    27
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 24
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 27
+                    }
+                },
+                "params": [
+                    {
+                        "type": "GenericTypeAnnotation",
+                        "range": [
+                            25,
+                            26
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 25
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 26
+                            }
+                        },
+                        "id": {
+                            "type": "Identifier",
+                            "range": [
+                                25,
+                                26
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 25
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 26
+                                }
+                            },
+                            "name": "B"
+                        },
+                        "typeParameters": null
+                    }
+                ]
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    6,
+                    9
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 9
+                    }
+                },
+                "name": "Foo"
+            },
+            "body": {
+                "type": "ClassBody",
+                "body": [],
+                "range": [
+                    28,
+                    32
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 28
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 1
+                    }
+                }
+            },
+            "superClass": {
+                "type": "Identifier",
+                "range": [
+                    21,
+                    24
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 21
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 24
+                    }
+                },
+                "name": "Bar"
+            },
+            "implements": [],
+            "decorators": []
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "class",
+            "range": [
+                0,
+                5
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Foo",
+            "range": [
+                6,
+                9
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 6
+                },
+                "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "<",
+            "range": [
+                9,
+                10
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "A",
+            "range": [
+                10,
+                11
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 10
+                },
+                "end": {
+                    "line": 1,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ">",
+            "range": [
+                11,
+                12
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 11
+                },
+                "end": {
+                    "line": 1,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "extends",
+            "range": [
+                13,
+                20
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Bar",
+            "range": [
+                21,
+                24
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 21
+                },
+                "end": {
+                    "line": 1,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "<",
+            "range": [
+                24,
+                25
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 24
+                },
+                "end": {
+                    "line": 1,
+                    "column": 25
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "B",
+            "range": [
+                25,
+                26
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 25
+                },
+                "end": {
+                    "line": 1,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ">",
+            "range": [
+                26,
+                27
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 26
+                },
+                "end": {
+                    "line": 1,
+                    "column": 27
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                28,
+                29
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 28
+                },
+                "end": {
+                    "line": 1,
+                    "column": 29
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                31,
+                32
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 1
+                }
+            }
+        }
+    ]
+};

--- a/tests/fixtures/typescript/basics/class-with-extends-generic.src.ts
+++ b/tests/fixtures/typescript/basics/class-with-extends-generic.src.ts
@@ -1,0 +1,3 @@
+class Foo<A> extends Bar<B> {
+
+}

--- a/tests/fixtures/typescript/basics/class-with-mixin.result.js
+++ b/tests/fixtures/typescript/basics/class-with-mixin.result.js
@@ -1,0 +1,2027 @@
+module.exports = {
+    "type": "Program",
+    "range": [
+        0,
+        206
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 9,
+            "column": 48
+        }
+    },
+    "body": [
+        {
+            "type": "FunctionDeclaration",
+            "range": [
+                0,
+                84
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 1
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    9,
+                    10
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 9
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 10
+                    }
+                },
+                "name": "M"
+            },
+            "generator": false,
+            "expression": false,
+            "async": false,
+            "params": [
+                {
+                    "type": "Identifier",
+                    "range": [
+                        38,
+                        42
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 38
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 42
+                        }
+                    },
+                    "name": "Base",
+                    "typeAnnotation": {
+                        "type": "TypeAnnotation",
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 44
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 45
+                            }
+                        },
+                        "range": [
+                            44,
+                            45
+                        ],
+                        "typeAnnotation": {
+                            "type": "TSTypeReference",
+                            "range": [
+                                44,
+                                45
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 44
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 45
+                                }
+                            },
+                            "typeName": {
+                                "type": "Identifier",
+                                "range": [
+                                    44,
+                                    45
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 44
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 45
+                                    }
+                                },
+                                "name": "T"
+                            }
+                        }
+                    }
+                }
+            ],
+            "body": {
+                "type": "BlockStatement",
+                "range": [
+                    47,
+                    84
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 47
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 1
+                    }
+                },
+                "body": [
+                    {
+                        "type": "ReturnStatement",
+                        "range": [
+                            53,
+                            82
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 33
+                            }
+                        },
+                        "argument": {
+                            "type": "ClassExpression",
+                            "range": [
+                                60,
+                                82
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 11
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 33
+                                }
+                            },
+                            "id": null,
+                            "body": {
+                                "type": "ClassBody",
+                                "body": [],
+                                "range": [
+                                    79,
+                                    82
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 30
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 33
+                                    }
+                                }
+                            },
+                            "superClass": {
+                                "type": "Identifier",
+                                "range": [
+                                    74,
+                                    78
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 25
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 29
+                                    }
+                                },
+                                "name": "Base"
+                            },
+                            "implements": [],
+                            "decorators": []
+                        }
+                    }
+                ]
+            },
+            "typeParameters": {
+                "type": "TypeParameterDeclaration",
+                "range": [
+                    10,
+                    37
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 10
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 37
+                    }
+                },
+                "params": [
+                    {
+                        "type": "TypeParameter",
+                        "range": [
+                            11,
+                            36
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 11
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 36
+                            }
+                        },
+                        "name": "T",
+                        "constraint": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 21
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 36
+                                }
+                            },
+                            "range": [
+                                21,
+                                36
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSTypeReference",
+                                "range": [
+                                    21,
+                                    36
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 21
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 36
+                                    }
+                                },
+                                "typeName": {
+                                    "type": "Identifier",
+                                    "range": [
+                                        21,
+                                        32
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 1,
+                                            "column": 21
+                                        },
+                                        "end": {
+                                            "line": 1,
+                                            "column": 32
+                                        }
+                                    },
+                                    "name": "Constructor"
+                                },
+                                "typeArguments": [
+                                    {
+                                        "type": "TSTypeLiteral",
+                                        "range": [
+                                            33,
+                                            35
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 1,
+                                                "column": 33
+                                            },
+                                            "end": {
+                                                "line": 1,
+                                                "column": 35
+                                            }
+                                        },
+                                        "members": []
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "ClassDeclaration",
+            "range": [
+                86,
+                128
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 0
+                },
+                "end": {
+                    "line": 5,
+                    "column": 42
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    92,
+                    93
+                ],
+                "loc": {
+                    "start": {
+                        "line": 5,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 5,
+                        "column": 7
+                    }
+                },
+                "name": "X"
+            },
+            "body": {
+                "type": "ClassBody",
+                "body": [],
+                "range": [
+                    125,
+                    128
+                ],
+                "loc": {
+                    "start": {
+                        "line": 5,
+                        "column": 39
+                    },
+                    "end": {
+                        "line": 5,
+                        "column": 42
+                    }
+                }
+            },
+            "superClass": {
+                "type": "CallExpression",
+                "range": [
+                    102,
+                    111
+                ],
+                "loc": {
+                    "start": {
+                        "line": 5,
+                        "column": 16
+                    },
+                    "end": {
+                        "line": 5,
+                        "column": 25
+                    }
+                },
+                "callee": {
+                    "type": "Identifier",
+                    "range": [
+                        102,
+                        103
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 16
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 17
+                        }
+                    },
+                    "name": "M"
+                },
+                "arguments": [
+                    {
+                        "type": "Identifier",
+                        "range": [
+                            109,
+                            110
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 5,
+                                "column": 23
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 24
+                            }
+                        },
+                        "name": "C"
+                    }
+                ],
+                "typeParameters": {
+                    "type": "TypeParameterInstantiation",
+                    "range": [
+                        103,
+                        108
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 17
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 22
+                        }
+                    },
+                    "params": [
+                        {
+                            "type": "GenericTypeAnnotation",
+                            "range": [
+                                104,
+                                107
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 18
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 21
+                                }
+                            },
+                            "id": {
+                                "type": "TSAnyKeyword",
+                                "range": [
+                                    104,
+                                    107
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 5,
+                                        "column": 18
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 21
+                                    }
+                                }
+                            },
+                            "typeParameters": null
+                        }
+                    ]
+                }
+            },
+            "implements": [
+                {
+                    "type": "ClassImplements",
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 37
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 38
+                        }
+                    },
+                    "range": [
+                        123,
+                        124
+                    ],
+                    "id": {
+                        "type": "Identifier",
+                        "range": [
+                            123,
+                            124
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 5,
+                                "column": 37
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 38
+                            }
+                        },
+                        "name": "I"
+                    }
+                }
+            ],
+            "decorators": []
+        },
+        {
+            "type": "ClassDeclaration",
+            "range": [
+                130,
+                141
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 0
+                },
+                "end": {
+                    "line": 7,
+                    "column": 11
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    136,
+                    137
+                ],
+                "loc": {
+                    "start": {
+                        "line": 7,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 7,
+                        "column": 7
+                    }
+                },
+                "name": "C"
+            },
+            "body": {
+                "type": "ClassBody",
+                "body": [],
+                "range": [
+                    138,
+                    141
+                ],
+                "loc": {
+                    "start": {
+                        "line": 7,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 7,
+                        "column": 11
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
+        },
+        {
+            "type": "TSInterfaceDeclaration",
+            "range": [
+                142,
+                157
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 0
+                },
+                "end": {
+                    "line": 8,
+                    "column": 15
+                }
+            },
+            "name": {
+                "type": "Identifier",
+                "range": [
+                    152,
+                    153
+                ],
+                "loc": {
+                    "start": {
+                        "line": 8,
+                        "column": 10
+                    },
+                    "end": {
+                        "line": 8,
+                        "column": 11
+                    }
+                },
+                "name": "I"
+            },
+            "members": []
+        },
+        {
+            "type": "VariableDeclaration",
+            "range": [
+                158,
+                206
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 0
+                },
+                "end": {
+                    "line": 9,
+                    "column": 48
+                }
+            },
+            "kind": "type",
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "id": {
+                        "type": "Identifier",
+                        "range": [
+                            163,
+                            174
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 9,
+                                "column": 5
+                            },
+                            "end": {
+                                "line": 9,
+                                "column": 16
+                            }
+                        },
+                        "name": "Constructor"
+                    },
+                    "init": {
+                        "type": "TSConstructorType",
+                        "range": [
+                            180,
+                            205
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 9,
+                                "column": 22
+                            },
+                            "end": {
+                                "line": 9,
+                                "column": 47
+                            }
+                        },
+                        "parameters": [
+                            {
+                                "type": "RestElement",
+                                "range": [
+                                    185,
+                                    199
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 9,
+                                        "column": 27
+                                    },
+                                    "end": {
+                                        "line": 9,
+                                        "column": 41
+                                    }
+                                },
+                                "argument": {
+                                    "type": "Identifier",
+                                    "range": [
+                                        188,
+                                        192
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 9,
+                                            "column": 30
+                                        },
+                                        "end": {
+                                            "line": 9,
+                                            "column": 34
+                                        }
+                                    },
+                                    "name": "args",
+                                    "typeAnnotation": {
+                                        "type": "TypeAnnotation",
+                                        "loc": {
+                                            "start": {
+                                                "line": 9,
+                                                "column": 36
+                                            },
+                                            "end": {
+                                                "line": 9,
+                                                "column": 41
+                                            }
+                                        },
+                                        "range": [
+                                            194,
+                                            199
+                                        ],
+                                        "typeAnnotation": {
+                                            "type": "TSArrayType",
+                                            "range": [
+                                                194,
+                                                199
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 9,
+                                                    "column": 36
+                                                },
+                                                "end": {
+                                                    "line": 9,
+                                                    "column": 41
+                                                }
+                                            },
+                                            "elementType": {
+                                                "type": "TSAnyKeyword",
+                                                "range": [
+                                                    194,
+                                                    197
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 9,
+                                                        "column": 36
+                                                    },
+                                                    "end": {
+                                                        "line": 9,
+                                                        "column": 39
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 9,
+                                    "column": 46
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 47
+                                }
+                            },
+                            "range": [
+                                204,
+                                205
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSTypeReference",
+                                "range": [
+                                    204,
+                                    205
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 9,
+                                        "column": 46
+                                    },
+                                    "end": {
+                                        "line": 9,
+                                        "column": 47
+                                    }
+                                },
+                                "typeName": {
+                                    "type": "Identifier",
+                                    "range": [
+                                        204,
+                                        205
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 9,
+                                            "column": 46
+                                        },
+                                        "end": {
+                                            "line": 9,
+                                            "column": 47
+                                        }
+                                    },
+                                    "name": "T"
+                                }
+                            }
+                        }
+                    },
+                    "range": [
+                        163,
+                        206
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 9,
+                            "column": 5
+                        },
+                        "end": {
+                            "line": 9,
+                            "column": 48
+                        }
+                    },
+                    "typeParameters": {
+                        "type": "TypeParameterDeclaration",
+                        "range": [
+                            174,
+                            177
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 9,
+                                "column": 16
+                            },
+                            "end": {
+                                "line": 9,
+                                "column": 19
+                            }
+                        },
+                        "params": [
+                            {
+                                "type": "TypeParameter",
+                                "range": [
+                                    175,
+                                    176
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 9,
+                                        "column": 17
+                                    },
+                                    "end": {
+                                        "line": 9,
+                                        "column": 18
+                                    }
+                                },
+                                "name": "T",
+                                "constraint": null
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "function",
+            "range": [
+                0,
+                8
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "M",
+            "range": [
+                9,
+                10
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "<",
+            "range": [
+                10,
+                11
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 10
+                },
+                "end": {
+                    "line": 1,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "T",
+            "range": [
+                11,
+                12
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 11
+                },
+                "end": {
+                    "line": 1,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "extends",
+            "range": [
+                13,
+                20
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Constructor",
+            "range": [
+                21,
+                32
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 21
+                },
+                "end": {
+                    "line": 1,
+                    "column": 32
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "<",
+            "range": [
+                32,
+                33
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 32
+                },
+                "end": {
+                    "line": 1,
+                    "column": 33
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                33,
+                34
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 33
+                },
+                "end": {
+                    "line": 1,
+                    "column": 34
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                34,
+                35
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 34
+                },
+                "end": {
+                    "line": 1,
+                    "column": 35
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ">",
+            "range": [
+                35,
+                36
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 35
+                },
+                "end": {
+                    "line": 1,
+                    "column": 36
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ">",
+            "range": [
+                36,
+                37
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 36
+                },
+                "end": {
+                    "line": 1,
+                    "column": 37
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                37,
+                38
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 37
+                },
+                "end": {
+                    "line": 1,
+                    "column": 38
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Base",
+            "range": [
+                38,
+                42
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 38
+                },
+                "end": {
+                    "line": 1,
+                    "column": 42
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                42,
+                43
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 42
+                },
+                "end": {
+                    "line": 1,
+                    "column": 43
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "T",
+            "range": [
+                44,
+                45
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 44
+                },
+                "end": {
+                    "line": 1,
+                    "column": 45
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                45,
+                46
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 45
+                },
+                "end": {
+                    "line": 1,
+                    "column": 46
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                47,
+                48
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 47
+                },
+                "end": {
+                    "line": 1,
+                    "column": 48
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "return",
+            "range": [
+                53,
+                59
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "range": [
+                60,
+                65
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 11
+                },
+                "end": {
+                    "line": 2,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "extends",
+            "range": [
+                66,
+                73
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 17
+                },
+                "end": {
+                    "line": 2,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Base",
+            "range": [
+                74,
+                78
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 25
+                },
+                "end": {
+                    "line": 2,
+                    "column": 29
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                79,
+                80
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 30
+                },
+                "end": {
+                    "line": 2,
+                    "column": 31
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                81,
+                82
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 32
+                },
+                "end": {
+                    "line": 2,
+                    "column": 33
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                83,
+                84
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 1
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "range": [
+                86,
+                91
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 0
+                },
+                "end": {
+                    "line": 5,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "X",
+            "range": [
+                92,
+                93
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 6
+                },
+                "end": {
+                    "line": 5,
+                    "column": 7
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "extends",
+            "range": [
+                94,
+                101
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 8
+                },
+                "end": {
+                    "line": 5,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "M",
+            "range": [
+                102,
+                103
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 16
+                },
+                "end": {
+                    "line": 5,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "<",
+            "range": [
+                103,
+                104
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 17
+                },
+                "end": {
+                    "line": 5,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "any",
+            "range": [
+                104,
+                107
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 18
+                },
+                "end": {
+                    "line": 5,
+                    "column": 21
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ">",
+            "range": [
+                107,
+                108
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 21
+                },
+                "end": {
+                    "line": 5,
+                    "column": 22
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                108,
+                109
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 22
+                },
+                "end": {
+                    "line": 5,
+                    "column": 23
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "C",
+            "range": [
+                109,
+                110
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 23
+                },
+                "end": {
+                    "line": 5,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                110,
+                111
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 24
+                },
+                "end": {
+                    "line": 5,
+                    "column": 25
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "implements",
+            "range": [
+                112,
+                122
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 26
+                },
+                "end": {
+                    "line": 5,
+                    "column": 36
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "I",
+            "range": [
+                123,
+                124
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 37
+                },
+                "end": {
+                    "line": 5,
+                    "column": 38
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                125,
+                126
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 39
+                },
+                "end": {
+                    "line": 5,
+                    "column": 40
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                127,
+                128
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 41
+                },
+                "end": {
+                    "line": 5,
+                    "column": 42
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "range": [
+                130,
+                135
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 0
+                },
+                "end": {
+                    "line": 7,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "C",
+            "range": [
+                136,
+                137
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 6
+                },
+                "end": {
+                    "line": 7,
+                    "column": 7
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                138,
+                139
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 8
+                },
+                "end": {
+                    "line": 7,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                140,
+                141
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 10
+                },
+                "end": {
+                    "line": 7,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "interface",
+            "range": [
+                142,
+                151
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 0
+                },
+                "end": {
+                    "line": 8,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "I",
+            "range": [
+                152,
+                153
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 10
+                },
+                "end": {
+                    "line": 8,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                154,
+                155
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 12
+                },
+                "end": {
+                    "line": 8,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                156,
+                157
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 14
+                },
+                "end": {
+                    "line": 8,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "type",
+            "range": [
+                158,
+                162
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 0
+                },
+                "end": {
+                    "line": 9,
+                    "column": 4
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Constructor",
+            "range": [
+                163,
+                174
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 5
+                },
+                "end": {
+                    "line": 9,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "<",
+            "range": [
+                174,
+                175
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 16
+                },
+                "end": {
+                    "line": 9,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "T",
+            "range": [
+                175,
+                176
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 17
+                },
+                "end": {
+                    "line": 9,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ">",
+            "range": [
+                176,
+                177
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 18
+                },
+                "end": {
+                    "line": 9,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "range": [
+                178,
+                179
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 20
+                },
+                "end": {
+                    "line": 9,
+                    "column": 21
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "new",
+            "range": [
+                180,
+                183
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 22
+                },
+                "end": {
+                    "line": 9,
+                    "column": 25
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                184,
+                185
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 26
+                },
+                "end": {
+                    "line": 9,
+                    "column": 27
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "...",
+            "range": [
+                185,
+                188
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 27
+                },
+                "end": {
+                    "line": 9,
+                    "column": 30
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "args",
+            "range": [
+                188,
+                192
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 30
+                },
+                "end": {
+                    "line": 9,
+                    "column": 34
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                192,
+                193
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 34
+                },
+                "end": {
+                    "line": 9,
+                    "column": 35
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "any",
+            "range": [
+                194,
+                197
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 36
+                },
+                "end": {
+                    "line": 9,
+                    "column": 39
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "[",
+            "range": [
+                197,
+                198
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 39
+                },
+                "end": {
+                    "line": 9,
+                    "column": 40
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "]",
+            "range": [
+                198,
+                199
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 40
+                },
+                "end": {
+                    "line": 9,
+                    "column": 41
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                199,
+                200
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 41
+                },
+                "end": {
+                    "line": 9,
+                    "column": 42
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=>",
+            "range": [
+                201,
+                203
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 43
+                },
+                "end": {
+                    "line": 9,
+                    "column": 45
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "T",
+            "range": [
+                204,
+                205
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 46
+                },
+                "end": {
+                    "line": 9,
+                    "column": 47
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                205,
+                206
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 47
+                },
+                "end": {
+                    "line": 9,
+                    "column": 48
+                }
+            }
+        }
+    ]
+};

--- a/tests/fixtures/typescript/basics/class-with-mixin.src.ts
+++ b/tests/fixtures/typescript/basics/class-with-mixin.src.ts
@@ -1,0 +1,9 @@
+function M<T extends Constructor<{}>>(Base: T) {
+    return class extends Base { }
+}
+
+class X extends M<any>(C) implements I { }
+
+class C { }
+interface I { }
+type Constructor<T> = new (...args: any[]) => T;


### PR DESCRIPTION
Adds the `superTypeParameters` field to the `ClassExpression`/`ClassDeclaration` AST nodes.

prettier/prettier#1422

