### PR TITLE
Fix: Calculate correct type parameter range (fixes #316)

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -101,13 +101,15 @@ module.exports = function convert(config) {
     function convertTypeArgumentsToTypeParameters(typeArguments) {
         const firstTypeArgument = typeArguments[0];
         const lastTypeArgument = typeArguments[typeArguments.length - 1];
+        const greaterThanToken = nodeUtils.findNextToken(lastTypeArgument, ast);
+
         return {
             type: AST_NODE_TYPES.TypeParameterInstantiation,
             range: [
                 firstTypeArgument.pos - 1,
-                lastTypeArgument.end + 1
+                greaterThanToken.end
             ],
-            loc: nodeUtils.getLocFor(firstTypeArgument.pos - 1, lastTypeArgument.end + 1, ast),
+            loc: nodeUtils.getLocFor(firstTypeArgument.pos - 1, greaterThanToken.end, ast),
             params: typeArguments.map(typeArgument => ({
                 type: AST_NODE_TYPES.GenericTypeAnnotation,
                 range: [
@@ -131,13 +133,16 @@ module.exports = function convert(config) {
     function convertTSTypeParametersToTypeParametersDeclaration(typeParameters) {
         const firstTypeParameter = typeParameters[0];
         const lastTypeParameter = typeParameters[typeParameters.length - 1];
+
+        const greaterThanToken = nodeUtils.findNextToken(lastTypeParameter, ast);
+
         return {
             type: AST_NODE_TYPES.TypeParameterDeclaration,
             range: [
                 firstTypeParameter.pos - 1,
-                lastTypeParameter.end + 1
+                greaterThanToken.end
             ],
-            loc: nodeUtils.getLocFor(firstTypeParameter.pos - 1, lastTypeParameter.end + 1, ast),
+            loc: nodeUtils.getLocFor(firstTypeParameter.pos - 1, greaterThanToken.end, ast),
             params: typeParameters.map(typeParameter => {
                 const name = nodeUtils.unescapeIdentifier(typeParameter.name.text);
 

--- a/tests/fixtures/typescript/basics/type-parameters-comments.src.ts
+++ b/tests/fixtures/typescript/basics/type-parameters-comments.src.ts
@@ -1,0 +1,3 @@
+foo< /* comment 1 */ A /* comment 2 */ >();
+function bar< /* aaa */ A /* bbb */ >() { }
+function baz< /* aaa */ A /* bbb */ = Foo >() { }

--- a/tests/lib/__snapshots__/typescript.js.snap
+++ b/tests/lib/__snapshots__/typescript.js.snap
@@ -17001,6 +17001,362 @@ Object {
 }
 `;
 
+exports[`typescript fixtures/basics/type-parameters-comments.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "expression": Object {
+        "arguments": Array [],
+        "callee": Object {
+          "loc": Object {
+            "end": Object {
+              "column": 3,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 0,
+              "line": 1,
+            },
+          },
+          "name": "foo",
+          "range": Array [
+            0,
+            3,
+          ],
+          "type": "Identifier",
+        },
+        "loc": Object {
+          "end": Object {
+            "column": 42,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "range": Array [
+          0,
+          42,
+        ],
+        "type": "CallExpression",
+        "typeParameters": Object {
+          "loc": Object {
+            "end": Object {
+              "column": 40,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 3,
+              "line": 1,
+            },
+          },
+          "params": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 22,
+                    "line": 1,
+                  },
+                  "start": Object {
+                    "column": 21,
+                    "line": 1,
+                  },
+                },
+                "name": "A",
+                "range": Array [
+                  21,
+                  22,
+                ],
+                "type": "Identifier",
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 22,
+                  "line": 1,
+                },
+                "start": Object {
+                  "column": 21,
+                  "line": 1,
+                },
+              },
+              "range": Array [
+                21,
+                22,
+              ],
+              "type": "GenericTypeAnnotation",
+              "typeParameters": null,
+            },
+          ],
+          "range": Array [
+            3,
+            40,
+          ],
+          "type": "TypeParameterInstantiation",
+        },
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 43,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        43,
+      ],
+      "type": "ExpressionStatement",
+    },
+    Object {
+      "async": false,
+      "body": Object {
+        "body": Array [],
+        "loc": Object {
+          "end": Object {
+            "column": 43,
+            "line": 2,
+          },
+          "start": Object {
+            "column": 40,
+            "line": 2,
+          },
+        },
+        "range": Array [
+          84,
+          87,
+        ],
+        "type": "BlockStatement",
+      },
+      "expression": false,
+      "generator": false,
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 12,
+            "line": 2,
+          },
+          "start": Object {
+            "column": 9,
+            "line": 2,
+          },
+        },
+        "name": "bar",
+        "range": Array [
+          53,
+          56,
+        ],
+        "type": "Identifier",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 43,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 2,
+        },
+      },
+      "params": Array [],
+      "range": Array [
+        44,
+        87,
+      ],
+      "type": "FunctionDeclaration",
+      "typeParameters": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 37,
+            "line": 2,
+          },
+          "start": Object {
+            "column": 12,
+            "line": 2,
+          },
+        },
+        "params": Array [
+          Object {
+            "constraint": null,
+            "loc": Object {
+              "end": Object {
+                "column": 25,
+                "line": 2,
+              },
+              "start": Object {
+                "column": 24,
+                "line": 2,
+              },
+            },
+            "name": "A",
+            "range": Array [
+              68,
+              69,
+            ],
+            "type": "TypeParameter",
+          },
+        ],
+        "range": Array [
+          56,
+          81,
+        ],
+        "type": "TypeParameterDeclaration",
+      },
+    },
+    Object {
+      "async": false,
+      "body": Object {
+        "body": Array [],
+        "loc": Object {
+          "end": Object {
+            "column": 49,
+            "line": 3,
+          },
+          "start": Object {
+            "column": 46,
+            "line": 3,
+          },
+        },
+        "range": Array [
+          134,
+          137,
+        ],
+        "type": "BlockStatement",
+      },
+      "expression": false,
+      "generator": false,
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 12,
+            "line": 3,
+          },
+          "start": Object {
+            "column": 9,
+            "line": 3,
+          },
+        },
+        "name": "baz",
+        "range": Array [
+          97,
+          100,
+        ],
+        "type": "Identifier",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 49,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 3,
+        },
+      },
+      "params": Array [],
+      "range": Array [
+        88,
+        137,
+      ],
+      "type": "FunctionDeclaration",
+      "typeParameters": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 43,
+            "line": 3,
+          },
+          "start": Object {
+            "column": 12,
+            "line": 3,
+          },
+        },
+        "params": Array [
+          Object {
+            "constraint": null,
+            "default": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 41,
+                  "line": 3,
+                },
+                "start": Object {
+                  "column": 38,
+                  "line": 3,
+                },
+              },
+              "range": Array [
+                126,
+                129,
+              ],
+              "type": "TSTypeReference",
+              "typeName": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 41,
+                    "line": 3,
+                  },
+                  "start": Object {
+                    "column": 38,
+                    "line": 3,
+                  },
+                },
+                "name": "Foo",
+                "range": Array [
+                  126,
+                  129,
+                ],
+                "type": "Identifier",
+              },
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 41,
+                "line": 3,
+              },
+              "start": Object {
+                "column": 24,
+                "line": 3,
+              },
+            },
+            "name": "A",
+            "range": Array [
+              112,
+              129,
+            ],
+            "type": "TypeParameter",
+          },
+        ],
+        "range": Array [
+          100,
+          131,
+        ],
+        "type": "TypeParameterDeclaration",
+      },
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 49,
+      "line": 3,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    137,
+  ],
+  "sourceType": "script",
+  "type": "Program",
+}
+`;
+
 exports[`typescript fixtures/basics/typed-this.src 1`] = `
 Object {
   "body": Array [


### PR DESCRIPTION
The next token of the last type parameter should always be the greater than token. Its end property should be the end range of the type parameter declaration.