### PR TITLE
Fix: Convert range and line number corretly in JSX literals

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -1613,17 +1613,21 @@ module.exports = function convert(config) {
 
         }
 
-        case SyntaxKind.JsxText:
+        case SyntaxKind.JsxText: {
             Object.assign(result, {
                 type: AST_NODE_TYPES.Literal,
                 value: ast.text.slice(node.pos, node.end),
                 raw: ast.text.slice(node.pos, node.end)
             });
 
-            result.loc.start.column = node.pos;
-            result.range[0] = node.pos;
+            const start = node.getFullStart();
+            const end = node.getEnd();
+
+            result.loc = nodeUtils.getLocFor(start, end, ast);
+            result.range = [start, end];
 
             break;
+        }
 
         case SyntaxKind.JsxSpreadAttribute:
             Object.assign(result, {

--- a/tests/fixtures/comments/jsx-block-comment.result.js
+++ b/tests/fixtures/comments/jsx-block-comment.result.js
@@ -215,8 +215,8 @@ module.exports = {
                                                 ],
                                                 "loc": {
                                                     "start": {
-                                                        "line": 4,
-                                                        "column": 47
+                                                        "line": 3,
+                                                        "column": 13 
                                                     },
                                                     "end": {
                                                         "line": 4,
@@ -268,8 +268,8 @@ module.exports = {
                                                 ],
                                                 "loc": {
                                                     "start": {
-                                                        "line": 5,
-                                                        "column": 73
+                                                        "line": 4,
+                                                        "column": 25 
                                                     },
                                                     "end": {
                                                         "line": 5,

--- a/tests/fixtures/comments/jsx-tag-comments.result.js
+++ b/tests/fixtures/comments/jsx-tag-comments.result.js
@@ -215,8 +215,8 @@ module.exports = {
                                                 ],
                                                 "loc": {
                                                     "start": {
-                                                        "line": 7,
-                                                        "column": 103
+                                                        "line": 6,
+                                                        "column": 9
                                                     },
                                                     "end": {
                                                         "line": 7,

--- a/tests/fixtures/ecma-features/jsx/self-closing-tag-inside-tag.result.js
+++ b/tests/fixtures/ecma-features/jsx/self-closing-tag-inside-tag.result.js
@@ -128,7 +128,7 @@ module.exports = {
                         ],
                         "loc": {
                             "start": {
-                                "line": 2,
+                                "line": 1,
                                 "column": 5
                             },
                             "end": {
@@ -203,8 +203,8 @@ module.exports = {
                         ],
                         "loc": {
                             "start": {
-                                "line": 3,
-                                "column": 17
+                                "line": 2,
+                                "column": 11
                             },
                             "end": {
                                 "line": 3,


### PR DESCRIPTION
I ony fixed the JSXText tokens in my last commit. The Literal node needs to be fixed to use the correct range and line number. This fixes more issue with eslint-plugin-react rules