### PR TITLE
Fix type parameter start location calculation

### DIFF
--- a/lib/ast-converter.js
+++ b/lib/ast-converter.js
@@ -632,8 +632,8 @@ module.exports = function(ast, extra) {
                      * Have to manually calculate the start of the range,
                      * because TypeScript includes leading whitespace but Flow does not
                      */
-                    var typeParameterStart = (typeParameter.typeName && typeParameter.typeName.text)
-                        ? typeParameter.end - typeParameter.typeName.text.length
+                    var typeParameterStart = (typeParameter.name && typeParameter.name.text)
+                        ? typeParameter.name.end - typeParameter.name.text.length
                         : typeParameter.pos;
 
                     var defaultParameter = typeParameter.default

--- a/tests/fixtures/typescript/basics/export-default-class-with-multiple-generics.result.js
+++ b/tests/fixtures/typescript/basics/export-default-class-with-multiple-generics.result.js
@@ -72,13 +72,13 @@ module.exports = {
                                     "line": 1
                                 },
                                 "start": {
-                                    "column": 23,
+                                    "column": 24,
                                     "line": 1
                                 }
                             },
                             "name": "U",
                             "range": [
-                                23,
+                                24,
                                 25
                             ],
                             "type": "TypeParameter",

--- a/tests/fixtures/typescript/basics/export-named-class-with-multiple-generics.result.js
+++ b/tests/fixtures/typescript/basics/export-named-class-with-multiple-generics.result.js
@@ -89,13 +89,13 @@ module.exports = {
                                     "line": 1
                                 },
                                 "start": {
-                                    "column": 19,
+                                    "column": 20,
                                     "line": 1
                                 }
                             },
                             "name": "U",
                             "range": [
-                                19,
+                                20,
                                 21
                             ],
                             "type": "TypeParameter",

--- a/tests/fixtures/typescript/basics/function-with-type-parameters-that-have-comments.result.js
+++ b/tests/fixtures/typescript/basics/function-with-type-parameters-that-have-comments.result.js
@@ -1,0 +1,229 @@
+module.exports = {
+    body: [{
+        async: false,
+        body: {
+            body: [],
+            loc: {
+                end: {
+                    column: 35,
+                    line: 1
+                },
+                start: {
+                    column: 33,
+                    line: 1
+                }
+            },
+            range: [33, 35],
+            type: "BlockStatement"
+        },
+        expression: false,
+        generator: false,
+        id: {
+            loc: {
+                end: {
+                    column: 16,
+                    line: 1
+                },
+                start: {
+                    column: 9,
+                    line: 1
+                }
+            },
+            name: "compare",
+            range: [9, 16],
+            type: "Identifier"
+        },
+        loc: {
+            end: {
+                column: 35,
+                line: 1
+            },
+            start: {
+                column: 0,
+                line: 1
+            }
+        },
+        params: [],
+        range: [0, 35],
+        type: "FunctionDeclaration",
+        typeParameters: {
+            loc: {
+                end: {
+                    column: 30,
+                    line: 1
+                },
+                start: {
+                    column: 16,
+                    line: 1
+                }
+            },
+            params: [{
+                constraint: null,
+                loc: {
+                    end: {
+                        column: 29,
+                        line: 1
+                    },
+                    start: {
+                        column: 17,
+                        line: 1
+                    }
+                },
+                name: "T",
+                range: [17, 29],
+                type: "TypeParameter"
+            }],
+            range: [16, 30],
+            type: "TypeParameterDeclaration"
+        }
+    }],
+    loc: {
+        end: {
+            column: 35,
+            line: 1
+        },
+        start: {
+            column: 0,
+            line: 1
+        }
+    },
+    range: [0, 35],
+    sourceType: "script",
+    tokens: [{
+            loc: {
+                end: {
+                    column: 8,
+                    line: 1
+                },
+                start: {
+                    column: 0,
+                    line: 1
+                }
+            },
+            range: [0, 8],
+            type: "Keyword",
+            value: "function"
+        },
+        {
+            loc: {
+                end: {
+                    column: 16,
+                    line: 1
+                },
+                start: {
+                    column: 9,
+                    line: 1
+                }
+            },
+            range: [9, 16],
+            type: "Identifier",
+            value: "compare"
+        },
+        {
+            loc: {
+                end: {
+                    column: 17,
+                    line: 1
+                },
+                start: {
+                    column: 16,
+                    line: 1
+                }
+            },
+            range: [16, 17],
+            type: "Punctuator",
+            value: "<"
+        },
+        {
+            loc: {
+                end: {
+                    column: 29,
+                    line: 1
+                },
+                start: {
+                    column: 28,
+                    line: 1
+                }
+            },
+            range: [28, 29],
+            type: "Identifier",
+            value: "T"
+        },
+        {
+            loc: {
+                end: {
+                    column: 30,
+                    line: 1
+                },
+                start: {
+                    column: 29,
+                    line: 1
+                }
+            },
+            range: [29, 30],
+            type: "Punctuator",
+            value: ">"
+        },
+        {
+            loc: {
+                end: {
+                    column: 31,
+                    line: 1
+                },
+                start: {
+                    column: 30,
+                    line: 1
+                }
+            },
+            range: [30, 31],
+            type: "Punctuator",
+            value: "("
+        },
+        {
+            loc: {
+                end: {
+                    column: 32,
+                    line: 1
+                },
+                start: {
+                    column: 31,
+                    line: 1
+                }
+            },
+            range: [31, 32],
+            type: "Punctuator",
+            value: ")"
+        },
+        {
+            loc: {
+                end: {
+                    column: 34,
+                    line: 1
+                },
+                start: {
+                    column: 33,
+                    line: 1
+                }
+            },
+            range: [33, 34],
+            type: "Punctuator",
+            value: "{"
+        },
+        {
+            loc: {
+                end: {
+                    column: 35,
+                    line: 1
+                },
+                start: {
+                    column: 34,
+                    line: 1
+                }
+            },
+            range: [34, 35],
+            type: "Punctuator",
+            value: "}"
+        }
+    ],
+    type: "Program"
+};

--- a/tests/fixtures/typescript/basics/function-with-type-parameters-that-have-comments.result.js
+++ b/tests/fixtures/typescript/basics/function-with-type-parameters-that-have-comments.result.js
@@ -65,12 +65,12 @@ module.exports = {
                         line: 1
                     },
                     start: {
-                        column: 17,
+                        column: 28,
                         line: 1
                     }
                 },
                 name: "T",
-                range: [17, 29],
+                range: [28, 29],
                 type: "TypeParameter"
             }],
             range: [16, 30],

--- a/tests/fixtures/typescript/basics/function-with-type-parameters-that-have-comments.src.ts
+++ b/tests/fixtures/typescript/basics/function-with-type-parameters-that-have-comments.src.ts
@@ -1,0 +1,1 @@
+function compare</*comment*/T>() {}


### PR DESCRIPTION
Before:
```ts
function compare</*comment*/T,    U>() {}
//               ~~~~~~~~~~~~ TypeParameter T
//                            ~~~~~ TypeParameter U
```
After:
```ts
function compare</*comment*/T,    U>() {}
//                          ~ TypeParameter T
//                                ~ TypeParameter U
```