### PR TITLE
Fix: Use correct starting range and loc for JSXText tokens (fixes #227)

### DIFF
--- a/lib/node-utils.js
+++ b/lib/node-utils.js
@@ -588,15 +588,16 @@ function getTokenType(token) {
  * @returns {ESTreeToken}       the converted ESTreeToken
  */
 function convertToken(token, ast) {
-    const start = token.getStart(),
-        value = ast.text.slice(start, token.end),
+    const start = (token.kind === SyntaxKind.JsxText) ? token.getFullStart() : token.getStart(),
+        end = token.getEnd(),
+        value = ast.text.slice(start, end),
         newToken = {
             type: getTokenType(token),
             value,
             start,
-            end: token.end,
-            range: [start, token.end],
-            loc: getLoc(token, ast)
+            end,
+            range: [start, end],
+            loc: getLocFor(start, end, ast)
         };
 
     if (newToken.type === "RegularExpression") {

--- a/tests/fixtures/comments/jsx-block-comment.result.js
+++ b/tests/fixtures/comments/jsx-block-comment.result.js
@@ -512,15 +512,15 @@ module.exports = {
         },
         {
             "type": "JSXText",
-            "value": "",
+            "value": "\n            ",
             "range": [
-                60,
+                47,
                 60
             ],
             "loc": {
                 "start": {
-                    "line": 4,
-                    "column": 12
+                    "line": 3,
+                    "column": 13
                 },
                 "end": {
                     "line": 4,
@@ -566,15 +566,15 @@ module.exports = {
         },
         {
             "type": "JSXText",
-            "value": "",
+            "value": "\n        ",
             "range": [
-                82,
+                73,
                 82
             ],
             "loc": {
                 "start": {
-                    "line": 5,
-                    "column": 8
+                    "line": 4,
+                    "column": 25
                 },
                 "end": {
                     "line": 5,

--- a/tests/fixtures/comments/jsx-tag-comments.result.js
+++ b/tests/fixtures/comments/jsx-tag-comments.result.js
@@ -459,15 +459,15 @@ module.exports = {
         },
         {
             "type": "JSXText",
-            "value": "",
+            "value": "\n        ",
             "range": [
-                112,
+                103,
                 112
             ],
             "loc": {
                 "start": {
-                    "line": 7,
-                    "column": 8
+                    "line": 6,
+                    "column": 9
                 },
                 "end": {
                     "line": 7,

--- a/tests/fixtures/ecma-features/jsx/self-closing-tag-inside-tag.result.js
+++ b/tests/fixtures/ecma-features/jsx/self-closing-tag-inside-tag.result.js
@@ -276,15 +276,15 @@ module.exports = {
         },
         {
             "type": "JSXText",
-            "value": "",
+            "value": "\n    ",
             "range": [
-                10,
+                5,
                 10
             ],
             "loc": {
                 "start": {
-                    "line": 2,
-                    "column": 4
+                    "line": 1,
+                    "column": 5
                 },
                 "end": {
                     "line": 2,
@@ -366,15 +366,15 @@ module.exports = {
         },
         {
             "type": "JSXText",
-            "value": "",
+            "value": "\n",
             "range": [
-                18,
+                17,
                 18
             ],
             "loc": {
                 "start": {
-                    "line": 3,
-                    "column": 0
+                    "line": 2,
+                    "column": 11 
                 },
                 "end": {
                     "line": 3,

--- a/tests/lib/ecma-features.js
+++ b/tests/lib/ecma-features.js
@@ -29,8 +29,7 @@ const FIXTURES_DIR = "./tests/fixtures/ecma-features";
 const filesWithOutsandingTSIssues = [
     "jsx/embedded-tags", // https://github.com/Microsoft/TypeScript/issues/7410
     "jsx/namespaced-attribute-and-value-inserted", // https://github.com/Microsoft/TypeScript/issues/7411
-    "jsx/namespaced-name-and-attribute", // https://github.com/Microsoft/TypeScript/issues/7411
-    "jsx/multiple-blank-spaces"
+    "jsx/namespaced-name-and-attribute" // https://github.com/Microsoft/TypeScript/issues/7411
 ];
 
 const testFiles = shelljs.find(FIXTURES_DIR)


### PR DESCRIPTION
We used to use the method `getStart()` to calculate the starting range for JSXText tokens. This would skip over whitespace and cause the value of these tokens to be empty. This would also result in the range and starting line number and column to be incorrect. This commit uses the method `getFullStart()`, on JSXText tokens, which does not skip over whitespace and allows for the correct range, value and loc to be set.

This also fixes issues with JSX indentation in the new indent rule and in the eslint-plugin-react.