### PR TITLE
Fix: Use TSExportAssignment node type (fixes #304)

### DIFF
--- a/lib/ast-node-types.js
+++ b/lib/ast-node-types.js
@@ -108,6 +108,7 @@ module.exports = {
     TSConstructSignature: "TSConstructSignature",
     TSDeclareKeyword: "TSDeclareKeyword",
     TSEnumDeclaration: "TSEnumDeclaration",
+    TSExportAssignment: "TSExportAssigment",
     TSIndexSignature: "TSIndexSignature",
     TSInterfaceBody: "TSInterfaceBody",
     TSInterfaceDeclaration: "TSInterfaceDeclaration",

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -1330,10 +1330,17 @@ module.exports = function convert(config) {
             break;
 
         case SyntaxKind.ExportAssignment:
-            Object.assign(result, {
-                type: AST_NODE_TYPES.ExportDefaultDeclaration,
-                declaration: convertChild(node.expression)
-            });
+            if (node.isExportEquals) {
+                Object.assign(result, {
+                    type: AST_NODE_TYPES.TSExportAssignment,
+                    expression: convertChild(node.expression)
+                });
+            } else {
+                Object.assign(result, {
+                    type: AST_NODE_TYPES.ExportDefaultDeclaration,
+                    declaration: convertChild(node.expression)
+                });
+            }
             break;
 
         // Unary Operations

--- a/tests/fixtures/typescript/basics/export-assignment.src.ts
+++ b/tests/fixtures/typescript/basics/export-assignment.src.ts
@@ -1,0 +1,1 @@
+export = foo;

--- a/tests/lib/__snapshots__/typescript.js.snap
+++ b/tests/lib/__snapshots__/typescript.js.snap
@@ -8898,6 +8898,64 @@ Object {
 }
 `;
 
+exports[`typescript fixtures/basics/export-assignment.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "expression": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 12,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 9,
+            "line": 1,
+          },
+        },
+        "name": "foo",
+        "range": Array [
+          9,
+          12,
+        ],
+        "type": "Identifier",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        13,
+      ],
+      "type": "TSExportAssigment",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 13,
+      "line": 1,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    13,
+  ],
+  "sourceType": "module",
+  "type": "Program",
+}
+`;
+
 exports[`typescript fixtures/basics/export-default-class-with-generic.src 1`] = `
 Object {
   "body": Array [


### PR DESCRIPTION
I used the `TSExportAssignment` node with an expression property to match babylon's current behavior.