### PR TITLE
Breaking: Convert Signature types to be more ESTree like (fixes #262)

### DIFF
--- a/lib/ast-node-types.js
+++ b/lib/ast-node-types.js
@@ -106,6 +106,7 @@ module.exports = {
     TSConstructorType: "TSConstructorType",
     TSConstructSignature: "TSConstructSignature",
     TSDeclareKeyword: "TSDeclareKeyword",
+    TSIndexSignature: "TSIndexSignature",
     TSInterfaceBody: "TSInterfaceBody",
     TSInterfaceDeclaration: "TSInterfaceDeclaration",
     TSInterfaceHeritage: "TSInterfaceHeritage",

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -618,7 +618,7 @@ module.exports = function convert(config) {
                 type: AST_NODE_TYPES.Property,
                 key: convertChild(node.name),
                 value: convertChild(node.initializer),
-                computed: (node.name.kind === SyntaxKind.ComputedPropertyName),
+                computed: nodeUtils.isComputedProperty(node.name),
                 method: false,
                 shorthand: false,
                 kind: "init"
@@ -660,7 +660,7 @@ module.exports = function convert(config) {
                 type: (isAbstract) ? AST_NODE_TYPES.TSAbstractClassProperty : AST_NODE_TYPES.ClassProperty,
                 key: convertChild(node.name),
                 value: convertChild(node.initializer),
-                computed: (node.name.kind === SyntaxKind.ComputedPropertyName),
+                computed: nodeUtils.isComputedProperty(node.name),
                 static: nodeUtils.hasStaticModifierFlag(node),
                 accessibility: nodeUtils.getTSNodeAccessibility(node),
                 decorators: convertDecorators(node.decorators),
@@ -713,7 +713,7 @@ module.exports = function convert(config) {
                     type: AST_NODE_TYPES.Property,
                     key: convertChild(node.name),
                     value: method,
-                    computed: (node.name.kind === SyntaxKind.ComputedPropertyName),
+                    computed: nodeUtils.isComputedProperty(node.name),
                     method: nodeIsMethod,
                     shorthand: false,
                     kind: "init"
@@ -730,8 +730,6 @@ module.exports = function convert(config) {
                     return convertedParam;
                 });
 
-                const isMethodNameComputed = (node.name.kind === SyntaxKind.ComputedPropertyName);
-
                 /**
                  * TypeScript class methods can be defined as "abstract"
                  */
@@ -743,7 +741,7 @@ module.exports = function convert(config) {
                     type: methodDefinitionType,
                     key: convertChild(node.name),
                     value: method,
-                    computed: isMethodNameComputed,
+                    computed: nodeUtils.isComputedProperty(node.name),
                     static: nodeUtils.hasStaticModifierFlag(node),
                     kind: "method",
                     accessibility: nodeUtils.getTSNodeAccessibility(node),
@@ -805,7 +803,7 @@ module.exports = function convert(config) {
                 };
 
             const constructorIdentifierLoc = ast.getLineAndCharacterOfPosition(firstConstructorToken.getStart()),
-                constructorIsComputed = !!node.name && (node.name.kind === SyntaxKind.ComputedPropertyName);
+                constructorIsComputed = !!node.name && nodeUtils.isComputedProperty(node.name);
 
             let constructorKey;
 
@@ -1726,8 +1724,8 @@ module.exports = function convert(config) {
         case SyntaxKind.MethodSignature: {
             Object.assign(result, {
                 type: AST_NODE_TYPES.TSMethodSignature,
-                optional: (node.questionToken) ? (node.questionToken.kind === SyntaxKind.QuestionToken) : false,
-                computed: node.name.kind === SyntaxKind.ComputedPropertyName,
+                optional: nodeUtils.isOptional(node),
+                computed: nodeUtils.isComputedProperty(node.name),
                 key: convertChild(node.name),
                 params: node.parameters.map(parameter => convertChild(parameter)),
                 typeAnnotation: (node.type) ? convertTypeAnnotation(node.type) : null
@@ -1743,8 +1741,8 @@ module.exports = function convert(config) {
         case SyntaxKind.PropertySignature: {
             Object.assign(result, {
                 type: AST_NODE_TYPES.TSPropertySignature,
-                optional: (node.questionToken) ? (node.questionToken.kind === SyntaxKind.QuestionToken) : false,
-                computed: node.name.kind === SyntaxKind.ComputedPropertyName,
+                optional: nodeUtils.isOptional(node),
+                computed: nodeUtils.isComputedProperty(node.name),
                 key: convertChild(node.name),
                 typeAnnotation: (node.type) ? convertTypeAnnotation(node.type) : null
             });

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -1728,7 +1728,11 @@ module.exports = function convert(config) {
                 computed: nodeUtils.isComputedProperty(node.name),
                 key: convertChild(node.name),
                 params: node.parameters.map(parameter => convertChild(parameter)),
-                typeAnnotation: (node.type) ? convertTypeAnnotation(node.type) : null
+                typeAnnotation: (node.type) ? convertTypeAnnotation(node.type) : null,
+                accessibility: nodeUtils.getTSNodeAccessibility(node),
+                readonly: nodeUtils.hasModifier(SyntaxKind.ReadonlyKeyword, node),
+                static: nodeUtils.hasModifier(SyntaxKind.StaticKeyword, node),
+                export: nodeUtils.hasModifier(SyntaxKind.ExportKeyword, node)
             });
 
             if (node.typeParameters) {
@@ -1744,7 +1748,12 @@ module.exports = function convert(config) {
                 optional: nodeUtils.isOptional(node),
                 computed: nodeUtils.isComputedProperty(node.name),
                 key: convertChild(node.name),
-                typeAnnotation: (node.type) ? convertTypeAnnotation(node.type) : null
+                typeAnnotation: (node.type) ? convertTypeAnnotation(node.type) : null,
+                initializer: convertChild(node.initializer),
+                accessibility: nodeUtils.getTSNodeAccessibility(node),
+                readonly: nodeUtils.hasModifier(SyntaxKind.ReadonlyKeyword, node),
+                static: nodeUtils.hasModifier(SyntaxKind.StaticKeyword, node),
+                export: nodeUtils.hasModifier(SyntaxKind.ExportKeyword, node)
             });
 
             break;
@@ -1754,7 +1763,11 @@ module.exports = function convert(config) {
             Object.assign(result, {
                 type: AST_NODE_TYPES.TSIndexSignature,
                 index: convertChild(node.parameters[0]),
-                typeAnnotation: (node.type) ? convertTypeAnnotation(node.type) : null
+                typeAnnotation: (node.type) ? convertTypeAnnotation(node.type) : null,
+                accessibility: nodeUtils.getTSNodeAccessibility(node),
+                readonly: nodeUtils.hasModifier(SyntaxKind.ReadonlyKeyword, node),
+                static: nodeUtils.hasModifier(SyntaxKind.StaticKeyword, node),
+                export: nodeUtils.hasModifier(SyntaxKind.ExportKeyword, node)
             });
 
             break;

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -1723,6 +1723,59 @@ module.exports = function convert(config) {
 
         }
 
+        case SyntaxKind.MethodSignature: {
+            Object.assign(result, {
+                type: AST_NODE_TYPES.TSMethodSignature,
+                optional: (node.questionToken) ? (node.questionToken.kind === SyntaxKind.QuestionToken) : false,
+                computed: node.name.kind === SyntaxKind.ComputedPropertyName,
+                key: convertChild(node.name),
+                params: node.parameters.map(parameter => convertChild(parameter)),
+                typeAnnotation: (node.type) ? convertTypeAnnotation(node.type) : null
+            });
+
+            if (node.typeParameters) {
+                result.typeParameters = convertTSTypeParametersToTypeParametersDeclaration(node.typeParameters);
+            }
+
+            break;
+        }
+
+        case SyntaxKind.PropertySignature: {
+            Object.assign(result, {
+                type: AST_NODE_TYPES.TSPropertySignature,
+                optional: (node.questionToken) ? (node.questionToken.kind === SyntaxKind.QuestionToken) : false,
+                computed: node.name.kind === SyntaxKind.ComputedPropertyName,
+                key: convertChild(node.name),
+                typeAnnotation: (node.type) ? convertTypeAnnotation(node.type) : null
+            });
+
+            break;
+        }
+
+        case SyntaxKind.IndexSignature: {
+            Object.assign(result, {
+                type: AST_NODE_TYPES.TSIndexSignature,
+                index: convertChild(node.parameters[0]),
+                typeAnnotation: (node.type) ? convertTypeAnnotation(node.type) : null
+            });
+
+            break;
+        }
+
+        case SyntaxKind.ConstructSignature: {
+            Object.assign(result, {
+                type: AST_NODE_TYPES.TSConstructSignature,
+                params: node.parameters.map(parameter => convertChild(parameter)),
+                typeAnnotation: (node.type) ? convertTypeAnnotation(node.type) : null
+            });
+
+            if (node.typeParameters) {
+                result.typeParameters = convertTSTypeParametersToTypeParametersDeclaration(node.typeParameters);
+            }
+
+            break;
+        }
+
         case SyntaxKind.InterfaceDeclaration: {
             const interfaceHeritageClauses = node.heritageClauses || [];
 
@@ -1769,15 +1822,6 @@ module.exports = function convert(config) {
                 parameterName: convertChild(node.parameterName),
                 typeAnnotation: convertTypeAnnotation(node.type)
             });
-            break;
-
-        case SyntaxKind.PropertySignature:
-        case SyntaxKind.MethodSignature:
-            deeplyCopy();
-
-            if (node.questionToken) {
-                result.name.optional = true;
-            }
             break;
 
         default:

--- a/lib/node-utils.js
+++ b/lib/node-utils.js
@@ -186,6 +186,8 @@ module.exports = {
     hasJSXAncestor,
     unescapeIdentifier,
     unescapeStringLiteralText,
+    isComputedProperty,
+    isOptional,
     fixExports,
     getTokenType,
     convertToken,
@@ -444,6 +446,25 @@ function unescapeIdentifier(identifier) {
  */
 function unescapeStringLiteralText(text) {
     return unescape(text);
+}
+
+/**
+ * Returns true if a given TSNode is a computed property
+ * @param  {TSNode} node TSNode to be checked
+ * @returns {boolean}       is Computed Property
+ */
+function isComputedProperty(node) {
+    return node.kind === SyntaxKind.ComputedPropertyName;
+}
+
+/**
+ * Returns true if a given TSNode is optional (has QuestionToken)
+ * @param  {TSNode} node TSNode to be checked
+ * @returns {boolean}       is Optional
+ */
+function isOptional(node) {
+    return (node.questionToken)
+        ? (node.questionToken.kind === SyntaxKind.QuestionToken) : false;
 }
 
 /**

--- a/tests/fixtures/typescript/basics/export-type-class-declaration.result.js
+++ b/tests/fixtures/typescript/basics/export-type-class-declaration.result.js
@@ -107,49 +107,51 @@ module.exports = {
                                         48
                                     ],
                                     "loc": {
-                                        "end": {
-                                            "line": 2,
-                                            "column": 17
-                                        },
                                         "start": {
                                             "line": 2,
                                             "column": 4
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 17
                                         }
                                     },
-                                    "name": {
+                                    "optional": false,
+                                    "computed": false,
+                                    "key": {
                                         "type": "Identifier",
                                         "range": [
                                             35,
                                             40
                                         ],
                                         "loc": {
-                                            "end": {
-                                                "line": 2,
-                                                "column": 9
-                                            },
                                             "start": {
                                                 "line": 2,
                                                 "column": 4
+                                            },
+                                            "end": {
+                                                "line": 2,
+                                                "column": 9
                                             }
                                         },
                                         "name": "count"
                                     },
                                     "typeAnnotation": {
                                         "type": "TypeAnnotation",
+                                        "loc": {
+                                            "start": {
+                                                "line": 2,
+                                                "column": 11
+                                            },
+                                            "end": {
+                                                "line": 2,
+                                                "column": 17
+                                            }
+                                        },
                                         "range": [
                                             42,
                                             48
                                         ],
-                                        "loc": {
-                                            "end": {
-                                                "line": 2,
-                                                "column": 17
-                                            },
-                                            "start": {
-                                                "line": 2,
-                                                "column": 11
-                                            }
-                                        },
                                         "typeAnnotation": {
                                             "type": "TSNumberKeyword",
                                             "range": [
@@ -157,13 +159,13 @@ module.exports = {
                                                 48
                                             ],
                                             "loc": {
-                                                "end": {
-                                                    "line": 2,
-                                                    "column": 17
-                                                },
                                                 "start": {
                                                     "line": 2,
                                                     "column": 11
+                                                },
+                                                "end": {
+                                                    "line": 2,
+                                                    "column": 17
                                                 }
                                             }
                                         }

--- a/tests/fixtures/typescript/basics/export-type-class-declaration.result.js
+++ b/tests/fixtures/typescript/basics/export-type-class-declaration.result.js
@@ -169,7 +169,12 @@ module.exports = {
                                                 }
                                             }
                                         }
-                                    }
+                                    },
+                                    "initializer": null,
+                                    "accessibility": null,
+                                    "readonly": false,
+                                    "static": false,
+                                    "export": false
                                 }
                             ]
                         }

--- a/tests/fixtures/typescript/basics/function-with-object-type-with-optional-properties.result.js
+++ b/tests/fixtures/typescript/basics/function-with-object-type-with-optional-properties.result.js
@@ -212,144 +212,112 @@ module.exports = {
                             },
                             "members": [
                                 {
-                                    "loc": {
-                                        "end": {
-                                            "column": 39,
-                                            "line": 1
-                                        },
-                                        "start": {
-                                            "column": 26,
-                                            "line": 1
-                                        }
-                                    },
-                                    "name": {
-                                        "loc": {
-                                            "end": {
-                                                "column": 29,
-                                                "line": 1
-                                            },
-                                            "start": {
-                                                "column": 26,
-                                                "line": 1
-                                            }
-                                        },
-                                        "name": "bar",
-                                        "optional": true,
-                                        "range": [
-                                            26,
-                                            29
-                                        ],
-                                        "type": "Identifier"
-                                    },
-                                    "questionToken": {
-                                        "loc": {
-                                            "end": {
-                                                "column": 30,
-                                                "line": 1
-                                            },
-                                            "start": {
-                                                "column": 29,
-                                                "line": 1
-                                            }
-                                        },
-                                        "range": [
-                                            29,
-                                            30
-                                        ],
-                                        "type": "TSQuestionToken"
-                                    },
+                                    "type": "TSPropertySignature",
                                     "range": [
                                         26,
                                         39
                                     ],
-                                    "type": "TSPropertySignature",
-                                    "typeAnnotation": {
+                                    "loc": {
+                                        "start": {
+                                            "line": 1,
+                                            "column": 26
+                                        },
+                                        "end": {
+                                            "line": 1,
+                                            "column": 39
+                                        }
+                                    },
+                                    "optional": true,
+                                    "computed": false,
+                                    "key": {
+                                        "type": "Identifier",
+                                        "range": [
+                                            26,
+                                            29
+                                        ],
                                         "loc": {
-                                            "end": {
-                                                "column": 38,
-                                                "line": 1
-                                            },
                                             "start": {
-                                                "column": 32,
-                                                "line": 1
+                                                "line": 1,
+                                                "column": 26
+                                            },
+                                            "end": {
+                                                "line": 1,
+                                                "column": 29
+                                            }
+                                        },
+                                        "name": "bar"
+                                    },
+                                    "typeAnnotation": {
+                                        "type": "TypeAnnotation",
+                                        "loc": {
+                                            "start": {
+                                                "line": 1,
+                                                "column": 32
+                                            },
+                                            "end": {
+                                                "line": 1,
+                                                "column": 38
                                             }
                                         },
                                         "range": [
                                             32,
                                             38
                                         ],
-                                        "type": "TypeAnnotation",
                                         "typeAnnotation": {
-                                            "loc": {
-                                                "end": {
-                                                    "column": 38,
-                                                    "line": 1
-                                                },
-                                                "start": {
-                                                    "column": 32,
-                                                    "line": 1
-                                                }
-                                            },
+                                            "type": "TSStringKeyword",
                                             "range": [
                                                 32,
                                                 38
                                             ],
-                                            "type": "TSStringKeyword"
+                                            "loc": {
+                                                "start": {
+                                                    "line": 1,
+                                                    "column": 32
+                                                },
+                                                "end": {
+                                                    "line": 1,
+                                                    "column": 38
+                                                }
+                                            }
                                         }
                                     }
                                 },
                                 {
-                                    "loc": {
-                                        "end": {
-                                            "column": 44,
-                                            "line": 1
-                                        },
-                                        "start": {
-                                            "column": 40,
-                                            "line": 1
-                                        }
-                                    },
-                                    "name": {
-                                        "loc": {
-                                            "end": {
-                                                "column": 43,
-                                                "line": 1
-                                            },
-                                            "start": {
-                                                "column": 40,
-                                                "line": 1
-                                            }
-                                        },
-                                        "name": "baz",
-                                        "optional": true,
-                                        "range": [
-                                            40,
-                                            43
-                                        ],
-                                        "type": "Identifier"
-                                    },
-                                    "questionToken": {
-                                        "loc": {
-                                            "end": {
-                                                "column": 44,
-                                                "line": 1
-                                            },
-                                            "start": {
-                                                "column": 43,
-                                                "line": 1
-                                            }
-                                        },
-                                        "range": [
-                                            43,
-                                            44
-                                        ],
-                                        "type": "TSQuestionToken"
-                                    },
+                                    "type": "TSPropertySignature",
                                     "range": [
                                         40,
                                         44
                                     ],
-                                    "type": "TSPropertySignature",
+                                    "loc": {
+                                        "start": {
+                                            "line": 1,
+                                            "column": 40
+                                        },
+                                        "end": {
+                                            "line": 1,
+                                            "column": 44
+                                        }
+                                    },
+                                    "optional": true,
+                                    "computed": false,
+                                    "key": {
+                                        "type": "Identifier",
+                                        "range": [
+                                            40,
+                                            43
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 1,
+                                                "column": 40
+                                            },
+                                            "end": {
+                                                "line": 1,
+                                                "column": 43
+                                            }
+                                        },
+                                        "name": "baz"
+                                    },
                                     "typeAnnotation": null
                                 }
                             ],

--- a/tests/fixtures/typescript/basics/function-with-object-type-with-optional-properties.result.js
+++ b/tests/fixtures/typescript/basics/function-with-object-type-with-optional-properties.result.js
@@ -280,7 +280,12 @@ module.exports = {
                                                 }
                                             }
                                         }
-                                    }
+                                    },
+                                    "initializer": null,
+                                    "accessibility": null,
+                                    "readonly": false,
+                                    "static": false,
+                                    "export": false
                                 },
                                 {
                                     "type": "TSPropertySignature",
@@ -318,7 +323,12 @@ module.exports = {
                                         },
                                         "name": "baz"
                                     },
-                                    "typeAnnotation": null
+                                    "typeAnnotation": null,
+                                    "initializer": null,
+                                    "accessibility": null,
+                                    "readonly": false,
+                                    "static": false,
+                                    "export": false
                                 }
                             ],
                             "range": [

--- a/tests/fixtures/typescript/basics/function-with-object-type-without-annotation.result.js
+++ b/tests/fixtures/typescript/basics/function-with-object-type-without-annotation.result.js
@@ -287,7 +287,12 @@ module.exports = {
                                                 }
                                             }
                                         }
-                                    }
+                                    },
+                                    "initializer": null,
+                                    "accessibility": null,
+                                    "readonly": false,
+                                    "static": false,
+                                    "export": false
                                 },
                                 {
                                     "type": "TSPropertySignature",
@@ -325,7 +330,12 @@ module.exports = {
                                         },
                                         "name": "baz"
                                     },
-                                    "typeAnnotation": null
+                                    "typeAnnotation": null,
+                                    "initializer": null,
+                                    "accessibility": null,
+                                    "readonly": false,
+                                    "static": false,
+                                    "export": false
                                 }
                             ]
                         }

--- a/tests/fixtures/typescript/basics/function-with-object-type-without-annotation.result.js
+++ b/tests/fixtures/typescript/basics/function-with-object-type-without-annotation.result.js
@@ -234,7 +234,9 @@ module.exports = {
                                             "column": 38
                                         }
                                     },
-                                    "name": {
+                                    "optional": false,
+                                    "computed": false,
+                                    "key": {
                                         "type": "Identifier",
                                         "range": [
                                             26,
@@ -303,7 +305,9 @@ module.exports = {
                                             "column": 42
                                         }
                                     },
-                                    "name": {
+                                    "optional": false,
+                                    "computed": false,
+                                    "key": {
                                         "type": "Identifier",
                                         "range": [
                                             39,

--- a/tests/fixtures/typescript/basics/interface-with-all-property-types.result.js
+++ b/tests/fixtures/typescript/basics/interface-with-all-property-types.result.js
@@ -104,7 +104,12 @@ module.exports = {
                                     }
                                 }
                             }
-                        }
+                        },
+                        "initializer": null,
+                        "accessibility": null,
+                        "readonly": false,
+                        "static": false,
+                        "export": false
                     },
                     {
                         "type": "TSPropertySignature",
@@ -175,7 +180,12 @@ module.exports = {
                                     }
                                 }
                             }
-                        }
+                        },
+                        "initializer": null,
+                        "accessibility": null,
+                        "readonly": false,
+                        "static": false,
+                        "export": false
                     },
                     {
                         "type": "TSPropertySignature",
@@ -246,7 +256,12 @@ module.exports = {
                                     }
                                 }
                             }
-                        }
+                        },
+                        "initializer": null,
+                        "accessibility": null,
+                        "readonly": false,
+                        "static": false,
+                        "export": false
                     },
                     {
                         "type": "TSPropertySignature",
@@ -317,7 +332,12 @@ module.exports = {
                                     }
                                 }
                             }
-                        }
+                        },
+                        "initializer": null,
+                        "accessibility": null,
+                        "readonly": false,
+                        "static": false,
+                        "export": false
                     },
                     {
                         "type": "TSIndexSignature",
@@ -420,7 +440,11 @@ module.exports = {
                                     }
                                 }
                             }
-                        }
+                        },
+                        "accessibility": null,
+                        "readonly": false,
+                        "static": false,
+                        "export": false
                     },
                     {
                         "type": "TSIndexSignature",
@@ -524,7 +548,11 @@ module.exports = {
                                     }
                                 }
                             }
-                        }
+                        },
+                        "accessibility": null,
+                        "readonly": false,
+                        "static": false,
+                        "export": false
                     },
                     {
                         "type": "TSMethodSignature",
@@ -596,7 +624,11 @@ module.exports = {
                                     }
                                 }
                             }
-                        }
+                        },
+                        "accessibility": null,
+                        "readonly": false,
+                        "static": false,
+                        "export": false
                     },
                     {
                         "type": "TSMethodSignature",
@@ -723,7 +755,11 @@ module.exports = {
                                     }
                                 }
                             }
-                        }
+                        },
+                        "accessibility": null,
+                        "readonly": false,
+                        "static": false,
+                        "export": false
                     },
                     {
                         "type": "TSMethodSignature",
@@ -850,7 +886,11 @@ module.exports = {
                                     }
                                 }
                             }
-                        }
+                        },
+                        "accessibility": null,
+                        "readonly": false,
+                        "static": false,
+                        "export": false
                     },
                     {
                         "type": "TSMethodSignature",
@@ -1015,7 +1055,11 @@ module.exports = {
                                     "constraint": null
                                 }
                             ]
-                        }
+                        },
+                        "accessibility": null,
+                        "readonly": false,
+                        "static": false,
+                        "export": false
                     },
                     {
                         "type": "TSConstructSignature",

--- a/tests/fixtures/typescript/basics/interface-with-all-property-types.result.js
+++ b/tests/fixtures/typescript/basics/interface-with-all-property-types.result.js
@@ -1,0 +1,3294 @@
+module.exports = {
+    "type": "Program",
+    "range": [
+        0,
+        295
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 14,
+            "column": 1
+        }
+    },
+    "body": [
+        {
+            "type": "TSInterfaceDeclaration",
+            "abstract": false,
+            "range": [
+                0,
+                295
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 14,
+                    "column": 1
+                }
+            },
+            "body": {
+                "type": "TSInterfaceBody",
+                "body": [
+                    {
+                        "type": "TSPropertySignature",
+                        "range": [
+                            20,
+                            32
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 16
+                            }
+                        },
+                        "optional": false,
+                        "computed": false,
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                20,
+                                23
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 4
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 7
+                                }
+                            },
+                            "name": "baa"
+                        },
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 9
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 15
+                                }
+                            },
+                            "range": [
+                                25,
+                                31
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSNumberKeyword",
+                                "range": [
+                                    25,
+                                    31
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 9
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 15
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "type": "TSPropertySignature",
+                        "range": [
+                            37,
+                            50
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 3,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 17
+                            }
+                        },
+                        "optional": true,
+                        "computed": false,
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                37,
+                                40
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 4
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 7
+                                }
+                            },
+                            "name": "bar"
+                        },
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 10
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 16
+                                }
+                            },
+                            "range": [
+                                43,
+                                49
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSNumberKeyword",
+                                "range": [
+                                    43,
+                                    49
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 3,
+                                        "column": 10
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 16
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "type": "TSPropertySignature",
+                        "range": [
+                            55,
+                            69
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 4,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 18
+                            }
+                        },
+                        "optional": false,
+                        "computed": true,
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                56,
+                                59
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 4,
+                                    "column": 5
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 8
+                                }
+                            },
+                            "name": "bax"
+                        },
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 4,
+                                    "column": 11
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 17
+                                }
+                            },
+                            "range": [
+                                62,
+                                68
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSStringKeyword",
+                                "range": [
+                                    62,
+                                    68
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 4,
+                                        "column": 11
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 17
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "type": "TSPropertySignature",
+                        "range": [
+                            74,
+                            89
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 5,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 19
+                            }
+                        },
+                        "optional": true,
+                        "computed": true,
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                75,
+                                78
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 5
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 8
+                                }
+                            },
+                            "name": "baz"
+                        },
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 12
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 18
+                                }
+                            },
+                            "range": [
+                                82,
+                                88
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSStringKeyword",
+                                "range": [
+                                    82,
+                                    88
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 5,
+                                        "column": 12
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 18
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "type": "TSIndexSignature",
+                        "range": [
+                            94,
+                            116
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 6,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 26
+                            }
+                        },
+                        "index": {
+                            "type": "Identifier",
+                            "range": [
+                                95,
+                                98
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 6,
+                                    "column": 5
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 8
+                                }
+                            },
+                            "name": "eee",
+                            "typeAnnotation": {
+                                "type": "TypeAnnotation",
+                                "loc": {
+                                    "start": {
+                                        "line": 6,
+                                        "column": 10
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 16
+                                    }
+                                },
+                                "range": [
+                                    100,
+                                    106
+                                ],
+                                "typeAnnotation": {
+                                    "type": "TSNumberKeyword",
+                                    "range": [
+                                        100,
+                                        106
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 6,
+                                            "column": 10
+                                        },
+                                        "end": {
+                                            "line": 6,
+                                            "column": 16
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 6,
+                                    "column": 19
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 25
+                                }
+                            },
+                            "range": [
+                                109,
+                                115
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSStringKeyword",
+                                "range": [
+                                    109,
+                                    115
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 6,
+                                        "column": 19
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 25
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "type": "TSIndexSignature",
+                        "range": [
+                            121,
+                            144
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 7,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 7,
+                                "column": 27
+                            }
+                        },
+                        "index": {
+                            "type": "Identifier",
+                            "range": [
+                                122,
+                                125
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 7,
+                                    "column": 5
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 8
+                                }
+                            },
+                            "name": "fff",
+                            "optional": true,
+                            "typeAnnotation": {
+                                "type": "TypeAnnotation",
+                                "loc": {
+                                    "start": {
+                                        "line": 7,
+                                        "column": 11
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 17
+                                    }
+                                },
+                                "range": [
+                                    128,
+                                    134
+                                ],
+                                "typeAnnotation": {
+                                    "type": "TSNumberKeyword",
+                                    "range": [
+                                        128,
+                                        134
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 7,
+                                            "column": 11
+                                        },
+                                        "end": {
+                                            "line": 7,
+                                            "column": 17
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 7,
+                                    "column": 20
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 26
+                                }
+                            },
+                            "range": [
+                                137,
+                                143
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSStringKeyword",
+                                "range": [
+                                    137,
+                                    143
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 7,
+                                        "column": 20
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 26
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "type": "TSMethodSignature",
+                        "range": [
+                            149,
+                            161
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 8,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 8,
+                                "column": 16
+                            }
+                        },
+                        "optional": false,
+                        "computed": false,
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                149,
+                                152
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 8,
+                                    "column": 4
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 7
+                                }
+                            },
+                            "name": "doo"
+                        },
+                        "params": [],
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 8,
+                                    "column": 11
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 15
+                                }
+                            },
+                            "range": [
+                                156,
+                                160
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSVoidKeyword",
+                                "range": [
+                                    156,
+                                    160
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 8,
+                                        "column": 11
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 15
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "type": "TSMethodSignature",
+                        "range": [
+                            166,
+                            186
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 9,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 9,
+                                "column": 24
+                            }
+                        },
+                        "optional": true,
+                        "computed": false,
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                166,
+                                169
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 9,
+                                    "column": 4
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 7
+                                }
+                            },
+                            "name": "doo"
+                        },
+                        "params": [
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    171,
+                                    172
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 9,
+                                        "column": 9
+                                    },
+                                    "end": {
+                                        "line": 9,
+                                        "column": 10
+                                    }
+                                },
+                                "name": "a"
+                            },
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    174,
+                                    175
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 9,
+                                        "column": 12
+                                    },
+                                    "end": {
+                                        "line": 9,
+                                        "column": 13
+                                    }
+                                },
+                                "name": "b"
+                            },
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    177,
+                                    178
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 9,
+                                        "column": 15
+                                    },
+                                    "end": {
+                                        "line": 9,
+                                        "column": 16
+                                    }
+                                },
+                                "name": "c"
+                            }
+                        ],
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 9,
+                                    "column": 19
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 23
+                                }
+                            },
+                            "range": [
+                                181,
+                                185
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSVoidKeyword",
+                                "range": [
+                                    181,
+                                    185
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 9,
+                                        "column": 19
+                                    },
+                                    "end": {
+                                        "line": 9,
+                                        "column": 23
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "type": "TSMethodSignature",
+                        "range": [
+                            191,
+                            213
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 10,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 10,
+                                "column": 26
+                            }
+                        },
+                        "optional": true,
+                        "computed": true,
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                192,
+                                195
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 10,
+                                    "column": 5
+                                },
+                                "end": {
+                                    "line": 10,
+                                    "column": 8
+                                }
+                            },
+                            "name": "loo"
+                        },
+                        "params": [
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    198,
+                                    199
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 10,
+                                        "column": 11
+                                    },
+                                    "end": {
+                                        "line": 10,
+                                        "column": 12
+                                    }
+                                },
+                                "name": "a"
+                            },
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    201,
+                                    202
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 10,
+                                        "column": 14
+                                    },
+                                    "end": {
+                                        "line": 10,
+                                        "column": 15
+                                    }
+                                },
+                                "name": "b"
+                            },
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    204,
+                                    205
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 10,
+                                        "column": 17
+                                    },
+                                    "end": {
+                                        "line": 10,
+                                        "column": 18
+                                    }
+                                },
+                                "name": "c"
+                            }
+                        ],
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 10,
+                                    "column": 21
+                                },
+                                "end": {
+                                    "line": 10,
+                                    "column": 25
+                                }
+                            },
+                            "range": [
+                                208,
+                                212
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSVoidKeyword",
+                                "range": [
+                                    208,
+                                    212
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 10,
+                                        "column": 21
+                                    },
+                                    "end": {
+                                        "line": 10,
+                                        "column": 25
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "type": "TSMethodSignature",
+                        "range": [
+                            218,
+                            240
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 11,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 11,
+                                "column": 26
+                            }
+                        },
+                        "optional": false,
+                        "computed": false,
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                218,
+                                221
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 11,
+                                    "column": 4
+                                },
+                                "end": {
+                                    "line": 11,
+                                    "column": 7
+                                }
+                            },
+                            "name": "boo"
+                        },
+                        "params": [
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    225,
+                                    226
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 11,
+                                        "column": 11
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 12
+                                    }
+                                },
+                                "name": "a"
+                            },
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    228,
+                                    229
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 11,
+                                        "column": 14
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 15
+                                    }
+                                },
+                                "name": "b"
+                            },
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    231,
+                                    232
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 11,
+                                        "column": 17
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 18
+                                    }
+                                },
+                                "name": "c"
+                            }
+                        ],
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 11,
+                                    "column": 21
+                                },
+                                "end": {
+                                    "line": 11,
+                                    "column": 25
+                                }
+                            },
+                            "range": [
+                                235,
+                                239
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSVoidKeyword",
+                                "range": [
+                                    235,
+                                    239
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 11,
+                                        "column": 21
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 25
+                                    }
+                                }
+                            }
+                        },
+                        "typeParameters": {
+                            "type": "TypeParameterDeclaration",
+                            "range": [
+                                221,
+                                224
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 11,
+                                    "column": 7
+                                },
+                                "end": {
+                                    "line": 11,
+                                    "column": 10
+                                }
+                            },
+                            "params": [
+                                {
+                                    "type": "TypeParameter",
+                                    "range": [
+                                        222,
+                                        223
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 11,
+                                            "column": 8
+                                        },
+                                        "end": {
+                                            "line": 11,
+                                            "column": 9
+                                        }
+                                    },
+                                    "name": "J",
+                                    "constraint": null
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "TSConstructSignature",
+                        "range": [
+                            245,
+                            265
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 12,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 12,
+                                "column": 24
+                            }
+                        },
+                        "params": [
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    250,
+                                    251
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 12,
+                                        "column": 9
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 10
+                                    }
+                                },
+                                "name": "a"
+                            },
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    253,
+                                    254
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 12,
+                                        "column": 12
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 13
+                                    }
+                                },
+                                "name": "b",
+                                "optional": true
+                            }
+                        ],
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 12,
+                                    "column": 17
+                                },
+                                "end": {
+                                    "line": 12,
+                                    "column": 23
+                                }
+                            },
+                            "range": [
+                                258,
+                                264
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSStringKeyword",
+                                "range": [
+                                    258,
+                                    264
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 12,
+                                        "column": 17
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 23
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "type": "TSConstructSignature",
+                        "range": [
+                            270,
+                            293
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 13,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 13,
+                                "column": 27
+                            }
+                        },
+                        "params": [
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    278,
+                                    279
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 13,
+                                        "column": 12
+                                    },
+                                    "end": {
+                                        "line": 13,
+                                        "column": 13
+                                    }
+                                },
+                                "name": "a"
+                            },
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    281,
+                                    282
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 13,
+                                        "column": 15
+                                    },
+                                    "end": {
+                                        "line": 13,
+                                        "column": 16
+                                    }
+                                },
+                                "name": "b",
+                                "optional": true
+                            }
+                        ],
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 13,
+                                    "column": 20
+                                },
+                                "end": {
+                                    "line": 13,
+                                    "column": 26
+                                }
+                            },
+                            "range": [
+                                286,
+                                292
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSStringKeyword",
+                                "range": [
+                                    286,
+                                    292
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 13,
+                                        "column": 20
+                                    },
+                                    "end": {
+                                        "line": 13,
+                                        "column": 26
+                                    }
+                                }
+                            }
+                        },
+                        "typeParameters": {
+                            "type": "TypeParameterDeclaration",
+                            "range": [
+                                274,
+                                277
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 13,
+                                    "column": 8
+                                },
+                                "end": {
+                                    "line": 13,
+                                    "column": 11
+                                }
+                            },
+                            "params": [
+                                {
+                                    "type": "TypeParameter",
+                                    "range": [
+                                        275,
+                                        276
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 13,
+                                            "column": 9
+                                        },
+                                        "end": {
+                                            "line": 13,
+                                            "column": 10
+                                        }
+                                    },
+                                    "name": "F",
+                                    "constraint": null
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "range": [
+                    14,
+                    295
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 14
+                    },
+                    "end": {
+                        "line": 14,
+                        "column": 1
+                    }
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    10,
+                    13
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 10
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 13
+                    }
+                },
+                "name": "Foo"
+            },
+            "heritage": []
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "interface",
+            "range": [
+                0,
+                9
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Foo",
+            "range": [
+                10,
+                13
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 10
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                14,
+                15
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 14
+                },
+                "end": {
+                    "line": 1,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "baa",
+            "range": [
+                20,
+                23
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 7
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                23,
+                24
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 7
+                },
+                "end": {
+                    "line": 2,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "number",
+            "range": [
+                25,
+                31
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 9
+                },
+                "end": {
+                    "line": 2,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                31,
+                32
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 15
+                },
+                "end": {
+                    "line": 2,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "range": [
+                37,
+                40
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 4
+                },
+                "end": {
+                    "line": 3,
+                    "column": 7
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "?",
+            "range": [
+                40,
+                41
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 7
+                },
+                "end": {
+                    "line": 3,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                41,
+                42
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 8
+                },
+                "end": {
+                    "line": 3,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "number",
+            "range": [
+                43,
+                49
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 10
+                },
+                "end": {
+                    "line": 3,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                49,
+                50
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 16
+                },
+                "end": {
+                    "line": 3,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "[",
+            "range": [
+                55,
+                56
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 4
+                },
+                "end": {
+                    "line": 4,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bax",
+            "range": [
+                56,
+                59
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 5
+                },
+                "end": {
+                    "line": 4,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "]",
+            "range": [
+                59,
+                60
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 8
+                },
+                "end": {
+                    "line": 4,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                60,
+                61
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 9
+                },
+                "end": {
+                    "line": 4,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                62,
+                68
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 11
+                },
+                "end": {
+                    "line": 4,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                68,
+                69
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 17
+                },
+                "end": {
+                    "line": 4,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "[",
+            "range": [
+                74,
+                75
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 4
+                },
+                "end": {
+                    "line": 5,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "baz",
+            "range": [
+                75,
+                78
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 5
+                },
+                "end": {
+                    "line": 5,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "]",
+            "range": [
+                78,
+                79
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 8
+                },
+                "end": {
+                    "line": 5,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "?",
+            "range": [
+                79,
+                80
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 9
+                },
+                "end": {
+                    "line": 5,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                80,
+                81
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 10
+                },
+                "end": {
+                    "line": 5,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                82,
+                88
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 12
+                },
+                "end": {
+                    "line": 5,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                88,
+                89
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 18
+                },
+                "end": {
+                    "line": 5,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "[",
+            "range": [
+                94,
+                95
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 4
+                },
+                "end": {
+                    "line": 6,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "eee",
+            "range": [
+                95,
+                98
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 5
+                },
+                "end": {
+                    "line": 6,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                98,
+                99
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 8
+                },
+                "end": {
+                    "line": 6,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "number",
+            "range": [
+                100,
+                106
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 10
+                },
+                "end": {
+                    "line": 6,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "]",
+            "range": [
+                106,
+                107
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 16
+                },
+                "end": {
+                    "line": 6,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                107,
+                108
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 17
+                },
+                "end": {
+                    "line": 6,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                109,
+                115
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 19
+                },
+                "end": {
+                    "line": 6,
+                    "column": 25
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                115,
+                116
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 25
+                },
+                "end": {
+                    "line": 6,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "[",
+            "range": [
+                121,
+                122
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 4
+                },
+                "end": {
+                    "line": 7,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "fff",
+            "range": [
+                122,
+                125
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 5
+                },
+                "end": {
+                    "line": 7,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "?",
+            "range": [
+                125,
+                126
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 8
+                },
+                "end": {
+                    "line": 7,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                126,
+                127
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 9
+                },
+                "end": {
+                    "line": 7,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "number",
+            "range": [
+                128,
+                134
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 11
+                },
+                "end": {
+                    "line": 7,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "]",
+            "range": [
+                134,
+                135
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 17
+                },
+                "end": {
+                    "line": 7,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                135,
+                136
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 18
+                },
+                "end": {
+                    "line": 7,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                137,
+                143
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 20
+                },
+                "end": {
+                    "line": 7,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                143,
+                144
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 26
+                },
+                "end": {
+                    "line": 7,
+                    "column": 27
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "doo",
+            "range": [
+                149,
+                152
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 4
+                },
+                "end": {
+                    "line": 8,
+                    "column": 7
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                152,
+                153
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 7
+                },
+                "end": {
+                    "line": 8,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                153,
+                154
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 8
+                },
+                "end": {
+                    "line": 8,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                154,
+                155
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 9
+                },
+                "end": {
+                    "line": 8,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "void",
+            "range": [
+                156,
+                160
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 11
+                },
+                "end": {
+                    "line": 8,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                160,
+                161
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 15
+                },
+                "end": {
+                    "line": 8,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "doo",
+            "range": [
+                166,
+                169
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 4
+                },
+                "end": {
+                    "line": 9,
+                    "column": 7
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "?",
+            "range": [
+                169,
+                170
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 7
+                },
+                "end": {
+                    "line": 9,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                170,
+                171
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 8
+                },
+                "end": {
+                    "line": 9,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "a",
+            "range": [
+                171,
+                172
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 9
+                },
+                "end": {
+                    "line": 9,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "range": [
+                172,
+                173
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 10
+                },
+                "end": {
+                    "line": 9,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "b",
+            "range": [
+                174,
+                175
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 12
+                },
+                "end": {
+                    "line": 9,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "range": [
+                175,
+                176
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 13
+                },
+                "end": {
+                    "line": 9,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "c",
+            "range": [
+                177,
+                178
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 15
+                },
+                "end": {
+                    "line": 9,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                178,
+                179
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 16
+                },
+                "end": {
+                    "line": 9,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                179,
+                180
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 17
+                },
+                "end": {
+                    "line": 9,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "void",
+            "range": [
+                181,
+                185
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 19
+                },
+                "end": {
+                    "line": 9,
+                    "column": 23
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                185,
+                186
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 23
+                },
+                "end": {
+                    "line": 9,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "[",
+            "range": [
+                191,
+                192
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 4
+                },
+                "end": {
+                    "line": 10,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "loo",
+            "range": [
+                192,
+                195
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 5
+                },
+                "end": {
+                    "line": 10,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "]",
+            "range": [
+                195,
+                196
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 8
+                },
+                "end": {
+                    "line": 10,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "?",
+            "range": [
+                196,
+                197
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 9
+                },
+                "end": {
+                    "line": 10,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                197,
+                198
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 10
+                },
+                "end": {
+                    "line": 10,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "a",
+            "range": [
+                198,
+                199
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 11
+                },
+                "end": {
+                    "line": 10,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "range": [
+                199,
+                200
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 12
+                },
+                "end": {
+                    "line": 10,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "b",
+            "range": [
+                201,
+                202
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 14
+                },
+                "end": {
+                    "line": 10,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "range": [
+                202,
+                203
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 15
+                },
+                "end": {
+                    "line": 10,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "c",
+            "range": [
+                204,
+                205
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 17
+                },
+                "end": {
+                    "line": 10,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                205,
+                206
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 18
+                },
+                "end": {
+                    "line": 10,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                206,
+                207
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 19
+                },
+                "end": {
+                    "line": 10,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "void",
+            "range": [
+                208,
+                212
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 21
+                },
+                "end": {
+                    "line": 10,
+                    "column": 25
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                212,
+                213
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 25
+                },
+                "end": {
+                    "line": 10,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "boo",
+            "range": [
+                218,
+                221
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 4
+                },
+                "end": {
+                    "line": 11,
+                    "column": 7
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "<",
+            "range": [
+                221,
+                222
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 7
+                },
+                "end": {
+                    "line": 11,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "J",
+            "range": [
+                222,
+                223
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 8
+                },
+                "end": {
+                    "line": 11,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ">",
+            "range": [
+                223,
+                224
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 9
+                },
+                "end": {
+                    "line": 11,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                224,
+                225
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 10
+                },
+                "end": {
+                    "line": 11,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "a",
+            "range": [
+                225,
+                226
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 11
+                },
+                "end": {
+                    "line": 11,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "range": [
+                226,
+                227
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 12
+                },
+                "end": {
+                    "line": 11,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "b",
+            "range": [
+                228,
+                229
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 14
+                },
+                "end": {
+                    "line": 11,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "range": [
+                229,
+                230
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 15
+                },
+                "end": {
+                    "line": 11,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "c",
+            "range": [
+                231,
+                232
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 17
+                },
+                "end": {
+                    "line": 11,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                232,
+                233
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 18
+                },
+                "end": {
+                    "line": 11,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                233,
+                234
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 19
+                },
+                "end": {
+                    "line": 11,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "void",
+            "range": [
+                235,
+                239
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 21
+                },
+                "end": {
+                    "line": 11,
+                    "column": 25
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                239,
+                240
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 25
+                },
+                "end": {
+                    "line": 11,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "new",
+            "range": [
+                245,
+                248
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 4
+                },
+                "end": {
+                    "line": 12,
+                    "column": 7
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                249,
+                250
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 8
+                },
+                "end": {
+                    "line": 12,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "a",
+            "range": [
+                250,
+                251
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 9
+                },
+                "end": {
+                    "line": 12,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "range": [
+                251,
+                252
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 10
+                },
+                "end": {
+                    "line": 12,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "b",
+            "range": [
+                253,
+                254
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 12
+                },
+                "end": {
+                    "line": 12,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "?",
+            "range": [
+                254,
+                255
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 13
+                },
+                "end": {
+                    "line": 12,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                255,
+                256
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 14
+                },
+                "end": {
+                    "line": 12,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                256,
+                257
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 15
+                },
+                "end": {
+                    "line": 12,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                258,
+                264
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 17
+                },
+                "end": {
+                    "line": 12,
+                    "column": 23
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                264,
+                265
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 23
+                },
+                "end": {
+                    "line": 12,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "new",
+            "range": [
+                270,
+                273
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 4
+                },
+                "end": {
+                    "line": 13,
+                    "column": 7
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "<",
+            "range": [
+                274,
+                275
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 8
+                },
+                "end": {
+                    "line": 13,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "F",
+            "range": [
+                275,
+                276
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 9
+                },
+                "end": {
+                    "line": 13,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ">",
+            "range": [
+                276,
+                277
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 10
+                },
+                "end": {
+                    "line": 13,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                277,
+                278
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 11
+                },
+                "end": {
+                    "line": 13,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "a",
+            "range": [
+                278,
+                279
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 12
+                },
+                "end": {
+                    "line": 13,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "range": [
+                279,
+                280
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 13
+                },
+                "end": {
+                    "line": 13,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "b",
+            "range": [
+                281,
+                282
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 15
+                },
+                "end": {
+                    "line": 13,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "?",
+            "range": [
+                282,
+                283
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 16
+                },
+                "end": {
+                    "line": 13,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                283,
+                284
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 17
+                },
+                "end": {
+                    "line": 13,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                284,
+                285
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 18
+                },
+                "end": {
+                    "line": 13,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                286,
+                292
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 20
+                },
+                "end": {
+                    "line": 13,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                292,
+                293
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 26
+                },
+                "end": {
+                    "line": 13,
+                    "column": 27
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                294,
+                295
+            ],
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 0
+                },
+                "end": {
+                    "line": 14,
+                    "column": 1
+                }
+            }
+        }
+    ]
+};

--- a/tests/fixtures/typescript/basics/interface-with-all-property-types.src.ts
+++ b/tests/fixtures/typescript/basics/interface-with-all-property-types.src.ts
@@ -1,0 +1,15 @@
+interface Foo {
+    baa: number;
+    bar?: number;
+    [bax]: string;
+    [baz]?: string;
+    [eee: number]: string;
+    [fff?: number]: string;
+    doo(): void;
+    doo?(a, b, c): void;
+    [loo]?(a, b, c): void;
+    boo<J>(a, b, c): void;
+    new (a, b?): string;
+    new <F>(a, b?): string;
+}
+

--- a/tests/fixtures/typescript/basics/interface-with-construct-signature-with-parameter-accessibility.result.js
+++ b/tests/fixtures/typescript/basics/interface-with-construct-signature-with-parameter-accessibility.result.js
@@ -51,8 +51,7 @@ module.exports = {
                                 "column": 30
                             }
                         },
-                        "typeParameters": null,
-                        "parameters": [
+                        "params": [
                             {
                                 "type": "TSParameterProperty",
                                 "range": [
@@ -131,7 +130,8 @@ module.exports = {
                                     "name": "y"
                                 }
                             }
-                        ]
+                        ],
+                        "typeAnnotation": null
                     }
                 ],
                 "range": [

--- a/tests/fixtures/typescript/basics/interface-with-jsdoc.result.js
+++ b/tests/fixtures/typescript/basics/interface-with-jsdoc.result.js
@@ -51,7 +51,9 @@ module.exports = {
                                 "column": 13
                             }
                         },
-                        "name": {
+                        "optional": false,
+                        "computed": false,
+                        "key": {
                             "type": "Identifier",
                             "range": [
                                 76,
@@ -69,8 +71,7 @@ module.exports = {
                             },
                             "name": "foo"
                         },
-                        "typeParameters": null,
-                        "parameters": [
+                        "params": [
                             {
                                 "type": "Identifier",
                                 "range": [
@@ -89,7 +90,8 @@ module.exports = {
                                 },
                                 "name": "bar"
                             }
-                        ]
+                        ],
+                        "typeAnnotation": null
                     }
                 ],
                 "range": [

--- a/tests/fixtures/typescript/basics/interface-with-jsdoc.result.js
+++ b/tests/fixtures/typescript/basics/interface-with-jsdoc.result.js
@@ -91,7 +91,11 @@ module.exports = {
                                 "name": "bar"
                             }
                         ],
-                        "typeAnnotation": null
+                        "typeAnnotation": null,
+                        "accessibility": null,
+                        "readonly": false,
+                        "static": false,
+                        "export": false
                     }
                 ],
                 "range": [

--- a/tests/fixtures/typescript/basics/interface-with-optional-properties.result.js
+++ b/tests/fixtures/typescript/basics/interface-with-optional-properties.result.js
@@ -71,7 +71,12 @@ module.exports = {
                             },
                             "name": "foo"
                         },
-                        "typeAnnotation": null
+                        "typeAnnotation": null,
+                        "initializer": null,
+                        "accessibility": null,
+                        "readonly": false,
+                        "static": false,
+                        "export": false
                     },
                     {
                         "type": "TSPropertySignature",
@@ -142,7 +147,12 @@ module.exports = {
                                     }
                                 }
                             }
-                        }
+                        },
+                        "initializer": null,
+                        "accessibility": null,
+                        "readonly": false,
+                        "static": false,
+                        "export": false
                     },
                     {
                         "type": "TSMethodSignature",
@@ -272,7 +282,11 @@ module.exports = {
                                 "optional": true
                             }
                         ],
-                        "typeAnnotation": null
+                        "typeAnnotation": null,
+                        "accessibility": null,
+                        "readonly": false,
+                        "static": false,
+                        "export": false
                     }
                 ],
                 "range": [

--- a/tests/fixtures/typescript/basics/interface-with-optional-properties.result.js
+++ b/tests/fixtures/typescript/basics/interface-with-optional-properties.result.js
@@ -51,7 +51,9 @@ module.exports = {
                                 "column": 9
                             }
                         },
-                        "name": {
+                        "optional": true,
+                        "computed": false,
+                        "key": {
                             "type": "Identifier",
                             "range": [
                                 21,
@@ -67,25 +69,7 @@ module.exports = {
                                     "column": 7
                                 }
                             },
-                            "name": "foo",
-                            "optional": true
-                        },
-                        "questionToken": {
-                            "type": "TSQuestionToken",
-                            "range": [
-                                24,
-                                25
-                            ],
-                            "loc": {
-                                "start": {
-                                    "line": 2,
-                                    "column": 7
-                                },
-                                "end": {
-                                    "line": 2,
-                                    "column": 8
-                                }
-                            }
+                            "name": "foo"
                         },
                         "typeAnnotation": null
                     },
@@ -105,7 +89,9 @@ module.exports = {
                                 "column": 17
                             }
                         },
-                        "name": {
+                        "optional": true,
+                        "computed": false,
+                        "key": {
                             "type": "Identifier",
                             "range": [
                                 31,
@@ -121,25 +107,7 @@ module.exports = {
                                     "column": 7
                                 }
                             },
-                            "name": "bar",
-                            "optional": true
-                        },
-                        "questionToken": {
-                            "type": "TSQuestionToken",
-                            "range": [
-                                34,
-                                35
-                            ],
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 7
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 8
-                                }
-                            }
+                            "name": "bar"
                         },
                         "typeAnnotation": {
                             "type": "TypeAnnotation",
@@ -192,7 +160,9 @@ module.exports = {
                                 "column": 34
                             }
                         },
-                        "name": {
+                        "optional": true,
+                        "computed": false,
+                        "key": {
                             "type": "Identifier",
                             "range": [
                                 49,
@@ -208,28 +178,9 @@ module.exports = {
                                     "column": 7
                                 }
                             },
-                            "name": "baz",
-                            "optional": true
+                            "name": "baz"
                         },
-                        "questionToken": {
-                            "type": "TSQuestionToken",
-                            "range": [
-                                52,
-                                53
-                            ],
-                            "loc": {
-                                "start": {
-                                    "line": 4,
-                                    "column": 7
-                                },
-                                "end": {
-                                    "line": 4,
-                                    "column": 8
-                                }
-                            }
-                        },
-                        "typeParameters": null,
-                        "parameters": [
+                        "params": [
                             {
                                 "type": "Identifier",
                                 "range": [
@@ -320,7 +271,8 @@ module.exports = {
                                 "name": "baz",
                                 "optional": true
                             }
-                        ]
+                        ],
+                        "typeAnnotation": null
                     }
                 ],
                 "range": [

--- a/tests/fixtures/typescript/basics/interface-without-type-annotation.result.js
+++ b/tests/fixtures/typescript/basics/interface-without-type-annotation.result.js
@@ -51,7 +51,9 @@ module.exports = {
                                 "column": 8
                             }
                         },
-                        "name": {
+                        "optional": false,
+                        "computed": false,
+                        "key": {
                             "type": "Identifier",
                             "range": [
                                 21,

--- a/tests/fixtures/typescript/basics/interface-without-type-annotation.result.js
+++ b/tests/fixtures/typescript/basics/interface-without-type-annotation.result.js
@@ -71,7 +71,12 @@ module.exports = {
                             },
                             "name": "foo"
                         },
-                        "typeAnnotation": null
+                        "typeAnnotation": null,
+                        "initializer": null,
+                        "accessibility": null,
+                        "readonly": false,
+                        "static": false,
+                        "export": false
                     }
                 ],
                 "range": [

--- a/tests/fixtures/typescript/basics/type-alias-object-without-annotation.result.js
+++ b/tests/fixtures/typescript/basics/type-alias-object-without-annotation.result.js
@@ -139,7 +139,12 @@ module.exports = {
                                             }
                                         }
                                     }
-                                }
+                                },
+                                "initializer": null,
+                                "accessibility": null,
+                                "readonly": false,
+                                "static": false,
+                                "export": false
                             },
                             {
                                 "type": "TSPropertySignature",
@@ -177,7 +182,12 @@ module.exports = {
                                     },
                                     "name": "baz"
                                 },
-                                "typeAnnotation": null
+                                "typeAnnotation": null,
+                                "initializer": null,
+                                "accessibility": null,
+                                "readonly": false,
+                                "static": false,
+                                "export": false
                             }
                         ]
                     },

--- a/tests/fixtures/typescript/basics/type-alias-object-without-annotation.result.js
+++ b/tests/fixtures/typescript/basics/type-alias-object-without-annotation.result.js
@@ -86,7 +86,9 @@ module.exports = {
                                         "column": 24
                                     }
                                 },
-                                "name": {
+                                "optional": false,
+                                "computed": false,
+                                "key": {
                                     "type": "Identifier",
                                     "range": [
                                         12,
@@ -155,7 +157,9 @@ module.exports = {
                                         "column": 28
                                     }
                                 },
-                                "name": {
+                                "optional": false,
+                                "computed": false,
+                                "key": {
                                     "type": "Identifier",
                                     "range": [
                                         25,

--- a/tests/fixtures/typescript/basics/typed-this.result.js
+++ b/tests/fixtures/typescript/basics/typed-this.result.js
@@ -51,7 +51,9 @@ module.exports = {
                                 "column": 65
                             }
                         },
-                        "name": {
+                        "optional": false,
+                        "computed": false,
+                        "key": {
                             "type": "Identifier",
                             "range": [
                                 23,
@@ -69,8 +71,7 @@ module.exports = {
                             },
                             "name": "addClickListener"
                         },
-                        "typeParameters": null,
-                        "parameters": [
+                        "params": [
                             {
                                 "type": "Identifier",
                                 "range": [

--- a/tests/fixtures/typescript/basics/typed-this.result.js
+++ b/tests/fixtures/typescript/basics/typed-this.result.js
@@ -317,7 +317,11 @@ module.exports = {
                                     }
                                 }
                             }
-                        }
+                        },
+                        "accessibility": null,
+                        "readonly": false,
+                        "static": false,
+                        "export": false
                     }
                 ],
                 "range": [

--- a/tests/fixtures/typescript/errorRecovery/interface-property-modifiers.result.js
+++ b/tests/fixtures/typescript/errorRecovery/interface-property-modifiers.result.js
@@ -1,0 +1,4816 @@
+module.exports = {
+    "type": "Program",
+    "range": [
+        0,
+        594
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 23,
+            "column": 1
+        }
+    },
+    "body": [
+        {
+            "type": "TSInterfaceDeclaration",
+            "range": [
+                0,
+                594
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 23,
+                    "column": 1
+                }
+            },
+            "abstract": false,
+            "body": {
+                "type": "TSInterfaceBody",
+                "body": [
+                    {
+                        "type": "TSPropertySignature",
+                        "range": [
+                            20,
+                            38
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 22
+                            }
+                        },
+                        "optional": false,
+                        "computed": false,
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                20,
+                                23
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 4
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 7
+                                }
+                            },
+                            "name": "bar"
+                        },
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 9
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 15
+                                }
+                            },
+                            "range": [
+                                25,
+                                31
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSStringKeyword",
+                                "range": [
+                                    25,
+                                    31
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 9
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 15
+                                    }
+                                }
+                            }
+                        },
+                        "initializer": {
+                            "type": "Literal",
+                            "range": [
+                                34,
+                                37
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 18
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 21
+                                }
+                            },
+                            "value": "a",
+                            "raw": "'a'"
+                        },
+                        "accessibility": null,
+                        "readonly": false,
+                        "static": false,
+                        "export": false
+                    },
+                    {
+                        "type": "TSPropertySignature",
+                        "range": [
+                            43,
+                            60
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 3,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 21
+                            }
+                        },
+                        "optional": false,
+                        "computed": false,
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                50,
+                                51
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 11
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 12
+                                }
+                            },
+                            "name": "a"
+                        },
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 14
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 20
+                                }
+                            },
+                            "range": [
+                                53,
+                                59
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSStringKeyword",
+                                "range": [
+                                    53,
+                                    59
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 3,
+                                        "column": 14
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 20
+                                    }
+                                }
+                            }
+                        },
+                        "initializer": null,
+                        "accessibility": "public",
+                        "readonly": false,
+                        "static": false,
+                        "export": false
+                    },
+                    {
+                        "type": "TSPropertySignature",
+                        "range": [
+                            65,
+                            83
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 4,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 22
+                            }
+                        },
+                        "optional": false,
+                        "computed": false,
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                73,
+                                74
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 4,
+                                    "column": 12
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 13
+                                }
+                            },
+                            "name": "b"
+                        },
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 4,
+                                    "column": 15
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 21
+                                }
+                            },
+                            "range": [
+                                76,
+                                82
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSStringKeyword",
+                                "range": [
+                                    76,
+                                    82
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 4,
+                                        "column": 15
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 21
+                                    }
+                                }
+                            }
+                        },
+                        "initializer": null,
+                        "accessibility": "private",
+                        "readonly": false,
+                        "static": false,
+                        "export": false
+                    },
+                    {
+                        "type": "TSPropertySignature",
+                        "range": [
+                            88,
+                            108
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 5,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 24
+                            }
+                        },
+                        "optional": false,
+                        "computed": false,
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                98,
+                                99
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 14
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 15
+                                }
+                            },
+                            "name": "c"
+                        },
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 17
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 23
+                                }
+                            },
+                            "range": [
+                                101,
+                                107
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSStringKeyword",
+                                "range": [
+                                    101,
+                                    107
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 5,
+                                        "column": 17
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 23
+                                    }
+                                }
+                            }
+                        },
+                        "initializer": null,
+                        "accessibility": "protected",
+                        "readonly": false,
+                        "static": false,
+                        "export": false
+                    },
+                    {
+                        "type": "TSPropertySignature",
+                        "range": [
+                            113,
+                            130
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 6,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 21
+                            }
+                        },
+                        "optional": false,
+                        "computed": false,
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                120,
+                                121
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 6,
+                                    "column": 11
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 12
+                                }
+                            },
+                            "name": "d"
+                        },
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 6,
+                                    "column": 14
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 20
+                                }
+                            },
+                            "range": [
+                                123,
+                                129
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSStringKeyword",
+                                "range": [
+                                    123,
+                                    129
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 6,
+                                        "column": 14
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 20
+                                    }
+                                }
+                            }
+                        },
+                        "initializer": null,
+                        "accessibility": null,
+                        "readonly": false,
+                        "static": true,
+                        "export": false
+                    },
+                    {
+                        "type": "TSPropertySignature",
+                        "range": [
+                            135,
+                            152
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 7,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 7,
+                                "column": 21
+                            }
+                        },
+                        "optional": false,
+                        "computed": false,
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                142,
+                                143
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 7,
+                                    "column": 11
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 12
+                                }
+                            },
+                            "name": "e"
+                        },
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 7,
+                                    "column": 14
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 20
+                                }
+                            },
+                            "range": [
+                                145,
+                                151
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSStringKeyword",
+                                "range": [
+                                    145,
+                                    151
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 7,
+                                        "column": 14
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 20
+                                    }
+                                }
+                            }
+                        },
+                        "initializer": null,
+                        "accessibility": null,
+                        "readonly": false,
+                        "static": false,
+                        "export": true
+                    },
+                    {
+                        "type": "TSPropertySignature",
+                        "range": [
+                            157,
+                            176
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 8,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 8,
+                                "column": 23
+                            }
+                        },
+                        "optional": false,
+                        "computed": false,
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                166,
+                                167
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 8,
+                                    "column": 13
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 14
+                                }
+                            },
+                            "name": "f"
+                        },
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 8,
+                                    "column": 16
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 22
+                                }
+                            },
+                            "range": [
+                                169,
+                                175
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSStringKeyword",
+                                "range": [
+                                    169,
+                                    175
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 8,
+                                        "column": 16
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 22
+                                    }
+                                }
+                            }
+                        },
+                        "initializer": null,
+                        "accessibility": null,
+                        "readonly": true,
+                        "static": false,
+                        "export": false
+                    },
+                    {
+                        "type": "TSIndexSignature",
+                        "range": [
+                            182,
+                            211
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 10,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 10,
+                                "column": 33
+                            }
+                        },
+                        "index": {
+                            "type": "Identifier",
+                            "range": [
+                                190,
+                                193
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 10,
+                                    "column": 12
+                                },
+                                "end": {
+                                    "line": 10,
+                                    "column": 15
+                                }
+                            },
+                            "name": "baz",
+                            "typeAnnotation": {
+                                "type": "TypeAnnotation",
+                                "loc": {
+                                    "start": {
+                                        "line": 10,
+                                        "column": 17
+                                    },
+                                    "end": {
+                                        "line": 10,
+                                        "column": 23
+                                    }
+                                },
+                                "range": [
+                                    195,
+                                    201
+                                ],
+                                "typeAnnotation": {
+                                    "type": "TSStringKeyword",
+                                    "range": [
+                                        195,
+                                        201
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 10,
+                                            "column": 17
+                                        },
+                                        "end": {
+                                            "line": 10,
+                                            "column": 23
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 10,
+                                    "column": 26
+                                },
+                                "end": {
+                                    "line": 10,
+                                    "column": 32
+                                }
+                            },
+                            "range": [
+                                204,
+                                210
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSStringKeyword",
+                                "range": [
+                                    204,
+                                    210
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 10,
+                                        "column": 26
+                                    },
+                                    "end": {
+                                        "line": 10,
+                                        "column": 32
+                                    }
+                                }
+                            }
+                        },
+                        "accessibility": "public",
+                        "readonly": false,
+                        "static": false,
+                        "export": false
+                    },
+                    {
+                        "type": "TSIndexSignature",
+                        "range": [
+                            216,
+                            246
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 11,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 11,
+                                "column": 34
+                            }
+                        },
+                        "index": {
+                            "type": "Identifier",
+                            "range": [
+                                225,
+                                228
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 11,
+                                    "column": 13
+                                },
+                                "end": {
+                                    "line": 11,
+                                    "column": 16
+                                }
+                            },
+                            "name": "baz",
+                            "typeAnnotation": {
+                                "type": "TypeAnnotation",
+                                "loc": {
+                                    "start": {
+                                        "line": 11,
+                                        "column": 18
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 24
+                                    }
+                                },
+                                "range": [
+                                    230,
+                                    236
+                                ],
+                                "typeAnnotation": {
+                                    "type": "TSStringKeyword",
+                                    "range": [
+                                        230,
+                                        236
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 11,
+                                            "column": 18
+                                        },
+                                        "end": {
+                                            "line": 11,
+                                            "column": 24
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 11,
+                                    "column": 27
+                                },
+                                "end": {
+                                    "line": 11,
+                                    "column": 33
+                                }
+                            },
+                            "range": [
+                                239,
+                                245
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSStringKeyword",
+                                "range": [
+                                    239,
+                                    245
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 11,
+                                        "column": 27
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 33
+                                    }
+                                }
+                            }
+                        },
+                        "accessibility": "private",
+                        "readonly": false,
+                        "static": false,
+                        "export": false
+                    },
+                    {
+                        "type": "TSIndexSignature",
+                        "range": [
+                            251,
+                            283
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 12,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 12,
+                                "column": 36
+                            }
+                        },
+                        "index": {
+                            "type": "Identifier",
+                            "range": [
+                                262,
+                                265
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 12,
+                                    "column": 15
+                                },
+                                "end": {
+                                    "line": 12,
+                                    "column": 18
+                                }
+                            },
+                            "name": "baz",
+                            "typeAnnotation": {
+                                "type": "TypeAnnotation",
+                                "loc": {
+                                    "start": {
+                                        "line": 12,
+                                        "column": 20
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 26
+                                    }
+                                },
+                                "range": [
+                                    267,
+                                    273
+                                ],
+                                "typeAnnotation": {
+                                    "type": "TSStringKeyword",
+                                    "range": [
+                                        267,
+                                        273
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 12,
+                                            "column": 20
+                                        },
+                                        "end": {
+                                            "line": 12,
+                                            "column": 26
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 12,
+                                    "column": 29
+                                },
+                                "end": {
+                                    "line": 12,
+                                    "column": 35
+                                }
+                            },
+                            "range": [
+                                276,
+                                282
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSStringKeyword",
+                                "range": [
+                                    276,
+                                    282
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 12,
+                                        "column": 29
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 35
+                                    }
+                                }
+                            }
+                        },
+                        "accessibility": "protected",
+                        "readonly": false,
+                        "static": false,
+                        "export": false
+                    },
+                    {
+                        "type": "TSIndexSignature",
+                        "range": [
+                            288,
+                            317
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 13,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 13,
+                                "column": 33
+                            }
+                        },
+                        "index": {
+                            "type": "Identifier",
+                            "range": [
+                                296,
+                                299
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 13,
+                                    "column": 12
+                                },
+                                "end": {
+                                    "line": 13,
+                                    "column": 15
+                                }
+                            },
+                            "name": "baz",
+                            "typeAnnotation": {
+                                "type": "TypeAnnotation",
+                                "loc": {
+                                    "start": {
+                                        "line": 13,
+                                        "column": 17
+                                    },
+                                    "end": {
+                                        "line": 13,
+                                        "column": 23
+                                    }
+                                },
+                                "range": [
+                                    301,
+                                    307
+                                ],
+                                "typeAnnotation": {
+                                    "type": "TSStringKeyword",
+                                    "range": [
+                                        301,
+                                        307
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 13,
+                                            "column": 17
+                                        },
+                                        "end": {
+                                            "line": 13,
+                                            "column": 23
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 13,
+                                    "column": 26
+                                },
+                                "end": {
+                                    "line": 13,
+                                    "column": 32
+                                }
+                            },
+                            "range": [
+                                310,
+                                316
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSStringKeyword",
+                                "range": [
+                                    310,
+                                    316
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 13,
+                                        "column": 26
+                                    },
+                                    "end": {
+                                        "line": 13,
+                                        "column": 32
+                                    }
+                                }
+                            }
+                        },
+                        "accessibility": null,
+                        "readonly": false,
+                        "static": true,
+                        "export": false
+                    },
+                    {
+                        "type": "TSIndexSignature",
+                        "range": [
+                            322,
+                            351
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 14,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 14,
+                                "column": 33
+                            }
+                        },
+                        "index": {
+                            "type": "Identifier",
+                            "range": [
+                                330,
+                                333
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 14,
+                                    "column": 12
+                                },
+                                "end": {
+                                    "line": 14,
+                                    "column": 15
+                                }
+                            },
+                            "name": "baz",
+                            "typeAnnotation": {
+                                "type": "TypeAnnotation",
+                                "loc": {
+                                    "start": {
+                                        "line": 14,
+                                        "column": 17
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 23
+                                    }
+                                },
+                                "range": [
+                                    335,
+                                    341
+                                ],
+                                "typeAnnotation": {
+                                    "type": "TSStringKeyword",
+                                    "range": [
+                                        335,
+                                        341
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 14,
+                                            "column": 17
+                                        },
+                                        "end": {
+                                            "line": 14,
+                                            "column": 23
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 14,
+                                    "column": 26
+                                },
+                                "end": {
+                                    "line": 14,
+                                    "column": 32
+                                }
+                            },
+                            "range": [
+                                344,
+                                350
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSStringKeyword",
+                                "range": [
+                                    344,
+                                    350
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 14,
+                                        "column": 26
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 32
+                                    }
+                                }
+                            }
+                        },
+                        "accessibility": null,
+                        "readonly": false,
+                        "static": false,
+                        "export": true
+                    },
+                    {
+                        "type": "TSIndexSignature",
+                        "range": [
+                            356,
+                            387
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 15,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 15,
+                                "column": 35
+                            }
+                        },
+                        "index": {
+                            "type": "Identifier",
+                            "range": [
+                                366,
+                                369
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 15,
+                                    "column": 14
+                                },
+                                "end": {
+                                    "line": 15,
+                                    "column": 17
+                                }
+                            },
+                            "name": "baz",
+                            "typeAnnotation": {
+                                "type": "TypeAnnotation",
+                                "loc": {
+                                    "start": {
+                                        "line": 15,
+                                        "column": 19
+                                    },
+                                    "end": {
+                                        "line": 15,
+                                        "column": 25
+                                    }
+                                },
+                                "range": [
+                                    371,
+                                    377
+                                ],
+                                "typeAnnotation": {
+                                    "type": "TSStringKeyword",
+                                    "range": [
+                                        371,
+                                        377
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 15,
+                                            "column": 19
+                                        },
+                                        "end": {
+                                            "line": 15,
+                                            "column": 25
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 15,
+                                    "column": 28
+                                },
+                                "end": {
+                                    "line": 15,
+                                    "column": 34
+                                }
+                            },
+                            "range": [
+                                380,
+                                386
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSStringKeyword",
+                                "range": [
+                                    380,
+                                    386
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 15,
+                                        "column": 28
+                                    },
+                                    "end": {
+                                        "line": 15,
+                                        "column": 34
+                                    }
+                                }
+                            }
+                        },
+                        "accessibility": null,
+                        "readonly": true,
+                        "static": false,
+                        "export": false
+                    },
+                    {
+                        "type": "TSMethodSignature",
+                        "range": [
+                            393,
+                            421
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 17,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 17,
+                                "column": 32
+                            }
+                        },
+                        "optional": false,
+                        "computed": false,
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                400,
+                                401
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 17,
+                                    "column": 11
+                                },
+                                "end": {
+                                    "line": 17,
+                                    "column": 12
+                                }
+                            },
+                            "name": "g"
+                        },
+                        "params": [
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    402,
+                                    405
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 17,
+                                        "column": 13
+                                    },
+                                    "end": {
+                                        "line": 17,
+                                        "column": 16
+                                    }
+                                },
+                                "name": "bar",
+                                "typeAnnotation": {
+                                    "type": "TypeAnnotation",
+                                    "loc": {
+                                        "start": {
+                                            "line": 17,
+                                            "column": 18
+                                        },
+                                        "end": {
+                                            "line": 17,
+                                            "column": 24
+                                        }
+                                    },
+                                    "range": [
+                                        407,
+                                        413
+                                    ],
+                                    "typeAnnotation": {
+                                        "type": "TSStringKeyword",
+                                        "range": [
+                                            407,
+                                            413
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 17,
+                                                "column": 18
+                                            },
+                                            "end": {
+                                                "line": 17,
+                                                "column": 24
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 17,
+                                    "column": 27
+                                },
+                                "end": {
+                                    "line": 17,
+                                    "column": 31
+                                }
+                            },
+                            "range": [
+                                416,
+                                420
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSVoidKeyword",
+                                "range": [
+                                    416,
+                                    420
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 17,
+                                        "column": 27
+                                    },
+                                    "end": {
+                                        "line": 17,
+                                        "column": 31
+                                    }
+                                }
+                            }
+                        },
+                        "accessibility": "public",
+                        "readonly": false,
+                        "static": false,
+                        "export": false
+                    },
+                    {
+                        "type": "TSMethodSignature",
+                        "range": [
+                            426,
+                            455
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 18,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 18,
+                                "column": 33
+                            }
+                        },
+                        "optional": false,
+                        "computed": false,
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                434,
+                                435
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 18,
+                                    "column": 12
+                                },
+                                "end": {
+                                    "line": 18,
+                                    "column": 13
+                                }
+                            },
+                            "name": "h"
+                        },
+                        "params": [
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    436,
+                                    439
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 18,
+                                        "column": 14
+                                    },
+                                    "end": {
+                                        "line": 18,
+                                        "column": 17
+                                    }
+                                },
+                                "name": "bar",
+                                "typeAnnotation": {
+                                    "type": "TypeAnnotation",
+                                    "loc": {
+                                        "start": {
+                                            "line": 18,
+                                            "column": 19
+                                        },
+                                        "end": {
+                                            "line": 18,
+                                            "column": 25
+                                        }
+                                    },
+                                    "range": [
+                                        441,
+                                        447
+                                    ],
+                                    "typeAnnotation": {
+                                        "type": "TSStringKeyword",
+                                        "range": [
+                                            441,
+                                            447
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 18,
+                                                "column": 19
+                                            },
+                                            "end": {
+                                                "line": 18,
+                                                "column": 25
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 18,
+                                    "column": 28
+                                },
+                                "end": {
+                                    "line": 18,
+                                    "column": 32
+                                }
+                            },
+                            "range": [
+                                450,
+                                454
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSVoidKeyword",
+                                "range": [
+                                    450,
+                                    454
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 18,
+                                        "column": 28
+                                    },
+                                    "end": {
+                                        "line": 18,
+                                        "column": 32
+                                    }
+                                }
+                            }
+                        },
+                        "accessibility": "private",
+                        "readonly": false,
+                        "static": false,
+                        "export": false
+                    },
+                    {
+                        "type": "TSMethodSignature",
+                        "range": [
+                            460,
+                            491
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 19,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 19,
+                                "column": 35
+                            }
+                        },
+                        "optional": false,
+                        "computed": false,
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                470,
+                                471
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 19,
+                                    "column": 14
+                                },
+                                "end": {
+                                    "line": 19,
+                                    "column": 15
+                                }
+                            },
+                            "name": "i"
+                        },
+                        "params": [
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    472,
+                                    475
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 19,
+                                        "column": 16
+                                    },
+                                    "end": {
+                                        "line": 19,
+                                        "column": 19
+                                    }
+                                },
+                                "name": "bar",
+                                "typeAnnotation": {
+                                    "type": "TypeAnnotation",
+                                    "loc": {
+                                        "start": {
+                                            "line": 19,
+                                            "column": 21
+                                        },
+                                        "end": {
+                                            "line": 19,
+                                            "column": 27
+                                        }
+                                    },
+                                    "range": [
+                                        477,
+                                        483
+                                    ],
+                                    "typeAnnotation": {
+                                        "type": "TSStringKeyword",
+                                        "range": [
+                                            477,
+                                            483
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 19,
+                                                "column": 21
+                                            },
+                                            "end": {
+                                                "line": 19,
+                                                "column": 27
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 19,
+                                    "column": 30
+                                },
+                                "end": {
+                                    "line": 19,
+                                    "column": 34
+                                }
+                            },
+                            "range": [
+                                486,
+                                490
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSVoidKeyword",
+                                "range": [
+                                    486,
+                                    490
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 19,
+                                        "column": 30
+                                    },
+                                    "end": {
+                                        "line": 19,
+                                        "column": 34
+                                    }
+                                }
+                            }
+                        },
+                        "accessibility": "protected",
+                        "readonly": false,
+                        "static": false,
+                        "export": false
+                    },
+                    {
+                        "type": "TSMethodSignature",
+                        "range": [
+                            496,
+                            524
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 20,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 20,
+                                "column": 32
+                            }
+                        },
+                        "optional": false,
+                        "computed": false,
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                503,
+                                504
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 20,
+                                    "column": 11
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 12
+                                }
+                            },
+                            "name": "j"
+                        },
+                        "params": [
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    505,
+                                    508
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 20,
+                                        "column": 13
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 16
+                                    }
+                                },
+                                "name": "bar",
+                                "typeAnnotation": {
+                                    "type": "TypeAnnotation",
+                                    "loc": {
+                                        "start": {
+                                            "line": 20,
+                                            "column": 18
+                                        },
+                                        "end": {
+                                            "line": 20,
+                                            "column": 24
+                                        }
+                                    },
+                                    "range": [
+                                        510,
+                                        516
+                                    ],
+                                    "typeAnnotation": {
+                                        "type": "TSStringKeyword",
+                                        "range": [
+                                            510,
+                                            516
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 20,
+                                                "column": 18
+                                            },
+                                            "end": {
+                                                "line": 20,
+                                                "column": 24
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 20,
+                                    "column": 27
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 31
+                                }
+                            },
+                            "range": [
+                                519,
+                                523
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSVoidKeyword",
+                                "range": [
+                                    519,
+                                    523
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 20,
+                                        "column": 27
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 31
+                                    }
+                                }
+                            }
+                        },
+                        "accessibility": null,
+                        "readonly": false,
+                        "static": true,
+                        "export": false
+                    },
+                    {
+                        "type": "TSMethodSignature",
+                        "range": [
+                            529,
+                            557
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 21,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 21,
+                                "column": 32
+                            }
+                        },
+                        "optional": false,
+                        "computed": false,
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                536,
+                                537
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 21,
+                                    "column": 11
+                                },
+                                "end": {
+                                    "line": 21,
+                                    "column": 12
+                                }
+                            },
+                            "name": "k"
+                        },
+                        "params": [
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    538,
+                                    541
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 21,
+                                        "column": 13
+                                    },
+                                    "end": {
+                                        "line": 21,
+                                        "column": 16
+                                    }
+                                },
+                                "name": "bar",
+                                "typeAnnotation": {
+                                    "type": "TypeAnnotation",
+                                    "loc": {
+                                        "start": {
+                                            "line": 21,
+                                            "column": 18
+                                        },
+                                        "end": {
+                                            "line": 21,
+                                            "column": 24
+                                        }
+                                    },
+                                    "range": [
+                                        543,
+                                        549
+                                    ],
+                                    "typeAnnotation": {
+                                        "type": "TSStringKeyword",
+                                        "range": [
+                                            543,
+                                            549
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 21,
+                                                "column": 18
+                                            },
+                                            "end": {
+                                                "line": 21,
+                                                "column": 24
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 21,
+                                    "column": 27
+                                },
+                                "end": {
+                                    "line": 21,
+                                    "column": 31
+                                }
+                            },
+                            "range": [
+                                552,
+                                556
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSVoidKeyword",
+                                "range": [
+                                    552,
+                                    556
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 21,
+                                        "column": 27
+                                    },
+                                    "end": {
+                                        "line": 21,
+                                        "column": 31
+                                    }
+                                }
+                            }
+                        },
+                        "accessibility": null,
+                        "readonly": false,
+                        "static": false,
+                        "export": true
+                    },
+                    {
+                        "type": "TSMethodSignature",
+                        "range": [
+                            562,
+                            592
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 22,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 22,
+                                "column": 34
+                            }
+                        },
+                        "optional": false,
+                        "computed": false,
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                571,
+                                572
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 22,
+                                    "column": 13
+                                },
+                                "end": {
+                                    "line": 22,
+                                    "column": 14
+                                }
+                            },
+                            "name": "l"
+                        },
+                        "params": [
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    573,
+                                    576
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 22,
+                                        "column": 15
+                                    },
+                                    "end": {
+                                        "line": 22,
+                                        "column": 18
+                                    }
+                                },
+                                "name": "bar",
+                                "typeAnnotation": {
+                                    "type": "TypeAnnotation",
+                                    "loc": {
+                                        "start": {
+                                            "line": 22,
+                                            "column": 20
+                                        },
+                                        "end": {
+                                            "line": 22,
+                                            "column": 26
+                                        }
+                                    },
+                                    "range": [
+                                        578,
+                                        584
+                                    ],
+                                    "typeAnnotation": {
+                                        "type": "TSStringKeyword",
+                                        "range": [
+                                            578,
+                                            584
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 22,
+                                                "column": 20
+                                            },
+                                            "end": {
+                                                "line": 22,
+                                                "column": 26
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "loc": {
+                                "start": {
+                                    "line": 22,
+                                    "column": 29
+                                },
+                                "end": {
+                                    "line": 22,
+                                    "column": 33
+                                }
+                            },
+                            "range": [
+                                587,
+                                591
+                            ],
+                            "typeAnnotation": {
+                                "type": "TSVoidKeyword",
+                                "range": [
+                                    587,
+                                    591
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 22,
+                                        "column": 29
+                                    },
+                                    "end": {
+                                        "line": 22,
+                                        "column": 33
+                                    }
+                                }
+                            }
+                        },
+                        "accessibility": null,
+                        "readonly": true,
+                        "static": false,
+                        "export": false
+                    }
+                ],
+                "range": [
+                    14,
+                    594
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 14
+                    },
+                    "end": {
+                        "line": 23,
+                        "column": 1
+                    }
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    10,
+                    13
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 10
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 13
+                    }
+                },
+                "name": "Foo"
+            },
+            "heritage": []
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "interface",
+            "range": [
+                0,
+                9
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Foo",
+            "range": [
+                10,
+                13
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 10
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                14,
+                15
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 14
+                },
+                "end": {
+                    "line": 1,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "range": [
+                20,
+                23
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 7
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                23,
+                24
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 7
+                },
+                "end": {
+                    "line": 2,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                25,
+                31
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 9
+                },
+                "end": {
+                    "line": 2,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "range": [
+                32,
+                33
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 16
+                },
+                "end": {
+                    "line": 2,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "String",
+            "value": "'a'",
+            "range": [
+                34,
+                37
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 18
+                },
+                "end": {
+                    "line": 2,
+                    "column": 21
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                37,
+                38
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 21
+                },
+                "end": {
+                    "line": 2,
+                    "column": 22
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "public",
+            "range": [
+                43,
+                49
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 4
+                },
+                "end": {
+                    "line": 3,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "a",
+            "range": [
+                50,
+                51
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 11
+                },
+                "end": {
+                    "line": 3,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                51,
+                52
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 12
+                },
+                "end": {
+                    "line": 3,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                53,
+                59
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 14
+                },
+                "end": {
+                    "line": 3,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                59,
+                60
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 20
+                },
+                "end": {
+                    "line": 3,
+                    "column": 21
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "private",
+            "range": [
+                65,
+                72
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 4
+                },
+                "end": {
+                    "line": 4,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "b",
+            "range": [
+                73,
+                74
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 12
+                },
+                "end": {
+                    "line": 4,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                74,
+                75
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 13
+                },
+                "end": {
+                    "line": 4,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                76,
+                82
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 15
+                },
+                "end": {
+                    "line": 4,
+                    "column": 21
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                82,
+                83
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 21
+                },
+                "end": {
+                    "line": 4,
+                    "column": 22
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "protected",
+            "range": [
+                88,
+                97
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 4
+                },
+                "end": {
+                    "line": 5,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "c",
+            "range": [
+                98,
+                99
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 14
+                },
+                "end": {
+                    "line": 5,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                99,
+                100
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 15
+                },
+                "end": {
+                    "line": 5,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                101,
+                107
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 17
+                },
+                "end": {
+                    "line": 5,
+                    "column": 23
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                107,
+                108
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 23
+                },
+                "end": {
+                    "line": 5,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "range": [
+                113,
+                119
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 4
+                },
+                "end": {
+                    "line": 6,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "d",
+            "range": [
+                120,
+                121
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 11
+                },
+                "end": {
+                    "line": 6,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                121,
+                122
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 12
+                },
+                "end": {
+                    "line": 6,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                123,
+                129
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 14
+                },
+                "end": {
+                    "line": 6,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                129,
+                130
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 20
+                },
+                "end": {
+                    "line": 6,
+                    "column": 21
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "export",
+            "range": [
+                135,
+                141
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 4
+                },
+                "end": {
+                    "line": 7,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "e",
+            "range": [
+                142,
+                143
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 11
+                },
+                "end": {
+                    "line": 7,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                143,
+                144
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 12
+                },
+                "end": {
+                    "line": 7,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                145,
+                151
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 14
+                },
+                "end": {
+                    "line": 7,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                151,
+                152
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 20
+                },
+                "end": {
+                    "line": 7,
+                    "column": 21
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "readonly",
+            "range": [
+                157,
+                165
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 4
+                },
+                "end": {
+                    "line": 8,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "f",
+            "range": [
+                166,
+                167
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 13
+                },
+                "end": {
+                    "line": 8,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                167,
+                168
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 14
+                },
+                "end": {
+                    "line": 8,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                169,
+                175
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 16
+                },
+                "end": {
+                    "line": 8,
+                    "column": 22
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                175,
+                176
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 22
+                },
+                "end": {
+                    "line": 8,
+                    "column": 23
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "public",
+            "range": [
+                182,
+                188
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 4
+                },
+                "end": {
+                    "line": 10,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "[",
+            "range": [
+                189,
+                190
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 11
+                },
+                "end": {
+                    "line": 10,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "baz",
+            "range": [
+                190,
+                193
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 12
+                },
+                "end": {
+                    "line": 10,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                193,
+                194
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 15
+                },
+                "end": {
+                    "line": 10,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                195,
+                201
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 17
+                },
+                "end": {
+                    "line": 10,
+                    "column": 23
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "]",
+            "range": [
+                201,
+                202
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 23
+                },
+                "end": {
+                    "line": 10,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                202,
+                203
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 24
+                },
+                "end": {
+                    "line": 10,
+                    "column": 25
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                204,
+                210
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 26
+                },
+                "end": {
+                    "line": 10,
+                    "column": 32
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                210,
+                211
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 32
+                },
+                "end": {
+                    "line": 10,
+                    "column": 33
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "private",
+            "range": [
+                216,
+                223
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 4
+                },
+                "end": {
+                    "line": 11,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "[",
+            "range": [
+                224,
+                225
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 12
+                },
+                "end": {
+                    "line": 11,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "baz",
+            "range": [
+                225,
+                228
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 13
+                },
+                "end": {
+                    "line": 11,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                228,
+                229
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 16
+                },
+                "end": {
+                    "line": 11,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                230,
+                236
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 18
+                },
+                "end": {
+                    "line": 11,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "]",
+            "range": [
+                236,
+                237
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 24
+                },
+                "end": {
+                    "line": 11,
+                    "column": 25
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                237,
+                238
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 25
+                },
+                "end": {
+                    "line": 11,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                239,
+                245
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 27
+                },
+                "end": {
+                    "line": 11,
+                    "column": 33
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                245,
+                246
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 33
+                },
+                "end": {
+                    "line": 11,
+                    "column": 34
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "protected",
+            "range": [
+                251,
+                260
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 4
+                },
+                "end": {
+                    "line": 12,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "[",
+            "range": [
+                261,
+                262
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 14
+                },
+                "end": {
+                    "line": 12,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "baz",
+            "range": [
+                262,
+                265
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 15
+                },
+                "end": {
+                    "line": 12,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                265,
+                266
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 18
+                },
+                "end": {
+                    "line": 12,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                267,
+                273
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 20
+                },
+                "end": {
+                    "line": 12,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "]",
+            "range": [
+                273,
+                274
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 26
+                },
+                "end": {
+                    "line": 12,
+                    "column": 27
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                274,
+                275
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 27
+                },
+                "end": {
+                    "line": 12,
+                    "column": 28
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                276,
+                282
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 29
+                },
+                "end": {
+                    "line": 12,
+                    "column": 35
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                282,
+                283
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 35
+                },
+                "end": {
+                    "line": 12,
+                    "column": 36
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "range": [
+                288,
+                294
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 4
+                },
+                "end": {
+                    "line": 13,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "[",
+            "range": [
+                295,
+                296
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 11
+                },
+                "end": {
+                    "line": 13,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "baz",
+            "range": [
+                296,
+                299
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 12
+                },
+                "end": {
+                    "line": 13,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                299,
+                300
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 15
+                },
+                "end": {
+                    "line": 13,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                301,
+                307
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 17
+                },
+                "end": {
+                    "line": 13,
+                    "column": 23
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "]",
+            "range": [
+                307,
+                308
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 23
+                },
+                "end": {
+                    "line": 13,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                308,
+                309
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 24
+                },
+                "end": {
+                    "line": 13,
+                    "column": 25
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                310,
+                316
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 26
+                },
+                "end": {
+                    "line": 13,
+                    "column": 32
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                316,
+                317
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 32
+                },
+                "end": {
+                    "line": 13,
+                    "column": 33
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "export",
+            "range": [
+                322,
+                328
+            ],
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 4
+                },
+                "end": {
+                    "line": 14,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "[",
+            "range": [
+                329,
+                330
+            ],
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 11
+                },
+                "end": {
+                    "line": 14,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "baz",
+            "range": [
+                330,
+                333
+            ],
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 12
+                },
+                "end": {
+                    "line": 14,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                333,
+                334
+            ],
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 15
+                },
+                "end": {
+                    "line": 14,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                335,
+                341
+            ],
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 17
+                },
+                "end": {
+                    "line": 14,
+                    "column": 23
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "]",
+            "range": [
+                341,
+                342
+            ],
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 23
+                },
+                "end": {
+                    "line": 14,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                342,
+                343
+            ],
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 24
+                },
+                "end": {
+                    "line": 14,
+                    "column": 25
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                344,
+                350
+            ],
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 26
+                },
+                "end": {
+                    "line": 14,
+                    "column": 32
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                350,
+                351
+            ],
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 32
+                },
+                "end": {
+                    "line": 14,
+                    "column": 33
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "readonly",
+            "range": [
+                356,
+                364
+            ],
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 4
+                },
+                "end": {
+                    "line": 15,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "[",
+            "range": [
+                365,
+                366
+            ],
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 13
+                },
+                "end": {
+                    "line": 15,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "baz",
+            "range": [
+                366,
+                369
+            ],
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 14
+                },
+                "end": {
+                    "line": 15,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                369,
+                370
+            ],
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 17
+                },
+                "end": {
+                    "line": 15,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                371,
+                377
+            ],
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 19
+                },
+                "end": {
+                    "line": 15,
+                    "column": 25
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "]",
+            "range": [
+                377,
+                378
+            ],
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 25
+                },
+                "end": {
+                    "line": 15,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                378,
+                379
+            ],
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 26
+                },
+                "end": {
+                    "line": 15,
+                    "column": 27
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                380,
+                386
+            ],
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 28
+                },
+                "end": {
+                    "line": 15,
+                    "column": 34
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                386,
+                387
+            ],
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 34
+                },
+                "end": {
+                    "line": 15,
+                    "column": 35
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "public",
+            "range": [
+                393,
+                399
+            ],
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 4
+                },
+                "end": {
+                    "line": 17,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "g",
+            "range": [
+                400,
+                401
+            ],
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 11
+                },
+                "end": {
+                    "line": 17,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                401,
+                402
+            ],
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 12
+                },
+                "end": {
+                    "line": 17,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "range": [
+                402,
+                405
+            ],
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 13
+                },
+                "end": {
+                    "line": 17,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                405,
+                406
+            ],
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 16
+                },
+                "end": {
+                    "line": 17,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                407,
+                413
+            ],
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 18
+                },
+                "end": {
+                    "line": 17,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                413,
+                414
+            ],
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 24
+                },
+                "end": {
+                    "line": 17,
+                    "column": 25
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                414,
+                415
+            ],
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 25
+                },
+                "end": {
+                    "line": 17,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "void",
+            "range": [
+                416,
+                420
+            ],
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 27
+                },
+                "end": {
+                    "line": 17,
+                    "column": 31
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                420,
+                421
+            ],
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 31
+                },
+                "end": {
+                    "line": 17,
+                    "column": 32
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "private",
+            "range": [
+                426,
+                433
+            ],
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 4
+                },
+                "end": {
+                    "line": 18,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "h",
+            "range": [
+                434,
+                435
+            ],
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 12
+                },
+                "end": {
+                    "line": 18,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                435,
+                436
+            ],
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 13
+                },
+                "end": {
+                    "line": 18,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "range": [
+                436,
+                439
+            ],
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 14
+                },
+                "end": {
+                    "line": 18,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                439,
+                440
+            ],
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 17
+                },
+                "end": {
+                    "line": 18,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                441,
+                447
+            ],
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 19
+                },
+                "end": {
+                    "line": 18,
+                    "column": 25
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                447,
+                448
+            ],
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 25
+                },
+                "end": {
+                    "line": 18,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                448,
+                449
+            ],
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 26
+                },
+                "end": {
+                    "line": 18,
+                    "column": 27
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "void",
+            "range": [
+                450,
+                454
+            ],
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 28
+                },
+                "end": {
+                    "line": 18,
+                    "column": 32
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                454,
+                455
+            ],
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 32
+                },
+                "end": {
+                    "line": 18,
+                    "column": 33
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "protected",
+            "range": [
+                460,
+                469
+            ],
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 4
+                },
+                "end": {
+                    "line": 19,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "i",
+            "range": [
+                470,
+                471
+            ],
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 14
+                },
+                "end": {
+                    "line": 19,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                471,
+                472
+            ],
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 15
+                },
+                "end": {
+                    "line": 19,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "range": [
+                472,
+                475
+            ],
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 16
+                },
+                "end": {
+                    "line": 19,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                475,
+                476
+            ],
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 19
+                },
+                "end": {
+                    "line": 19,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                477,
+                483
+            ],
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 21
+                },
+                "end": {
+                    "line": 19,
+                    "column": 27
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                483,
+                484
+            ],
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 27
+                },
+                "end": {
+                    "line": 19,
+                    "column": 28
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                484,
+                485
+            ],
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 28
+                },
+                "end": {
+                    "line": 19,
+                    "column": 29
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "void",
+            "range": [
+                486,
+                490
+            ],
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 30
+                },
+                "end": {
+                    "line": 19,
+                    "column": 34
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                490,
+                491
+            ],
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 34
+                },
+                "end": {
+                    "line": 19,
+                    "column": 35
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "range": [
+                496,
+                502
+            ],
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 4
+                },
+                "end": {
+                    "line": 20,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "j",
+            "range": [
+                503,
+                504
+            ],
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 11
+                },
+                "end": {
+                    "line": 20,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                504,
+                505
+            ],
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 12
+                },
+                "end": {
+                    "line": 20,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "range": [
+                505,
+                508
+            ],
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 13
+                },
+                "end": {
+                    "line": 20,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                508,
+                509
+            ],
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 16
+                },
+                "end": {
+                    "line": 20,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                510,
+                516
+            ],
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 18
+                },
+                "end": {
+                    "line": 20,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                516,
+                517
+            ],
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 24
+                },
+                "end": {
+                    "line": 20,
+                    "column": 25
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                517,
+                518
+            ],
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 25
+                },
+                "end": {
+                    "line": 20,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "void",
+            "range": [
+                519,
+                523
+            ],
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 27
+                },
+                "end": {
+                    "line": 20,
+                    "column": 31
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                523,
+                524
+            ],
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 31
+                },
+                "end": {
+                    "line": 20,
+                    "column": 32
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "export",
+            "range": [
+                529,
+                535
+            ],
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 4
+                },
+                "end": {
+                    "line": 21,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "k",
+            "range": [
+                536,
+                537
+            ],
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 11
+                },
+                "end": {
+                    "line": 21,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                537,
+                538
+            ],
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 12
+                },
+                "end": {
+                    "line": 21,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "range": [
+                538,
+                541
+            ],
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 13
+                },
+                "end": {
+                    "line": 21,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                541,
+                542
+            ],
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 16
+                },
+                "end": {
+                    "line": 21,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                543,
+                549
+            ],
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 18
+                },
+                "end": {
+                    "line": 21,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                549,
+                550
+            ],
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 24
+                },
+                "end": {
+                    "line": 21,
+                    "column": 25
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                550,
+                551
+            ],
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 25
+                },
+                "end": {
+                    "line": 21,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "void",
+            "range": [
+                552,
+                556
+            ],
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 27
+                },
+                "end": {
+                    "line": 21,
+                    "column": 31
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                556,
+                557
+            ],
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 31
+                },
+                "end": {
+                    "line": 21,
+                    "column": 32
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "readonly",
+            "range": [
+                562,
+                570
+            ],
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 4
+                },
+                "end": {
+                    "line": 22,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "l",
+            "range": [
+                571,
+                572
+            ],
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 13
+                },
+                "end": {
+                    "line": 22,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                572,
+                573
+            ],
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 14
+                },
+                "end": {
+                    "line": 22,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "range": [
+                573,
+                576
+            ],
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 15
+                },
+                "end": {
+                    "line": 22,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                576,
+                577
+            ],
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 18
+                },
+                "end": {
+                    "line": 22,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "range": [
+                578,
+                584
+            ],
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 20
+                },
+                "end": {
+                    "line": 22,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                584,
+                585
+            ],
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 26
+                },
+                "end": {
+                    "line": 22,
+                    "column": 27
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                585,
+                586
+            ],
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 27
+                },
+                "end": {
+                    "line": 22,
+                    "column": 28
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "void",
+            "range": [
+                587,
+                591
+            ],
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 29
+                },
+                "end": {
+                    "line": 22,
+                    "column": 33
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                591,
+                592
+            ],
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 33
+                },
+                "end": {
+                    "line": 22,
+                    "column": 34
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                593,
+                594
+            ],
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 0
+                },
+                "end": {
+                    "line": 23,
+                    "column": 1
+                }
+            }
+        }
+    ]
+};

--- a/tests/fixtures/typescript/errorRecovery/interface-property-modifiers.src.ts
+++ b/tests/fixtures/typescript/errorRecovery/interface-property-modifiers.src.ts
@@ -1,0 +1,24 @@
+interface Foo {
+    bar: string = 'a';
+    public a: string;
+    private b: string;
+    protected c: string;
+    static d: string;
+    export e: string;
+    readonly f: string;
+
+    public [baz: string]: string;
+    private [baz: string]: string;
+    protected [baz: string]: string;
+    static [baz: string]: string;
+    export [baz: string]: string;
+    readonly [baz: string]: string;
+
+    public g(bar: string): void;
+    private h(bar: string): void;
+    protected i(bar: string): void;
+    static j(bar: string): void;
+    export k(bar: string): void;
+    readonly l(bar: string): void;
+}
+


### PR DESCRIPTION
I noticed that optional is used twice. Once in identifier and once in the TSPropertySignature. Maybe we should clean that up.

Here is what this produces:
https://github.com/eslint/typescript-eslint-parser/issues/262#issuecomment-299722772