### PR TITLE
Fix: Include newlines at the end of source in AST (fixes #352)

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -331,8 +331,7 @@ module.exports = function convert(config) {
                 }
             });
 
-            // fix end location
-            result.range[1] = node.endOfFileToken.pos;
+            result.range[1] = node.endOfFileToken.end;
             result.loc = nodeUtils.getLocFor(node.getStart(), result.range[1], ast);
             break;
 

--- a/tests/lib/__snapshots__/basics.js.snap
+++ b/tests/lib/__snapshots__/basics.js.snap
@@ -96,8 +96,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 15,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -106,7 +106,7 @@ Object {
   },
   "range": Array [
     0,
-    15,
+    16,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -501,8 +501,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 16,
-      "line": 6,
+      "column": 0,
+      "line": 7,
     },
     "start": Object {
       "column": 0,
@@ -511,7 +511,7 @@ Object {
   },
   "range": Array [
     0,
-    58,
+    59,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -1181,8 +1181,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 9,
+      "column": 0,
+      "line": 10,
     },
     "start": Object {
       "column": 0,
@@ -1191,7 +1191,7 @@ Object {
   },
   "range": Array [
     0,
-    59,
+    60,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -1716,8 +1716,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 14,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -1726,7 +1726,7 @@ Object {
   },
   "range": Array [
     0,
-    14,
+    15,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -2219,8 +2219,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 12,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -2229,7 +2229,7 @@ Object {
   },
   "range": Array [
     0,
-    12,
+    13,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -2978,8 +2978,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 8,
-      "line": 2,
+      "column": 0,
+      "line": 3,
     },
     "start": Object {
       "column": 0,
@@ -2988,7 +2988,7 @@ Object {
   },
   "range": Array [
     0,
-    16,
+    17,
   ],
   "sourceType": "script",
   "tokens": Array [

--- a/tests/lib/__snapshots__/comments.js.snap
+++ b/tests/lib/__snapshots__/comments.js.snap
@@ -98,8 +98,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 4,
+      "column": 0,
+      "line": 5,
     },
     "start": Object {
       "column": 0,
@@ -108,7 +108,7 @@ Object {
   },
   "range": Array [
     0,
-    26,
+    27,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -323,8 +323,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 20,
-      "line": 2,
+      "column": 0,
+      "line": 3,
     },
     "start": Object {
       "column": 0,
@@ -333,7 +333,7 @@ Object {
   },
   "range": Array [
     10,
-    30,
+    31,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -635,8 +635,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 10,
+      "column": 0,
+      "line": 11,
     },
     "start": Object {
       "column": 0,
@@ -645,7 +645,7 @@ Object {
   },
   "range": Array [
     36,
-    121,
+    122,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -1140,8 +1140,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 7,
+      "column": 0,
+      "line": 8,
     },
     "start": Object {
       "column": 0,
@@ -1150,7 +1150,7 @@ Object {
   },
   "range": Array [
     0,
-    97,
+    98,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -1844,8 +1844,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 9,
+      "column": 0,
+      "line": 11,
     },
     "start": Object {
       "column": 0,
@@ -1854,7 +1854,7 @@ Object {
   },
   "range": Array [
     0,
-    127,
+    129,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -2250,7 +2250,7 @@ Object {
   "loc": Object {
     "end": Object {
       "column": 0,
-      "line": 1,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -2259,7 +2259,7 @@ Object {
   },
   "range": Array [
     12,
-    0,
+    12,
   ],
   "sourceType": "script",
   "tokens": Array [],
@@ -2403,8 +2403,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 22,
-      "line": 2,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -2413,7 +2413,7 @@ Object {
   },
   "range": Array [
     6,
-    28,
+    35,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -2597,8 +2597,8 @@ Object {
   "comments": Array [],
   "loc": Object {
     "end": Object {
-      "column": 34,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -2607,7 +2607,7 @@ Object {
   },
   "range": Array [
     0,
-    34,
+    35,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -2855,8 +2855,8 @@ Object {
   "comments": Array [],
   "loc": Object {
     "end": Object {
-      "column": 37,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -2865,7 +2865,7 @@ Object {
   },
   "range": Array [
     0,
-    37,
+    38,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -3155,8 +3155,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 5,
+      "column": 0,
+      "line": 6,
     },
     "start": Object {
       "column": 0,
@@ -3165,7 +3165,7 @@ Object {
   },
   "range": Array [
     0,
-    60,
+    61,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -3473,8 +3473,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 5,
+      "column": 0,
+      "line": 6,
     },
     "start": Object {
       "column": 0,
@@ -3483,7 +3483,7 @@ Object {
   },
   "range": Array [
     0,
-    63,
+    64,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -3756,8 +3756,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 5,
+      "column": 0,
+      "line": 6,
     },
     "start": Object {
       "column": 0,
@@ -3766,7 +3766,7 @@ Object {
   },
   "range": Array [
     0,
-    61,
+    62,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -4057,8 +4057,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 5,
+      "column": 0,
+      "line": 6,
     },
     "start": Object {
       "column": 0,
@@ -4067,7 +4067,7 @@ Object {
   },
   "range": Array [
     0,
-    63,
+    64,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -4450,8 +4450,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 68,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -4460,7 +4460,7 @@ Object {
   },
   "range": Array [
     0,
-    68,
+    69,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -4948,8 +4948,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 7,
+      "column": 0,
+      "line": 8,
     },
     "start": Object {
       "column": 0,
@@ -4958,7 +4958,7 @@ Object {
   },
   "range": Array [
     0,
-    91,
+    92,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -5541,8 +5541,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 9,
+      "column": 0,
+      "line": 10,
     },
     "start": Object {
       "column": 0,
@@ -5551,7 +5551,7 @@ Object {
   },
   "range": Array [
     0,
-    141,
+    142,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -6093,8 +6093,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 5,
+      "column": 0,
+      "line": 6,
     },
     "start": Object {
       "column": 0,
@@ -6103,7 +6103,7 @@ Object {
   },
   "range": Array [
     0,
-    58,
+    59,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -6562,8 +6562,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 9,
+      "column": 0,
+      "line": 10,
     },
     "start": Object {
       "column": 0,
@@ -6572,7 +6572,7 @@ Object {
   },
   "range": Array [
     0,
-    133,
+    134,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -7647,8 +7647,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 2,
-      "line": 12,
+      "column": 0,
+      "line": 13,
     },
     "start": Object {
       "column": 0,
@@ -7657,7 +7657,7 @@ Object {
   },
   "range": Array [
     0,
-    287,
+    288,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -8766,8 +8766,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 5,
+      "column": 0,
+      "line": 6,
     },
     "start": Object {
       "column": 0,
@@ -8776,7 +8776,7 @@ Object {
   },
   "range": Array [
     0,
-    64,
+    65,
   ],
   "sourceType": "script",
   "tokens": Array [

--- a/tests/lib/__snapshots__/ecma-features.js.snap
+++ b/tests/lib/__snapshots__/ecma-features.js.snap
@@ -84,8 +84,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 41,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -94,7 +94,7 @@ Object {
   },
   "range": Array [
     0,
-    41,
+    42,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -281,8 +281,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 17,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -291,7 +291,7 @@ Object {
   },
   "range": Array [
     0,
-    17,
+    18,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -478,8 +478,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 17,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -488,7 +488,7 @@ Object {
   },
   "range": Array [
     0,
-    17,
+    18,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -675,8 +675,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 41,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -685,7 +685,7 @@ Object {
   },
   "range": Array [
     0,
-    41,
+    42,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -872,8 +872,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 17,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -882,7 +882,7 @@ Object {
   },
   "range": Array [
     0,
-    17,
+    18,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -1069,8 +1069,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 17,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -1079,7 +1079,7 @@ Object {
   },
   "range": Array [
     0,
-    17,
+    18,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -2466,8 +2466,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 18,
-      "line": 4,
+      "column": 0,
+      "line": 6,
     },
     "start": Object {
       "column": 0,
@@ -2476,7 +2476,7 @@ Object {
   },
   "range": Array [
     0,
-    71,
+    73,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -7382,8 +7382,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 6,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -7392,7 +7392,7 @@ Object {
   },
   "range": Array [
     0,
-    6,
+    7,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -7479,8 +7479,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 6,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -7489,7 +7489,7 @@ Object {
   },
   "range": Array [
     0,
-    6,
+    7,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -7613,8 +7613,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 16,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -7623,7 +7623,7 @@ Object {
   },
   "range": Array [
     0,
-    16,
+    17,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -7801,8 +7801,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 14,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -7811,7 +7811,7 @@ Object {
   },
   "range": Array [
     0,
-    14,
+    15,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -8083,8 +8083,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 47,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -8093,7 +8093,7 @@ Object {
   },
   "range": Array [
     0,
-    47,
+    48,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -10510,8 +10510,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 25,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -10520,7 +10520,7 @@ Object {
   },
   "range": Array [
     0,
-    25,
+    26,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -11263,8 +11263,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 2,
-      "line": 5,
+      "column": 0,
+      "line": 6,
     },
     "start": Object {
       "column": 0,
@@ -11273,7 +11273,7 @@ Object {
   },
   "range": Array [
     0,
-    44,
+    45,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -18113,8 +18113,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 33,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -18123,7 +18123,7 @@ Object {
   },
   "range": Array [
     0,
-    33,
+    34,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -18507,8 +18507,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 27,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -18517,7 +18517,7 @@ Object {
   },
   "range": Array [
     0,
-    27,
+    28,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -20807,8 +20807,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 4,
+      "column": 0,
+      "line": 5,
     },
     "start": Object {
       "column": 0,
@@ -20817,7 +20817,7 @@ Object {
   },
   "range": Array [
     0,
-    46,
+    47,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -21241,8 +21241,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 4,
+      "column": 0,
+      "line": 5,
     },
     "start": Object {
       "column": 0,
@@ -21251,7 +21251,7 @@ Object {
   },
   "range": Array [
     0,
-    38,
+    39,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -24253,8 +24253,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 4,
+      "column": 0,
+      "line": 5,
     },
     "start": Object {
       "column": 0,
@@ -24263,7 +24263,7 @@ Object {
   },
   "range": Array [
     0,
-    47,
+    48,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -24796,8 +24796,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 4,
+      "column": 0,
+      "line": 5,
     },
     "start": Object {
       "column": 0,
@@ -24806,7 +24806,7 @@ Object {
   },
   "range": Array [
     0,
-    51,
+    52,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -25489,8 +25489,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 4,
+      "column": 0,
+      "line": 5,
     },
     "start": Object {
       "column": 0,
@@ -25499,7 +25499,7 @@ Object {
   },
   "range": Array [
     0,
-    51,
+    52,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -26110,8 +26110,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 4,
+      "column": 0,
+      "line": 5,
     },
     "start": Object {
       "column": 0,
@@ -26120,7 +26120,7 @@ Object {
   },
   "range": Array [
     0,
-    47,
+    48,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -26581,8 +26581,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 4,
+      "column": 0,
+      "line": 5,
     },
     "start": Object {
       "column": 0,
@@ -26591,7 +26591,7 @@ Object {
   },
   "range": Array [
     0,
-    39,
+    40,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -27124,8 +27124,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 4,
+      "column": 0,
+      "line": 5,
     },
     "start": Object {
       "column": 0,
@@ -27134,7 +27134,7 @@ Object {
   },
   "range": Array [
     0,
-    43,
+    44,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -27817,8 +27817,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 4,
+      "column": 0,
+      "line": 5,
     },
     "start": Object {
       "column": 0,
@@ -27827,7 +27827,7 @@ Object {
   },
   "range": Array [
     0,
-    43,
+    44,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -28438,8 +28438,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 4,
+      "column": 0,
+      "line": 5,
     },
     "start": Object {
       "column": 0,
@@ -28448,7 +28448,7 @@ Object {
   },
   "range": Array [
     0,
-    39,
+    40,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -43774,8 +43774,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 23,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -43784,7 +43784,7 @@ Object {
   },
   "range": Array [
     0,
-    23,
+    24,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -53435,8 +53435,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 17,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -53445,7 +53445,7 @@ Object {
   },
   "range": Array [
     0,
-    17,
+    18,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -54283,8 +54283,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 19,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -54293,7 +54293,7 @@ Object {
   },
   "range": Array [
     0,
-    19,
+    20,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -57254,8 +57254,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -57264,7 +57264,7 @@ Object {
   },
   "range": Array [
     0,
-    26,
+    27,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -57591,8 +57591,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 5,
+      "column": 0,
+      "line": 6,
     },
     "start": Object {
       "column": 0,
@@ -57601,7 +57601,7 @@ Object {
   },
   "range": Array [
     0,
-    69,
+    70,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -58067,8 +58067,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 25,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -58077,7 +58077,7 @@ Object {
   },
   "range": Array [
     0,
-    25,
+    26,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -58443,8 +58443,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 24,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -58453,7 +58453,7 @@ Object {
   },
   "range": Array [
     0,
-    24,
+    25,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -58941,8 +58941,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 23,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -58951,7 +58951,7 @@ Object {
   },
   "range": Array [
     0,
-    23,
+    24,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -59350,8 +59350,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 26,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -59360,7 +59360,7 @@ Object {
   },
   "range": Array [
     0,
-    26,
+    27,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -60013,8 +60013,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 48,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -60023,7 +60023,7 @@ Object {
   },
   "range": Array [
     0,
-    48,
+    49,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -60929,8 +60929,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 2,
-      "line": 9,
+      "column": 0,
+      "line": 10,
     },
     "start": Object {
       "column": 0,
@@ -60939,7 +60939,7 @@ Object {
   },
   "range": Array [
     0,
-    83,
+    84,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -61690,8 +61690,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 3,
-      "line": 5,
+      "column": 0,
+      "line": 6,
     },
     "start": Object {
       "column": 0,
@@ -61700,7 +61700,7 @@ Object {
   },
   "range": Array [
     0,
-    108,
+    109,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -63081,8 +63081,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 2,
-      "line": 9,
+      "column": 0,
+      "line": 10,
     },
     "start": Object {
       "column": 0,
@@ -63091,7 +63091,7 @@ Object {
   },
   "range": Array [
     0,
-    69,
+    70,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -63799,8 +63799,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 2,
-      "line": 9,
+      "column": 0,
+      "line": 10,
     },
     "start": Object {
       "column": 0,
@@ -63809,7 +63809,7 @@ Object {
   },
   "range": Array [
     0,
-    79,
+    80,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -64423,8 +64423,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 17,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -64433,7 +64433,7 @@ Object {
   },
   "range": Array [
     0,
-    17,
+    18,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -64975,8 +64975,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 2,
-      "line": 9,
+      "column": 0,
+      "line": 10,
     },
     "start": Object {
       "column": 0,
@@ -64985,7 +64985,7 @@ Object {
   },
   "range": Array [
     0,
-    77,
+    78,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -65579,8 +65579,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 8,
-      "line": 2,
+      "column": 0,
+      "line": 3,
     },
     "start": Object {
       "column": 0,
@@ -65589,7 +65589,7 @@ Object {
   },
   "range": Array [
     0,
-    24,
+    25,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -66077,8 +66077,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 64,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -66087,7 +66087,7 @@ Object {
   },
   "range": Array [
     0,
-    64,
+    65,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -66679,8 +66679,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -66689,7 +66689,7 @@ Object {
   },
   "range": Array [
     0,
-    41,
+    42,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -67082,8 +67082,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 18,
-      "line": 2,
+      "column": 0,
+      "line": 3,
     },
     "start": Object {
       "column": 0,
@@ -67092,7 +67092,7 @@ Object {
   },
   "range": Array [
     0,
-    37,
+    38,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -67696,8 +67696,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 4,
+      "column": 0,
+      "line": 5,
     },
     "start": Object {
       "column": 0,
@@ -67706,7 +67706,7 @@ Object {
   },
   "range": Array [
     1,
-    27,
+    28,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -68112,8 +68112,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 5,
+      "column": 0,
+      "line": 6,
     },
     "start": Object {
       "column": 0,
@@ -68122,7 +68122,7 @@ Object {
   },
   "range": Array [
     0,
-    65,
+    66,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -69908,8 +69908,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 26,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -69918,7 +69918,7 @@ Object {
   },
   "range": Array [
     0,
-    26,
+    27,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -70262,8 +70262,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 30,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -70272,7 +70272,7 @@ Object {
   },
   "range": Array [
     0,
-    30,
+    31,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -70633,8 +70633,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 25,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -70643,7 +70643,7 @@ Object {
   },
   "range": Array [
     0,
-    25,
+    26,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -70873,8 +70873,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 18,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -70883,7 +70883,7 @@ Object {
   },
   "range": Array [
     0,
-    18,
+    19,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -71044,8 +71044,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -71054,7 +71054,7 @@ Object {
   },
   "range": Array [
     0,
-    25,
+    26,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -71232,8 +71232,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 23,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -71242,7 +71242,7 @@ Object {
   },
   "range": Array [
     0,
-    23,
+    24,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -71458,8 +71458,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 29,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -71468,7 +71468,7 @@ Object {
   },
   "range": Array [
     0,
-    29,
+    30,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -71682,8 +71682,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -71692,7 +71692,7 @@ Object {
   },
   "range": Array [
     0,
-    30,
+    31,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -71889,8 +71889,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 32,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -71899,7 +71899,7 @@ Object {
   },
   "range": Array [
     0,
-    32,
+    33,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -72094,8 +72094,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 18,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -72104,7 +72104,7 @@ Object {
   },
   "range": Array [
     0,
-    18,
+    19,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -72285,8 +72285,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 26,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -72295,7 +72295,7 @@ Object {
   },
   "range": Array [
     0,
-    26,
+    27,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -72489,8 +72489,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 19,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -72499,7 +72499,7 @@ Object {
   },
   "range": Array [
     0,
-    19,
+    20,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -72622,8 +72622,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 20,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -72632,7 +72632,7 @@ Object {
   },
   "range": Array [
     0,
-    20,
+    21,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -72829,8 +72829,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 28,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -72839,7 +72839,7 @@ Object {
   },
   "range": Array [
     0,
-    28,
+    29,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -73072,8 +73072,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 35,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -73082,7 +73082,7 @@ Object {
   },
   "range": Array [
     0,
-    35,
+    36,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -73351,8 +73351,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 31,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -73361,7 +73361,7 @@ Object {
   },
   "range": Array [
     0,
-    31,
+    32,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -73683,8 +73683,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 40,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -73693,7 +73693,7 @@ Object {
   },
   "range": Array [
     0,
-    40,
+    41,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -73998,8 +73998,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 24,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -74008,7 +74008,7 @@ Object {
   },
   "range": Array [
     0,
-    24,
+    25,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -74294,8 +74294,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 29,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -74304,7 +74304,7 @@ Object {
   },
   "range": Array [
     0,
-    29,
+    30,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -74557,8 +74557,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 25,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -74567,7 +74567,7 @@ Object {
   },
   "range": Array [
     0,
-    25,
+    26,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -74782,8 +74782,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 24,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -74792,7 +74792,7 @@ Object {
   },
   "range": Array [
     0,
-    24,
+    25,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -75007,8 +75007,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 20,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -75017,7 +75017,7 @@ Object {
   },
   "range": Array [
     0,
-    20,
+    21,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -75285,8 +75285,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 29,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -75295,7 +75295,7 @@ Object {
   },
   "range": Array [
     0,
-    29,
+    30,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -75547,8 +75547,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -75557,7 +75557,7 @@ Object {
   },
   "range": Array [
     0,
-    22,
+    23,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -75682,8 +75682,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 10,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -75692,7 +75692,7 @@ Object {
   },
   "range": Array [
     0,
-    10,
+    11,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -75853,8 +75853,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 13,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -75863,7 +75863,7 @@ Object {
   },
   "range": Array [
     0,
-    13,
+    14,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -76095,8 +76095,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 18,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -76105,7 +76105,7 @@ Object {
   },
   "range": Array [
     0,
-    18,
+    19,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -76373,8 +76373,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 19,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -76383,7 +76383,7 @@ Object {
   },
   "range": Array [
     0,
-    19,
+    20,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -76617,8 +76617,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 15,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -76627,7 +76627,7 @@ Object {
   },
   "range": Array [
     0,
-    15,
+    16,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -76828,8 +76828,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 32,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -76838,7 +76838,7 @@ Object {
   },
   "range": Array [
     0,
-    32,
+    33,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -77126,8 +77126,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 19,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -77136,7 +77136,7 @@ Object {
   },
   "range": Array [
     0,
-    19,
+    20,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -77332,8 +77332,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 22,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -77342,7 +77342,7 @@ Object {
   },
   "range": Array [
     0,
-    22,
+    23,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -77573,8 +77573,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 29,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -77583,7 +77583,7 @@ Object {
   },
   "range": Array [
     0,
-    29,
+    30,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -77868,8 +77868,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 32,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -77878,7 +77878,7 @@ Object {
   },
   "range": Array [
     0,
-    32,
+    33,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -78146,8 +78146,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 35,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -78156,7 +78156,7 @@ Object {
   },
   "range": Array [
     0,
-    35,
+    36,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -78406,8 +78406,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 22,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -78416,7 +78416,7 @@ Object {
   },
   "range": Array [
     0,
-    22,
+    23,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -78540,8 +78540,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 13,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -78550,7 +78550,7 @@ Object {
   },
   "range": Array [
     0,
-    13,
+    14,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -78710,8 +78710,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 31,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -78720,7 +78720,7 @@ Object {
   },
   "range": Array [
     0,
-    31,
+    32,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -79041,8 +79041,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 36,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -79051,7 +79051,7 @@ Object {
   },
   "range": Array [
     0,
-    36,
+    37,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -79301,8 +79301,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 21,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -79311,7 +79311,7 @@ Object {
   },
   "range": Array [
     0,
-    21,
+    22,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -79525,8 +79525,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 24,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -79535,7 +79535,7 @@ Object {
   },
   "range": Array [
     0,
-    24,
+    25,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -79820,8 +79820,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 29,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -79830,7 +79830,7 @@ Object {
   },
   "range": Array [
     0,
-    29,
+    30,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -80151,8 +80151,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 30,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -80161,7 +80161,7 @@ Object {
   },
   "range": Array [
     0,
-    30,
+    31,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -80429,8 +80429,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 27,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -80439,7 +80439,7 @@ Object {
   },
   "range": Array [
     0,
-    27,
+    28,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -80671,8 +80671,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 33,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -80681,7 +80681,7 @@ Object {
   },
   "range": Array [
     0,
-    33,
+    34,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -81006,8 +81006,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -81016,7 +81016,7 @@ Object {
   },
   "range": Array [
     0,
-    40,
+    41,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -81434,8 +81434,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 2,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -81444,7 +81444,7 @@ Object {
   },
   "range": Array [
     0,
-    29,
+    30,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -82906,8 +82906,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 2,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -82916,7 +82916,7 @@ Object {
   },
   "range": Array [
     0,
-    29,
+    30,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -83260,8 +83260,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 2,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -83270,7 +83270,7 @@ Object {
   },
   "range": Array [
     0,
-    27,
+    28,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -83577,8 +83577,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 12,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -83587,7 +83587,7 @@ Object {
   },
   "range": Array [
     0,
-    12,
+    13,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -83914,8 +83914,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 20,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -83924,7 +83924,7 @@ Object {
   },
   "range": Array [
     0,
-    20,
+    21,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -84270,8 +84270,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 23,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -84280,7 +84280,7 @@ Object {
   },
   "range": Array [
     0,
-    23,
+    24,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -85780,8 +85780,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 2,
-      "line": 5,
+      "column": 0,
+      "line": 6,
     },
     "start": Object {
       "column": 0,
@@ -85790,7 +85790,7 @@ Object {
   },
   "range": Array [
     0,
-    50,
+    51,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -88240,8 +88240,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 2,
-      "line": 5,
+      "column": 0,
+      "line": 6,
     },
     "start": Object {
       "column": 0,
@@ -88250,7 +88250,7 @@ Object {
   },
   "range": Array [
     0,
-    52,
+    53,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -88890,8 +88890,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 2,
-      "line": 9,
+      "column": 0,
+      "line": 10,
     },
     "start": Object {
       "column": 0,
@@ -88900,7 +88900,7 @@ Object {
   },
   "range": Array [
     0,
-    66,
+    67,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -89277,8 +89277,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 6,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -89287,7 +89287,7 @@ Object {
   },
   "range": Array [
     0,
-    6,
+    7,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -89410,8 +89410,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 6,
-      "line": 2,
+      "column": 0,
+      "line": 3,
     },
     "start": Object {
       "column": 0,
@@ -89420,7 +89420,7 @@ Object {
   },
   "range": Array [
     0,
-    20,
+    21,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -89543,8 +89543,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 6,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -89553,7 +89553,7 @@ Object {
   },
   "range": Array [
     0,
-    6,
+    7,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -89682,8 +89682,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 17,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -89692,7 +89692,7 @@ Object {
   },
   "range": Array [
     0,
-    17,
+    18,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -90325,8 +90325,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 4,
+      "column": 0,
+      "line": 5,
     },
     "start": Object {
       "column": 0,
@@ -90335,7 +90335,7 @@ Object {
   },
   "range": Array [
     0,
-    43,
+    44,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -90722,8 +90722,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 4,
+      "column": 0,
+      "line": 5,
     },
     "start": Object {
       "column": 0,
@@ -90732,7 +90732,7 @@ Object {
   },
   "range": Array [
     0,
-    35,
+    36,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -93038,8 +93038,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 45,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -93048,7 +93048,7 @@ Object {
   },
   "range": Array [
     0,
-    45,
+    46,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -94692,8 +94692,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 9,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -94702,7 +94702,7 @@ Object {
   },
   "range": Array [
     0,
-    9,
+    10,
   ],
   "sourceType": "script",
   "tokens": Array [

--- a/tests/lib/__snapshots__/jsx.js.snap
+++ b/tests/lib/__snapshots__/jsx.js.snap
@@ -1038,8 +1038,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 6,
-      "line": 5,
+      "column": 0,
+      "line": 6,
     },
     "start": Object {
       "column": 0,
@@ -1048,7 +1048,7 @@ Object {
   },
   "range": Array [
     0,
-    59,
+    60,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -5070,8 +5070,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 11,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -5080,7 +5080,7 @@ Object {
   },
   "range": Array [
     0,
-    11,
+    12,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -5544,8 +5544,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 19,
-      "line": 2,
+      "column": 0,
+      "line": 3,
     },
     "start": Object {
       "column": 0,
@@ -5554,7 +5554,7 @@ Object {
   },
   "range": Array [
     0,
-    45,
+    46,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -6567,8 +6567,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 6,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -6577,7 +6577,7 @@ Object {
   },
   "range": Array [
     0,
-    24,
+    25,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -9925,8 +9925,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 6,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -9935,7 +9935,7 @@ Object {
   },
   "range": Array [
     0,
-    24,
+    25,
   ],
   "sourceType": "script",
   "tokens": Array [

--- a/tests/lib/__snapshots__/typescript.js.snap
+++ b/tests/lib/__snapshots__/typescript.js.snap
@@ -1471,8 +1471,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 4,
+      "column": 0,
+      "line": 5,
     },
     "start": Object {
       "column": 0,
@@ -1481,7 +1481,7 @@ Object {
   },
   "range": Array [
     0,
-    62,
+    63,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -1847,8 +1847,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -1857,7 +1857,7 @@ Object {
   },
   "range": Array [
     0,
-    65,
+    66,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -4034,8 +4034,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 5,
+      "column": 0,
+      "line": 6,
     },
     "start": Object {
       "column": 0,
@@ -4044,7 +4044,7 @@ Object {
   },
   "range": Array [
     0,
-    96,
+    97,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -5054,8 +5054,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 10,
+      "column": 0,
+      "line": 11,
     },
     "start": Object {
       "column": 0,
@@ -5064,7 +5064,7 @@ Object {
   },
   "range": Array [
     0,
-    173,
+    174,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -6028,8 +6028,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 5,
+      "column": 0,
+      "line": 7,
     },
     "start": Object {
       "column": 0,
@@ -6038,7 +6038,7 @@ Object {
   },
   "range": Array [
     0,
-    56,
+    58,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -6453,8 +6453,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -6463,7 +6463,7 @@ Object {
   },
   "range": Array [
     0,
-    32,
+    33,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -6930,8 +6930,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -6940,7 +6940,7 @@ Object {
   },
   "range": Array [
     0,
-    45,
+    46,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -7418,8 +7418,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -7428,7 +7428,7 @@ Object {
   },
   "range": Array [
     0,
-    30,
+    31,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -7869,8 +7869,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -7879,7 +7879,7 @@ Object {
   },
   "range": Array [
     0,
-    36,
+    37,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -8238,8 +8238,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -8248,7 +8248,7 @@ Object {
   },
   "range": Array [
     0,
-    29,
+    30,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -8518,8 +8518,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -8528,7 +8528,7 @@ Object {
   },
   "range": Array [
     0,
-    32,
+    33,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -8888,8 +8888,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -8898,7 +8898,7 @@ Object {
   },
   "range": Array [
     0,
-    35,
+    36,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -10002,8 +10002,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 48,
-      "line": 9,
+      "column": 0,
+      "line": 10,
     },
     "start": Object {
       "column": 0,
@@ -10012,7 +10012,7 @@ Object {
   },
   "range": Array [
     0,
-    206,
+    207,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -11297,8 +11297,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -11307,7 +11307,7 @@ Object {
   },
   "range": Array [
     0,
-    45,
+    46,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -11855,8 +11855,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 5,
+      "column": 0,
+      "line": 6,
     },
     "start": Object {
       "column": 0,
@@ -11865,7 +11865,7 @@ Object {
   },
   "range": Array [
     0,
-    67,
+    68,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -12564,8 +12564,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 5,
+      "column": 0,
+      "line": 6,
     },
     "start": Object {
       "column": 0,
@@ -12574,7 +12574,7 @@ Object {
   },
   "range": Array [
     0,
-    63,
+    64,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -13030,8 +13030,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 5,
     },
     "start": Object {
       "column": 0,
@@ -13040,7 +13040,7 @@ Object {
   },
   "range": Array [
     0,
-    39,
+    41,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -17484,8 +17484,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -17494,7 +17494,7 @@ Object {
   },
   "range": Array [
     0,
-    49,
+    50,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -17900,8 +17900,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 5,
+      "column": 0,
+      "line": 8,
     },
     "start": Object {
       "column": 0,
@@ -17910,7 +17910,7 @@ Object {
   },
   "range": Array [
     0,
-    56,
+    59,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -18253,8 +18253,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -18263,7 +18263,7 @@ Object {
   },
   "range": Array [
     0,
-    17,
+    18,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -18533,8 +18533,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -18543,7 +18543,7 @@ Object {
   },
   "range": Array [
     0,
-    23,
+    24,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -18814,8 +18814,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 15,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -18824,7 +18824,7 @@ Object {
   },
   "range": Array [
     0,
-    15,
+    16,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -20133,8 +20133,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 13,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -20143,7 +20143,7 @@ Object {
   },
   "range": Array [
     0,
-    13,
+    14,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -20324,8 +20324,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -20334,7 +20334,7 @@ Object {
   },
   "range": Array [
     0,
-    28,
+    29,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -20606,8 +20606,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -20616,7 +20616,7 @@ Object {
   },
   "range": Array [
     0,
-    31,
+    32,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -20924,8 +20924,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -20934,7 +20934,7 @@ Object {
   },
   "range": Array [
     0,
-    24,
+    25,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -21225,8 +21225,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -21235,7 +21235,7 @@ Object {
   },
   "range": Array [
     0,
-    27,
+    28,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -22650,8 +22650,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -22660,7 +22660,7 @@ Object {
   },
   "range": Array [
     0,
-    49,
+    50,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -23219,8 +23219,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -23229,7 +23229,7 @@ Object {
   },
   "range": Array [
     0,
-    51,
+    52,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -23968,8 +23968,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -23978,7 +23978,7 @@ Object {
   },
   "range": Array [
     0,
-    49,
+    50,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -24589,8 +24589,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -24599,7 +24599,7 @@ Object {
   },
   "range": Array [
     0,
-    40,
+    41,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -25473,8 +25473,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -25483,7 +25483,7 @@ Object {
   },
   "range": Array [
     0,
-    51,
+    52,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -26038,8 +26038,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -26048,7 +26048,7 @@ Object {
   },
   "range": Array [
     0,
-    57,
+    58,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -26724,8 +26724,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -26734,7 +26734,7 @@ Object {
   },
   "range": Array [
     0,
-    96,
+    97,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -27344,8 +27344,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -27354,7 +27354,7 @@ Object {
   },
   "range": Array [
     0,
-    30,
+    31,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -27603,8 +27603,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -27613,7 +27613,7 @@ Object {
   },
   "range": Array [
     0,
-    34,
+    35,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -27865,8 +27865,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -27875,7 +27875,7 @@ Object {
   },
   "range": Array [
     0,
-    21,
+    22,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -29316,8 +29316,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 14,
+      "column": 0,
+      "line": 16,
     },
     "start": Object {
       "column": 0,
@@ -29326,7 +29326,7 @@ Object {
   },
   "range": Array [
     0,
-    295,
+    297,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -31511,8 +31511,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -31521,7 +31521,7 @@ Object {
   },
   "range": Array [
     0,
-    49,
+    50,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -31954,8 +31954,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -31964,7 +31964,7 @@ Object {
   },
   "range": Array [
     0,
-    36,
+    37,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -32288,8 +32288,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 2,
+      "column": 0,
+      "line": 3,
     },
     "start": Object {
       "column": 0,
@@ -32298,7 +32298,7 @@ Object {
   },
   "range": Array [
     0,
-    21,
+    22,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -32557,8 +32557,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 7,
+      "column": 0,
+      "line": 8,
     },
     "start": Object {
       "column": 0,
@@ -32567,7 +32567,7 @@ Object {
   },
   "range": Array [
     0,
-    87,
+    88,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -33053,8 +33053,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 5,
+      "column": 0,
+      "line": 6,
     },
     "start": Object {
       "column": 0,
@@ -33063,7 +33063,7 @@ Object {
   },
   "range": Array [
     0,
-    81,
+    82,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -33645,8 +33645,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -33655,7 +33655,7 @@ Object {
   },
   "range": Array [
     0,
-    27,
+    28,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -35883,8 +35883,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 23,
-      "line": 7,
+      "column": 0,
+      "line": 8,
     },
     "start": Object {
       "column": 0,
@@ -35893,7 +35893,7 @@ Object {
   },
   "range": Array [
     0,
-    81,
+    82,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -37758,8 +37758,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 30,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -37768,7 +37768,7 @@ Object {
   },
   "range": Array [
     0,
-    30,
+    31,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -38951,8 +38951,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 49,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -38961,7 +38961,7 @@ Object {
   },
   "range": Array [
     0,
-    137,
+    138,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -39806,8 +39806,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -39816,7 +39816,7 @@ Object {
   },
   "range": Array [
     0,
-    89,
+    90,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -40423,8 +40423,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 15,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -40433,7 +40433,7 @@ Object {
   },
   "range": Array [
     0,
-    15,
+    16,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -40826,8 +40826,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 24,
-      "line": 2,
+      "column": 0,
+      "line": 3,
     },
     "start": Object {
       "column": 0,
@@ -40836,7 +40836,7 @@ Object {
   },
   "range": Array [
     0,
-    54,
+    55,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -44951,8 +44951,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 4,
+      "column": 0,
+      "line": 5,
     },
     "start": Object {
       "column": 0,
@@ -44961,7 +44961,7 @@ Object {
   },
   "range": Array [
     0,
-    56,
+    57,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -45439,8 +45439,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 4,
+      "column": 0,
+      "line": 5,
     },
     "start": Object {
       "column": 0,
@@ -45449,7 +45449,7 @@ Object {
   },
   "range": Array [
     0,
-    56,
+    57,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -45907,8 +45907,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 4,
+      "column": 0,
+      "line": 5,
     },
     "start": Object {
       "column": 0,
@@ -45917,7 +45917,7 @@ Object {
   },
   "range": Array [
     0,
-    49,
+    50,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -46303,8 +46303,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 4,
+      "column": 0,
+      "line": 5,
     },
     "start": Object {
       "column": 0,
@@ -46313,7 +46313,7 @@ Object {
   },
   "range": Array [
     0,
-    49,
+    50,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -46968,8 +46968,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 5,
+      "column": 0,
+      "line": 6,
     },
     "start": Object {
       "column": 0,
@@ -46978,7 +46978,7 @@ Object {
   },
   "range": Array [
     0,
-    115,
+    116,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -47708,8 +47708,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -47718,7 +47718,7 @@ Object {
   },
   "range": Array [
     0,
-    52,
+    53,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -48304,8 +48304,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -48314,7 +48314,7 @@ Object {
   },
   "range": Array [
     0,
-    65,
+    66,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -48990,8 +48990,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 5,
+      "column": 0,
+      "line": 6,
     },
     "start": Object {
       "column": 0,
@@ -49000,7 +49000,7 @@ Object {
   },
   "range": Array [
     0,
-    97,
+    98,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -49730,8 +49730,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 5,
+      "column": 0,
+      "line": 6,
     },
     "start": Object {
       "column": 0,
@@ -49740,7 +49740,7 @@ Object {
   },
   "range": Array [
     0,
-    110,
+    111,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -52179,8 +52179,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 5,
+      "column": 0,
+      "line": 6,
     },
     "start": Object {
       "column": 0,
@@ -52189,7 +52189,7 @@ Object {
   },
   "range": Array [
     0,
-    53,
+    54,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -52512,8 +52512,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -52522,7 +52522,7 @@ Object {
   },
   "range": Array [
     0,
-    22,
+    23,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -52683,8 +52683,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -52693,7 +52693,7 @@ Object {
   },
   "range": Array [
     0,
-    37,
+    38,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -52907,8 +52907,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -52917,7 +52917,7 @@ Object {
   },
   "range": Array [
     0,
-    37,
+    38,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -53319,8 +53319,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -53329,7 +53329,7 @@ Object {
   },
   "range": Array [
     0,
-    26,
+    27,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -55456,8 +55456,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 23,
+      "column": 0,
+      "line": 25,
     },
     "start": Object {
       "column": 0,
@@ -55466,7 +55466,7 @@ Object {
   },
   "range": Array [
     0,
-    594,
+    596,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -59261,8 +59261,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 3,
+      "column": 0,
+      "line": 4,
     },
     "start": Object {
       "column": 0,
@@ -59271,7 +59271,7 @@ Object {
   },
   "range": Array [
     0,
-    56,
+    57,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -60459,8 +60459,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 1,
-      "line": 6,
+      "column": 0,
+      "line": 8,
     },
     "start": Object {
       "column": 0,
@@ -60469,7 +60469,7 @@ Object {
   },
   "range": Array [
     0,
-    112,
+    114,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -61007,8 +61007,8 @@ Object {
   ],
   "loc": Object {
     "end": Object {
-      "column": 32,
-      "line": 1,
+      "column": 0,
+      "line": 2,
     },
     "start": Object {
       "column": 0,
@@ -61017,7 +61017,7 @@ Object {
   },
   "range": Array [
     0,
-    32,
+    33,
   ],
   "sourceType": "script",
   "tokens": Array [


### PR DESCRIPTION
Tiny code change with a huge diff in snapshot data because it will affect any fixtures which have one or more newlines at the end of their source.

I found this when building out AST comparison tests against babylon.