### PR TITLE
Only warn about an unsupported TypeScript version once

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -100,6 +100,9 @@ function parse(code, options) {
          */
         if (typeof options.loggerFn === "function") {
             extra.log = options.loggerFn;
+        } else if (options.loggerFn === false) {
+            /** */ // eslint-disable-line valid-jsdoc
+            extra.log = () => {};
         }
 
     }

--- a/parser.js
+++ b/parser.js
@@ -27,7 +27,7 @@ if (!isRunningSupportedTypeScriptVersion) {
         "Please only submit bug reports when using the officially supported version.",
         border
     ];
-    console.log(versionWarning.join("\n\n"));
+    console.log(versionWarning.join("\n\n")); // eslint-disable-line no-console
 }
 
 let extra;

--- a/parser.js
+++ b/parser.js
@@ -16,21 +16,8 @@ const SUPPORTED_TYPESCRIPT_VERSIONS = require("./package.json").devDependencies.
 const ACTIVE_TYPESCRIPT_VERSION = ts.version;
 const isRunningSupportedTypeScriptVersion = semver.satisfies(ACTIVE_TYPESCRIPT_VERSION, SUPPORTED_TYPESCRIPT_VERSIONS);
 
-if (!isRunningSupportedTypeScriptVersion) {
-    const border = "=============";
-    const versionWarning = [
-        border,
-        "WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-eslint-parser.",
-        "You may find that it works just fine, or you may not.",
-        `SUPPORTED TYPESCRIPT VERSIONS: ${SUPPORTED_TYPESCRIPT_VERSIONS}`,
-        `YOUR TYPESCRIPT VERSION: ${ACTIVE_TYPESCRIPT_VERSION}`,
-        "Please only submit bug reports when using the officially supported version.",
-        border
-    ];
-    console.log(versionWarning.join("\n\n")); // eslint-disable-line no-console
-}
-
 let extra;
+let warnedAboutTSVersion = false;
 
 /**
  * Resets the extra config object
@@ -115,6 +102,21 @@ function parse(code, options) {
             extra.log = options.loggerFn;
         }
 
+    }
+
+    if (!isRunningSupportedTypeScriptVersion && !warnedAboutTSVersion) {
+        const border = "=============";
+        const versionWarning = [
+            border,
+            "WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-eslint-parser.",
+            "You may find that it works just fine, or you may not.",
+            `SUPPORTED TYPESCRIPT VERSIONS: ${SUPPORTED_TYPESCRIPT_VERSIONS}`,
+            `YOUR TYPESCRIPT VERSION: ${ACTIVE_TYPESCRIPT_VERSION}`,
+            "Please only submit bug reports when using the officially supported version.",
+            border
+        ];
+        extra.log(versionWarning.join("\n\n"));
+        warnedAboutTSVersion = true;
     }
 
     // Even if jsx option is set in typescript compiler, filename still has to

--- a/parser.js
+++ b/parser.js
@@ -16,8 +16,21 @@ const SUPPORTED_TYPESCRIPT_VERSIONS = require("./package.json").devDependencies.
 const ACTIVE_TYPESCRIPT_VERSION = ts.version;
 const isRunningSupportedTypeScriptVersion = semver.satisfies(ACTIVE_TYPESCRIPT_VERSION, SUPPORTED_TYPESCRIPT_VERSIONS);
 
+if (!isRunningSupportedTypeScriptVersion) {
+    const border = "=============";
+    const versionWarning = [
+        border,
+        "WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-eslint-parser.",
+        "You may find that it works just fine, or you may not.",
+        `SUPPORTED TYPESCRIPT VERSIONS: ${SUPPORTED_TYPESCRIPT_VERSIONS}`,
+        `YOUR TYPESCRIPT VERSION: ${ACTIVE_TYPESCRIPT_VERSION}`,
+        "Please only submit bug reports when using the officially supported version.",
+        border
+    ];
+    console.log(versionWarning.join("\n\n"));
+}
+
 let extra;
-let warnedAboutTSVersion = false;
 
 /**
  * Resets the extra config object
@@ -102,21 +115,6 @@ function parse(code, options) {
             extra.log = options.loggerFn;
         }
 
-    }
-
-    if (!isRunningSupportedTypeScriptVersion && !warnedAboutTSVersion) {
-        const border = "=============";
-        const versionWarning = [
-            border,
-            "WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-eslint-parser.",
-            "You may find that it works just fine, or you may not.",
-            `SUPPORTED TYPESCRIPT VERSIONS: ${SUPPORTED_TYPESCRIPT_VERSIONS}`,
-            `YOUR TYPESCRIPT VERSION: ${ACTIVE_TYPESCRIPT_VERSION}`,
-            "Please only submit bug reports when using the officially supported version.",
-            border
-        ];
-        extra.log(versionWarning.join("\n\n"));
-        warnedAboutTSVersion = true;
     }
 
     // Even if jsx option is set in typescript compiler, filename still has to

--- a/parser.js
+++ b/parser.js
@@ -101,8 +101,7 @@ function parse(code, options) {
         if (typeof options.loggerFn === "function") {
             extra.log = options.loggerFn;
         } else if (options.loggerFn === false) {
-            /** */ // eslint-disable-line valid-jsdoc
-            extra.log = () => {};
+            extra.log = Function.prototype;
         }
 
     }

--- a/parser.js
+++ b/parser.js
@@ -17,6 +17,7 @@ const ACTIVE_TYPESCRIPT_VERSION = ts.version;
 const isRunningSupportedTypeScriptVersion = semver.satisfies(ACTIVE_TYPESCRIPT_VERSION, SUPPORTED_TYPESCRIPT_VERSIONS);
 
 let extra;
+let warnedAboutTSVersion = false;
 
 /**
  * Resets the extra config object
@@ -103,7 +104,7 @@ function parse(code, options) {
 
     }
 
-    if (!isRunningSupportedTypeScriptVersion) {
+    if (!isRunningSupportedTypeScriptVersion && !warnedAboutTSVersion) {
         const border = "=============";
         const versionWarning = [
             border,
@@ -115,6 +116,7 @@ function parse(code, options) {
             border
         ];
         extra.log(versionWarning.join("\n\n"));
+        warnedAboutTSVersion = true;
     }
 
     // Even if jsx option is set in typescript compiler, filename still has to


### PR DESCRIPTION
It gets annoying when you’re trying to lint a project with lots of files. Fixes #348.