### PR TITLE
Breaking: Use ESTree export node types in modules (fixes# 263)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A parser that converts TypeScript into an [ESTree](https://github.com/estree/estree)-compatible form so it can be used in ESLint.
 
-**Important:** This parser is not fully compatbile with all ESLint rules and plugins. Some rules will improperly mark source code as failing or not find problems where it should.
+**Important:** This parser is not fully compatible with all ESLint rules and plugins. Some rules will improperly mark source code as failing or not find problems where it should.
 
 ## Supported TypeScript Version
 
@@ -24,6 +24,8 @@ The following ESLint rules will fail on acceptable code:
  
 The follow ESLint plugins have issues when used with this parser:
  - eslint-plugin-react [#213](https://github.com/eslint/typescript-eslint-parser/issues/213)
+ - eslint-plugin-import
+    - prefer-default-export - Will fail exports inside of Namespaces or Modules
   
 The following TypeScript syntax will cause rules to fail or ESLint v3 to crash:
  - Empty body functions
@@ -51,7 +53,7 @@ If you're familiar with TypeScript and ESLint, and you'd like to see this projec
 
 ## Reporting Bugs
 
-Please check the current list of open and known issues and ensure the bug has not been reported before. When creating a new issue provide as much information about your enviroment as possible. This includes:
+Please check the current list of open and known issues and ensure the bug has not been reported before. When creating a new issue provide as much information about your environment as possible. This includes:
  - ESLint Version
  - TypeScript version
  - TypeScript parser version

--- a/lib/node-utils.js
+++ b/lib/node-utils.js
@@ -486,15 +486,7 @@ function fixExports(node, result, ast) {
         result.range[0] = varToken.getStart();
         result.loc = getLocFor(result.range[0], result.range[1], ast);
 
-        let declarationType = declarationIsDefault ? "ExportDefaultDeclaration" : "ExportNamedDeclaration";
-
-        /**
-         * Prefix exports from TypeScript namespaces with "TS" to distinguish
-         * them from ES2015 exports
-         */
-        if (node.parent && node.parent.kind === SyntaxKind.ModuleBlock) {
-            declarationType = "TSNamespaceExportDeclaration";
-        }
+        const declarationType = declarationIsDefault ? "ExportDefaultDeclaration" : "ExportNamedDeclaration";
 
         const newResult = {
             type: declarationType,

--- a/tests/fixtures/typescript/namespaces-and-modules/declare-namespace-with-exported-function.result.js
+++ b/tests/fixtures/typescript/namespaces-and-modules/declare-namespace-with-exported-function.result.js
@@ -86,7 +86,7 @@ module.exports = {
                 },
                 "body": [
                     {
-                        "type": "TSNamespaceExportDeclaration",
+                        "type": "ExportNamedDeclaration",
                         "declaration": {
                             "type": "TSNamespaceFunctionDeclaration",
                             "range": [

--- a/tests/fixtures/typescript/namespaces-and-modules/module-with-default-exports.result.js
+++ b/tests/fixtures/typescript/namespaces-and-modules/module-with-default-exports.result.js
@@ -1,0 +1,825 @@
+module.exports = {
+    "type": "Program",
+    "range": [
+        0,
+        112
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 6,
+            "column": 1
+        }
+    },
+    "body": [
+        {
+            "type": "TSModuleDeclaration",
+            "range": [
+                0,
+                112
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 6,
+                    "column": 1
+                }
+            },
+            "name": {
+                "type": "Literal",
+                "range": [
+                    7,
+                    12
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 7
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 12
+                    }
+                },
+                "value": "foo",
+                "raw": "\"foo\""
+            },
+            "body": {
+                "type": "TSModuleBlock",
+                "range": [
+                    13,
+                    112
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 13
+                    },
+                    "end": {
+                        "line": 6,
+                        "column": 1
+                    }
+                },
+                "body": [
+                    {
+                        "type": "ExportDefaultDeclaration",
+                        "declaration": {
+                            "type": "ClassDeclaration",
+                            "range": [
+                                34,
+                                73
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 19
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 5
+                                }
+                            },
+                            "id": {
+                                "type": "Identifier",
+                                "range": [
+                                    40,
+                                    41
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 25
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 26
+                                    }
+                                },
+                                "name": "C"
+                            },
+                            "body": {
+                                "type": "ClassBody",
+                                "body": [
+                                    {
+                                        "type": "MethodDefinition",
+                                        "range": [
+                                            52,
+                                            66
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 3,
+                                                "column": 8
+                                            },
+                                            "end": {
+                                                "line": 3,
+                                                "column": 22
+                                            }
+                                        },
+                                        "key": {
+                                            "type": "Identifier",
+                                            "range": [
+                                                52,
+                                                58
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 3,
+                                                    "column": 8
+                                                },
+                                                "end": {
+                                                    "line": 3,
+                                                    "column": 14
+                                                }
+                                            },
+                                            "name": "method"
+                                        },
+                                        "value": {
+                                            "type": "FunctionExpression",
+                                            "id": null,
+                                            "generator": false,
+                                            "expression": false,
+                                            "async": false,
+                                            "body": {
+                                                "type": "BlockStatement",
+                                                "range": [
+                                                    64,
+                                                    66
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 3,
+                                                        "column": 20
+                                                    },
+                                                    "end": {
+                                                        "line": 3,
+                                                        "column": 22
+                                                    }
+                                                },
+                                                "body": []
+                                            },
+                                            "range": [
+                                                58,
+                                                66
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 3,
+                                                    "column": 14
+                                                },
+                                                "end": {
+                                                    "line": 3,
+                                                    "column": 22
+                                                }
+                                            },
+                                            "returnType": {
+                                                "type": "TypeAnnotation",
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 3,
+                                                        "column": 18
+                                                    },
+                                                    "end": {
+                                                        "line": 3,
+                                                        "column": 19
+                                                    }
+                                                },
+                                                "range": [
+                                                    62,
+                                                    63
+                                                ],
+                                                "typeAnnotation": {
+                                                    "type": "TSTypeReference",
+                                                    "range": [
+                                                        62,
+                                                        63
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 3,
+                                                            "column": 18
+                                                        },
+                                                        "end": {
+                                                            "line": 3,
+                                                            "column": 19
+                                                        }
+                                                    },
+                                                    "typeName": {
+                                                        "type": "Identifier",
+                                                        "range": [
+                                                            62,
+                                                            63
+                                                        ],
+                                                        "loc": {
+                                                            "start": {
+                                                                "line": 3,
+                                                                "column": 18
+                                                            },
+                                                            "end": {
+                                                                "line": 3,
+                                                                "column": 19
+                                                            }
+                                                        },
+                                                        "name": "C"
+                                                    }
+                                                }
+                                            },
+                                            "params": []
+                                        },
+                                        "computed": false,
+                                        "static": false,
+                                        "kind": "method",
+                                        "accessibility": null,
+                                        "decorators": []
+                                    }
+                                ],
+                                "range": [
+                                    42,
+                                    73
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 27
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 5
+                                    }
+                                }
+                            },
+                            "superClass": null,
+                            "implements": [],
+                            "decorators": []
+                        },
+                        "range": [
+                            19,
+                            73
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 5
+                            }
+                        }
+                    },
+                    {
+                        "type": "ExportDefaultDeclaration",
+                        "declaration": {
+                            "type": "TSNamespaceFunctionDeclaration",
+                            "range": [
+                                93,
+                                110
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 19
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 36
+                                }
+                            },
+                            "id": {
+                                "type": "Identifier",
+                                "range": [
+                                    102,
+                                    105
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 5,
+                                        "column": 28
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 31
+                                    }
+                                },
+                                "name": "bar"
+                            },
+                            "generator": false,
+                            "expression": false,
+                            "async": false,
+                            "params": [],
+                            "body": {
+                                "type": "BlockStatement",
+                                "range": [
+                                    108,
+                                    110
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 5,
+                                        "column": 34
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 36
+                                    }
+                                },
+                                "body": []
+                            }
+                        },
+                        "range": [
+                            78,
+                            110
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 5,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 36
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Identifier",
+            "value": "module",
+            "range": [
+                0,
+                6
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 6
+                }
+            }
+        },
+        {
+            "type": "String",
+            "value": "\"foo\"",
+            "range": [
+                7,
+                12
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 7
+                },
+                "end": {
+                    "line": 1,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                13,
+                14
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "export",
+            "range": [
+                19,
+                25
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "default",
+            "range": [
+                26,
+                33
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 11
+                },
+                "end": {
+                    "line": 2,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "range": [
+                34,
+                39
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 19
+                },
+                "end": {
+                    "line": 2,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "C",
+            "range": [
+                40,
+                41
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 25
+                },
+                "end": {
+                    "line": 2,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                42,
+                43
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 27
+                },
+                "end": {
+                    "line": 2,
+                    "column": 28
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "method",
+            "range": [
+                52,
+                58
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 8
+                },
+                "end": {
+                    "line": 3,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                58,
+                59
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 14
+                },
+                "end": {
+                    "line": 3,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                59,
+                60
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 15
+                },
+                "end": {
+                    "line": 3,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "range": [
+                60,
+                61
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 16
+                },
+                "end": {
+                    "line": 3,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "C",
+            "range": [
+                62,
+                63
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 18
+                },
+                "end": {
+                    "line": 3,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                64,
+                65
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 20
+                },
+                "end": {
+                    "line": 3,
+                    "column": 21
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                65,
+                66
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 21
+                },
+                "end": {
+                    "line": 3,
+                    "column": 22
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                66,
+                67
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 22
+                },
+                "end": {
+                    "line": 3,
+                    "column": 23
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                72,
+                73
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 4
+                },
+                "end": {
+                    "line": 4,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "export",
+            "range": [
+                78,
+                84
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 4
+                },
+                "end": {
+                    "line": 5,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "default",
+            "range": [
+                85,
+                92
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 11
+                },
+                "end": {
+                    "line": 5,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "function",
+            "range": [
+                93,
+                101
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 19
+                },
+                "end": {
+                    "line": 5,
+                    "column": 27
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "range": [
+                102,
+                105
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 28
+                },
+                "end": {
+                    "line": 5,
+                    "column": 31
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                105,
+                106
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 31
+                },
+                "end": {
+                    "line": 5,
+                    "column": 32
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                106,
+                107
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 32
+                },
+                "end": {
+                    "line": 5,
+                    "column": 33
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                108,
+                109
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 34
+                },
+                "end": {
+                    "line": 5,
+                    "column": 35
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                109,
+                110
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 35
+                },
+                "end": {
+                    "line": 5,
+                    "column": 36
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                111,
+                112
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 0
+                },
+                "end": {
+                    "line": 6,
+                    "column": 1
+                }
+            }
+        }
+    ]
+};

--- a/tests/fixtures/typescript/namespaces-and-modules/module-with-default-exports.src.ts
+++ b/tests/fixtures/typescript/namespaces-and-modules/module-with-default-exports.src.ts
@@ -1,0 +1,7 @@
+module "foo" {
+    export default class C {
+        method(): C {};
+    }
+    export default function bar() {}
+}
+


### PR DESCRIPTION
We currently do not rename the import node type in modules. Also we do not rename all the export statement types, only ones that are used to export functions or variables. Named exports or export all statements are not converted. I think it makes more sense to follow the ESTree spec as it allows for eslint rules in the eslint-plugin-import to work correctly. 