### PR TITLE
Chore: Add node 8 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ node_js:
     - "5"
     - "6"
     - "7"
+    - "8"
 after_success:
     - npm run coveralls


### PR DESCRIPTION
Node 8 is now the current stable version, and we should be testing against it