### PR TITLE
Fix: add `instanceof` to ast-converter

### DIFF
--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -59,6 +59,7 @@ TOKEN_TO_TEXT[SyntaxKind.GreaterThanEqualsToken] = ">=";
 TOKEN_TO_TEXT[SyntaxKind.EqualsEqualsToken] = "==";
 TOKEN_TO_TEXT[SyntaxKind.ExclamationEqualsToken] = "!=";
 TOKEN_TO_TEXT[SyntaxKind.EqualsEqualsEqualsToken] = "===";
+TOKEN_TO_TEXT[SyntaxKind.InstanceOfKeyword] = "instanceof";
 TOKEN_TO_TEXT[SyntaxKind.ExclamationEqualsEqualsToken] = "!==";
 TOKEN_TO_TEXT[SyntaxKind.EqualsGreaterThanToken] = "=>";
 TOKEN_TO_TEXT[SyntaxKind.PlusToken] = "+";

--- a/tests/fixtures/basics/instanceof.result.js
+++ b/tests/fixtures/basics/instanceof.result.js
@@ -1,0 +1,148 @@
+module.exports = {
+    "type": "Program",
+    "range": [
+        0,
+        17
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 17
+        }
+    },
+    "body": [
+        {
+            "type": "ExpressionStatement",
+            "range": [
+                0,
+                17
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 17
+                }
+            },
+            "expression": {
+                "type": "BinaryExpression",
+                "range": [
+                    0,
+                    17
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 17
+                    }
+                },
+                "left": {
+                    "type": "Literal",
+                    "range": [
+                        0,
+                        2
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 2
+                        }
+                    },
+                    "value": "",
+                    "raw": "''"
+                },
+                "operator": "instanceof",
+                "right": {
+                    "type": "Identifier",
+                    "range": [
+                        14,
+                        17
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 14
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 17
+                        }
+                    },
+                    "name": "Set"
+                }
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "String",
+            "value": "''",
+            "range": [
+                0,
+                2
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 2
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "instanceof",
+            "range": [
+                3,
+                13
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 3
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Set",
+            "range": [
+                14,
+                17
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 14
+                },
+                "end": {
+                    "line": 1,
+                    "column": 17
+                }
+            }
+        }
+    ]
+};

--- a/tests/fixtures/basics/instanceof.src.js
+++ b/tests/fixtures/basics/instanceof.src.js
@@ -1,0 +1,1 @@
+'' instanceof Set


### PR DESCRIPTION
The `BinaryExpression` created by `instanceof` does not set the operator of the node, because the keyword is missing in `TOKEN_TO_TEXT`.

This was discovered by https://github.com/prettier/prettier/issues/1480

fixes: #252