### PR TITLE
Breaking: Only add .implements/.accessibility/.decorators if "truthy"

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -230,6 +230,26 @@ module.exports = function convert(config) {
     }
 
     /**
+     * Converts an array of TSNode parameters into an array of ESTreeNode params
+     * @param  {TSNode[]} parameters An array of TSNode params to be converted
+     * @returns {ESTreeNode[]}       an array of converted ESTreeNode params
+     */
+    function convertParameters(parameters) {
+        if (!parameters || !parameters.length) {
+            return [];
+        }
+        return parameters.map(param => {
+            const convertedParam = convertChild(param);
+            if (!param.decorators || !param.decorators.length) {
+                return convertedParam;
+            }
+            return Object.assign(convertedParam, {
+                decorators: convertDecorators(param.decorators)
+            });
+        });
+    }
+
+    /**
      * For nodes that are copied directly from the TypeScript AST into
      * ESTree mostly as-is. The only difference is the addition of a type
      * property instead of a kind property. Recursively copies all children.
@@ -470,7 +490,7 @@ module.exports = function convert(config) {
 
         case SyntaxKind.ForInStatement:
         case SyntaxKind.ForOfStatement: {
-            const isAwait = node.awaitModifier && node.awaitModifier.kind === SyntaxKind.AwaitKeyword;
+            const isAwait = !!(node.awaitModifier && node.awaitModifier.kind === SyntaxKind.AwaitKeyword);
             Object.assign(result, {
                 type: SyntaxKind[node.kind],
                 left: convertChild(node.initializer),
@@ -507,7 +527,7 @@ module.exports = function convert(config) {
                 generator: !!node.asteriskToken,
                 expression: false,
                 async: nodeUtils.hasModifier(SyntaxKind.AsyncKeyword, node),
-                params: node.parameters.map(convertChild),
+                params: convertParameters(node.parameters),
                 body: convertChild(node.body)
             });
 
@@ -724,11 +744,18 @@ module.exports = function convert(config) {
                 value: convertChild(node.initializer),
                 computed: nodeUtils.isComputedProperty(node.name),
                 static: nodeUtils.hasStaticModifierFlag(node),
-                accessibility: nodeUtils.getTSNodeAccessibility(node),
                 readonly: nodeUtils.hasModifier(SyntaxKind.ReadonlyKeyword, node),
-                decorators: convertDecorators(node.decorators),
                 typeAnnotation: (node.type) ? convertTypeAnnotation(node.type) : null
             });
+
+            if (node.decorators) {
+                result.decorators = convertDecorators(node.decorators);
+            }
+
+            const accessibility = nodeUtils.getTSNodeAccessibility(node);
+            if (accessibility) {
+                result.accessibility = accessibility;
+            }
 
             if (node.name.kind === SyntaxKind.Identifier && node.questionToken) {
                 result.key.optional = true;
@@ -787,11 +814,7 @@ module.exports = function convert(config) {
                 /**
                  * Unlike in object literal methods, class method params can have decorators
                  */
-                method.params = node.parameters.map(param => {
-                    const convertedParam = convertChild(param);
-                    convertedParam.decorators = convertDecorators(param.decorators);
-                    return convertedParam;
-                });
+                method.params = convertParameters(node.parameters);
 
                 /**
                  * TypeScript class methods can be defined as "abstract"
@@ -806,10 +829,17 @@ module.exports = function convert(config) {
                     value: method,
                     computed: nodeUtils.isComputedProperty(node.name),
                     static: nodeUtils.hasStaticModifierFlag(node),
-                    kind: "method",
-                    accessibility: nodeUtils.getTSNodeAccessibility(node),
-                    decorators: convertDecorators(node.decorators)
+                    kind: "method"
                 });
+
+                if (node.decorators) {
+                    result.decorators = convertDecorators(node.decorators);
+                }
+
+                const accessibility = nodeUtils.getTSNodeAccessibility(node);
+                if (accessibility) {
+                    result.accessibility = accessibility;
+                }
 
             }
 
@@ -844,13 +874,7 @@ module.exports = function convert(config) {
                 constructor = {
                     type: AST_NODE_TYPES.FunctionExpression,
                     id: null,
-                    params: node.parameters.map(param => {
-                        const convertedParam = convertChild(param);
-                        const decorators = convertDecorators(param.decorators);
-                        return Object.assign(convertedParam, {
-                            decorators
-                        });
-                    }),
+                    params: convertParameters(node.parameters),
                     generator: false,
                     expression: false,
                     async: false,
@@ -910,10 +934,15 @@ module.exports = function convert(config) {
                 key: constructorKey,
                 value: constructor,
                 computed: constructorIsComputed,
-                accessibility: nodeUtils.getTSNodeAccessibility(node),
                 static: constructorIsStatic,
                 kind: (constructorIsStatic || constructorIsComputed) ? "method" : "constructor"
             });
+
+            const accessibility = nodeUtils.getTSNodeAccessibility(node);
+            if (accessibility) {
+                result.accessibility = accessibility;
+            }
+
             break;
 
         }
@@ -923,7 +952,7 @@ module.exports = function convert(config) {
                 type: AST_NODE_TYPES.FunctionExpression,
                 id: convertChild(node.name),
                 generator: !!node.asteriskToken,
-                params: node.parameters.map(convertChild),
+                params: convertParameters(node.parameters),
                 body: convertChild(node.body),
                 async: nodeUtils.hasModifier(SyntaxKind.AsyncKeyword, node),
                 expression: false
@@ -1022,7 +1051,7 @@ module.exports = function convert(config) {
                 type: AST_NODE_TYPES.ArrowFunctionExpression,
                 generator: false,
                 id: null,
-                params: node.parameters.map(convertChild),
+                params: convertParameters(node.parameters),
                 body: convertChild(node.body),
                 async: nodeUtils.hasModifier(SyntaxKind.AsyncKeyword, node),
                 expression: node.body.kind !== SyntaxKind.Block
@@ -1271,10 +1300,16 @@ module.exports = function convert(config) {
                     range: [openBrace.getStart(), result.range[1]],
                     loc: nodeUtils.getLocFor(openBrace.getStart(), node.end, ast)
                 },
-                superClass: (superClass ? convertChild(superClass.types[0].expression) : null),
-                implements: hasImplements ? heritageClauses[0].types.map(convertClassImplements) : [],
-                decorators: convertDecorators(node.decorators)
+                superClass: (superClass ? convertChild(superClass.types[0].expression) : null)
             });
+
+            if (hasImplements) {
+                result.implements = heritageClauses[0].types.map(convertClassImplements);
+            }
+
+            if (node.decorators) {
+                result.decorators = convertDecorators(node.decorators);
+            }
 
             const filteredMembers = node.members.filter(nodeUtils.isESTreeClassMember);
 
@@ -1836,13 +1871,17 @@ module.exports = function convert(config) {
                 optional: nodeUtils.isOptional(node),
                 computed: nodeUtils.isComputedProperty(node.name),
                 key: convertChild(node.name),
-                params: node.parameters.map(parameter => convertChild(parameter)),
+                params: convertParameters(node.parameters),
                 typeAnnotation: (node.type) ? convertTypeAnnotation(node.type) : null,
-                accessibility: nodeUtils.getTSNodeAccessibility(node),
                 readonly: nodeUtils.hasModifier(SyntaxKind.ReadonlyKeyword, node),
                 static: nodeUtils.hasModifier(SyntaxKind.StaticKeyword, node),
                 export: nodeUtils.hasModifier(SyntaxKind.ExportKeyword, node)
             });
+
+            const accessibility = nodeUtils.getTSNodeAccessibility(node);
+            if (accessibility) {
+                result.accessibility = accessibility;
+            }
 
             if (node.typeParameters) {
                 result.typeParameters = convertTSTypeParametersToTypeParametersDeclaration(node.typeParameters);
@@ -1859,11 +1898,15 @@ module.exports = function convert(config) {
                 key: convertChild(node.name),
                 typeAnnotation: (node.type) ? convertTypeAnnotation(node.type) : null,
                 initializer: convertChild(node.initializer),
-                accessibility: nodeUtils.getTSNodeAccessibility(node),
                 readonly: nodeUtils.hasModifier(SyntaxKind.ReadonlyKeyword, node),
                 static: nodeUtils.hasModifier(SyntaxKind.StaticKeyword, node),
                 export: nodeUtils.hasModifier(SyntaxKind.ExportKeyword, node)
             });
+
+            const accessibility = nodeUtils.getTSNodeAccessibility(node);
+            if (accessibility) {
+                result.accessibility = accessibility;
+            }
 
             break;
         }
@@ -1873,11 +1916,15 @@ module.exports = function convert(config) {
                 type: AST_NODE_TYPES.TSIndexSignature,
                 index: convertChild(node.parameters[0]),
                 typeAnnotation: (node.type) ? convertTypeAnnotation(node.type) : null,
-                accessibility: nodeUtils.getTSNodeAccessibility(node),
                 readonly: nodeUtils.hasModifier(SyntaxKind.ReadonlyKeyword, node),
                 static: nodeUtils.hasModifier(SyntaxKind.StaticKeyword, node),
                 export: nodeUtils.hasModifier(SyntaxKind.ExportKeyword, node)
             });
+
+            const accessibility = nodeUtils.getTSNodeAccessibility(node);
+            if (accessibility) {
+                result.accessibility = accessibility;
+            }
 
             break;
         }
@@ -1885,7 +1932,7 @@ module.exports = function convert(config) {
         case SyntaxKind.ConstructSignature: {
             Object.assign(result, {
                 type: AST_NODE_TYPES.TSConstructSignature,
-                params: node.parameters.map(parameter => convertChild(parameter)),
+                params: convertParameters(node.parameters),
                 typeAnnotation: (node.type) ? convertTypeAnnotation(node.type) : null
             });
 

--- a/tests/lib/__snapshots__/basics.js.snap
+++ b/tests/lib/__snapshots__/basics.js.snap
@@ -1084,7 +1084,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -1103,7 +1102,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,

--- a/tests/lib/__snapshots__/comments.js.snap
+++ b/tests/lib/__snapshots__/comments.js.snap
@@ -458,9 +458,7 @@ Object {
         "body": Object {
           "body": Array [
             Object {
-              "accessibility": null,
               "computed": false,
-              "decorators": Array [],
               "key": Object {
                 "loc": Object {
                   "end": Object {
@@ -554,9 +552,7 @@ Object {
           ],
           "type": "ClassBody",
         },
-        "decorators": Array [],
         "id": null,
-        "implements": Array [],
         "loc": Object {
           "end": Object {
             "column": 1,

--- a/tests/lib/__snapshots__/ecma-features.js.snap
+++ b/tests/lib/__snapshots__/ecma-features.js.snap
@@ -8397,9 +8397,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -8477,9 +8475,7 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -8550,7 +8546,6 @@ Object {
               },
               "params": Array [
                 Object {
-                  "decorators": Array [],
                   "loc": Object {
                     "end": Object {
                       "column": 26,
@@ -8593,7 +8588,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -8612,7 +8606,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 31,
@@ -9018,9 +9011,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": true,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -9114,7 +9105,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -9133,7 +9123,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 25,
@@ -9465,9 +9454,7 @@ Object {
           ],
           "type": "ClassBody",
         },
-        "decorators": Array [],
         "id": null,
-        "implements": Array [],
         "loc": Object {
           "end": Object {
             "column": 9,
@@ -9638,9 +9625,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -9734,7 +9719,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -9753,7 +9737,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 23,
@@ -9997,9 +9980,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -10093,7 +10074,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -10112,7 +10092,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 21,
@@ -10374,9 +10353,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -10470,7 +10447,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -10489,7 +10465,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 25,
@@ -10698,9 +10673,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -10794,7 +10767,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -10813,7 +10785,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -11057,9 +11028,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -11206,7 +11175,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -11225,7 +11193,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -11541,9 +11508,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -11637,7 +11602,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -11656,7 +11620,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 23,
@@ -11936,9 +11899,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": true,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -12033,7 +11994,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -12052,7 +12012,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 34,
@@ -12350,9 +12309,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -12446,7 +12403,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -12465,7 +12421,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 28,
@@ -12745,9 +12700,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -12825,9 +12778,7 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -12905,9 +12856,7 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -12978,7 +12927,6 @@ Object {
               },
               "params": Array [
                 Object {
-                  "decorators": Array [],
                   "loc": Object {
                     "end": Object {
                       "column": 53,
@@ -13021,7 +12969,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -13040,7 +12987,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 58,
@@ -13572,9 +13518,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": true,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -13652,9 +13596,7 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": true,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -13748,7 +13690,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -13767,7 +13708,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 38,
@@ -14227,9 +14167,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -14307,9 +14245,7 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -14403,7 +14339,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -14422,7 +14357,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 20,
@@ -14756,9 +14690,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -14837,9 +14769,7 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": true,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -14934,7 +14864,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -14953,7 +14882,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 47,
@@ -15323,9 +15251,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -15403,9 +15329,7 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -15499,7 +15423,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -15518,7 +15441,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 21,
@@ -15870,9 +15792,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -15950,9 +15870,7 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -16046,7 +15964,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -16065,7 +15982,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 23,
@@ -16453,9 +16369,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -16533,9 +16447,7 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -16629,7 +16541,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -16648,7 +16559,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 22,
@@ -17018,7 +16928,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "key": Object {
               "loc": Object {
@@ -17097,7 +17006,6 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": false,
             "key": Object {
               "loc": Object {
@@ -17192,7 +17100,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -17211,7 +17118,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 55,
@@ -17581,7 +17487,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "key": Object {
               "loc": Object {
@@ -17676,7 +17581,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -17695,7 +17599,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 25,
@@ -17939,7 +17842,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "key": Object {
               "loc": Object {
@@ -18011,7 +17913,6 @@ Object {
               },
               "params": Array [
                 Object {
-                  "decorators": Array [],
                   "loc": Object {
                     "end": Object {
                       "column": 24,
@@ -18030,7 +17931,6 @@ Object {
                   "type": "Identifier",
                 },
                 Object {
-                  "decorators": Array [],
                   "loc": Object {
                     "end": Object {
                       "column": 29,
@@ -18073,7 +17973,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -18092,7 +17991,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 33,
@@ -18355,7 +18253,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "key": Object {
               "loc": Object {
@@ -18450,7 +18347,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -18469,7 +18365,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 26,
@@ -18749,7 +18644,6 @@ Object {
               ],
               "type": "ClassBody",
             },
-            "decorators": Array [],
             "id": Object {
               "loc": Object {
                 "end": Object {
@@ -18768,7 +18662,6 @@ Object {
               ],
               "type": "Identifier",
             },
-            "implements": Array [],
             "loc": Object {
               "end": Object {
                 "column": 27,
@@ -19063,9 +18956,7 @@ Object {
           ],
           "type": "ClassBody",
         },
-        "decorators": Array [],
         "id": null,
-        "implements": Array [],
         "loc": Object {
           "end": Object {
             "column": 18,
@@ -19305,7 +19196,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -19324,7 +19214,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 10,
@@ -19493,7 +19382,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -19512,7 +19400,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 10,
@@ -19681,7 +19568,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -19700,7 +19586,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 11,
@@ -19887,7 +19772,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -19906,7 +19790,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 20,
@@ -20130,7 +20013,6 @@ Object {
           ],
           "type": "ClassBody",
         },
-        "decorators": Array [],
         "id": Object {
           "loc": Object {
             "end": Object {
@@ -20149,7 +20031,6 @@ Object {
           ],
           "type": "Identifier",
         },
-        "implements": Array [],
         "loc": Object {
           "end": Object {
             "column": 11,
@@ -20354,7 +20235,6 @@ Object {
           ],
           "type": "ClassBody",
         },
-        "decorators": Array [],
         "id": Object {
           "loc": Object {
             "end": Object {
@@ -20373,7 +20253,6 @@ Object {
           ],
           "type": "Identifier",
         },
-        "implements": Array [],
         "loc": Object {
           "end": Object {
             "column": 20,
@@ -20616,7 +20495,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "key": Object {
               "loc": Object {
@@ -20688,7 +20566,6 @@ Object {
               },
               "params": Array [
                 Object {
-                  "decorators": Array [],
                   "left": Object {
                     "loc": Object {
                       "end": Object {
@@ -20767,7 +20644,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -20786,7 +20662,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -21049,9 +20924,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -21122,7 +20995,6 @@ Object {
               },
               "params": Array [
                 Object {
-                  "decorators": Array [],
                   "left": Object {
                     "loc": Object {
                       "end": Object {
@@ -21201,7 +21073,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -21220,7 +21091,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -24060,9 +23930,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -24133,7 +24001,6 @@ Object {
               },
               "params": Array [
                 Object {
-                  "decorators": Array [],
                   "elements": Array [
                     Object {
                       "loc": Object {
@@ -24213,7 +24080,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -24232,7 +24098,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -24531,9 +24396,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -24604,7 +24467,6 @@ Object {
               },
               "params": Array [
                 Object {
-                  "decorators": Array [],
                   "elements": Array [
                     Object {
                       "left": Object {
@@ -24756,7 +24618,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -24775,7 +24636,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -25146,9 +25006,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -25219,7 +25077,6 @@ Object {
               },
               "params": Array [
                 Object {
-                  "decorators": Array [],
                   "loc": Object {
                     "end": Object {
                       "column": 30,
@@ -25449,7 +25306,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -25468,7 +25324,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -25839,9 +25694,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -25912,7 +25765,6 @@ Object {
               },
               "params": Array [
                 Object {
-                  "decorators": Array [],
                   "loc": Object {
                     "end": Object {
                       "column": 26,
@@ -26070,7 +25922,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -26089,7 +25940,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -26388,9 +26238,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -26461,7 +26309,6 @@ Object {
               },
               "params": Array [
                 Object {
-                  "decorators": Array [],
                   "elements": Array [
                     Object {
                       "loc": Object {
@@ -26541,7 +26388,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -26560,7 +26406,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -26859,9 +26704,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -26932,7 +26775,6 @@ Object {
               },
               "params": Array [
                 Object {
-                  "decorators": Array [],
                   "elements": Array [
                     Object {
                       "left": Object {
@@ -27084,7 +26926,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -27103,7 +26944,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -27474,9 +27314,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -27547,7 +27385,6 @@ Object {
               },
               "params": Array [
                 Object {
-                  "decorators": Array [],
                   "loc": Object {
                     "end": Object {
                       "column": 22,
@@ -27777,7 +27614,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -27796,7 +27632,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -28167,9 +28002,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -28240,7 +28073,6 @@ Object {
               },
               "params": Array [
                 Object {
-                  "decorators": Array [],
                   "loc": Object {
                     "end": Object {
                       "column": 18,
@@ -28398,7 +28230,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -28417,7 +28248,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -53344,6 +53174,7 @@ exports[`ecmaFeatures fixtures/destructuring-and-forOf/loop.src 1`] = `
 Object {
   "body": Array [
     Object {
+      "await": false,
       "body": Object {
         "loc": Object {
           "end": Object {
@@ -65800,6 +65631,7 @@ exports[`ecmaFeatures fixtures/forOf/for-of-with-function-initializer.src 1`] = 
 Object {
   "body": Array [
     Object {
+      "await": false,
       "body": Object {
         "expression": Object {
           "arguments": Array [
@@ -66514,6 +66346,7 @@ exports[`ecmaFeatures fixtures/forOf/for-of-with-var-and-braces.src 1`] = `
 Object {
   "body": Array [
     Object {
+      "await": false,
       "body": Object {
         "body": Array [
           Object {
@@ -66936,6 +66769,7 @@ exports[`ecmaFeatures fixtures/forOf/for-of-with-var-and-no-braces.src 1`] = `
 Object {
   "body": Array [
     Object {
+      "await": false,
       "body": Object {
         "expression": Object {
           "arguments": Array [],
@@ -67866,9 +67700,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -68072,7 +67904,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -68091,7 +67922,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -71005,9 +70835,7 @@ Object {
           ],
           "type": "ClassBody",
         },
-        "decorators": Array [],
         "id": null,
-        "implements": Array [],
         "loc": Object {
           "end": Object {
             "column": 1,
@@ -71626,7 +71454,6 @@ Object {
           ],
           "type": "ClassBody",
         },
-        "decorators": Array [],
         "id": Object {
           "loc": Object {
             "end": Object {
@@ -71645,7 +71472,6 @@ Object {
           ],
           "type": "Identifier",
         },
-        "implements": Array [],
         "loc": Object {
           "end": Object {
             "column": 1,
@@ -75489,7 +75315,6 @@ Object {
           ],
           "type": "ClassBody",
         },
-        "decorators": Array [],
         "id": Object {
           "loc": Object {
             "end": Object {
@@ -75508,7 +75333,6 @@ Object {
           ],
           "type": "Identifier",
         },
-        "implements": Array [],
         "loc": Object {
           "end": Object {
             "column": 1,
@@ -90153,7 +89977,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "key": Object {
               "loc": Object {
@@ -90243,7 +90066,6 @@ Object {
                     ],
                     "type": "Identifier",
                   },
-                  "decorators": Array [],
                   "loc": Object {
                     "end": Object {
                       "column": 22,
@@ -90285,7 +90107,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -90304,7 +90125,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -90549,9 +90369,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -90640,7 +90458,6 @@ Object {
                     ],
                     "type": "Identifier",
                   },
-                  "decorators": Array [],
                   "loc": Object {
                     "end": Object {
                       "column": 14,
@@ -90682,7 +90499,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -90701,7 +90517,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,

--- a/tests/lib/__snapshots__/typescript.js.snap
+++ b/tests/lib/__snapshots__/typescript.js.snap
@@ -395,7 +395,6 @@ Object {
         "body": Object {
           "body": Array [
             Object {
-              "accessibility": null,
               "computed": false,
               "key": Object {
                 "loc": Object {
@@ -473,7 +472,6 @@ Object {
           ],
           "type": "ClassBody",
         },
-        "decorators": Array [],
         "id": Object {
           "loc": Object {
             "end": Object {
@@ -492,7 +490,6 @@ Object {
           ],
           "type": "Identifier",
         },
-        "implements": Array [],
         "loc": Object {
           "end": Object {
             "column": 1,
@@ -756,9 +753,7 @@ Object {
         "body": Object {
           "body": Array [
             Object {
-              "accessibility": null,
               "computed": false,
-              "decorators": Array [],
               "key": Object {
                 "loc": Object {
                   "end": Object {
@@ -941,7 +936,6 @@ Object {
           ],
           "type": "ClassBody",
         },
-        "decorators": Array [],
         "id": Object {
           "loc": Object {
             "end": Object {
@@ -960,7 +954,6 @@ Object {
           ],
           "type": "Identifier",
         },
-        "implements": Array [],
         "loc": Object {
           "end": Object {
             "column": 1,
@@ -1313,9 +1306,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -1355,9 +1346,7 @@ Object {
             "value": null,
           },
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -1431,7 +1420,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -1450,7 +1438,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -1733,7 +1720,6 @@ Object {
           Object {
             "accessibility": "public",
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -1807,7 +1793,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -1826,7 +1811,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -2090,9 +2074,7 @@ Object {
         "body": Object {
           "body": Array [
             Object {
-              "accessibility": null,
               "computed": false,
-              "decorators": Array [],
               "key": Object {
                 "loc": Object {
                   "end": Object {
@@ -2276,7 +2258,6 @@ Object {
           ],
           "type": "ClassBody",
         },
-        "decorators": Array [],
         "id": Object {
           "loc": Object {
             "end": Object {
@@ -2295,7 +2276,6 @@ Object {
           ],
           "type": "Identifier",
         },
-        "implements": Array [],
         "loc": Object {
           "end": Object {
             "column": 1,
@@ -4458,7 +4438,6 @@ Object {
           Object {
             "accessibility": "private",
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -4533,7 +4512,6 @@ Object {
           Object {
             "accessibility": "public",
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -4608,7 +4586,6 @@ Object {
           Object {
             "accessibility": "public",
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -4759,7 +4736,6 @@ Object {
           Object {
             "accessibility": "protected",
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -4937,7 +4913,6 @@ Object {
               },
               "params": Array [
                 Object {
-                  "decorators": Array [],
                   "loc": Object {
                     "end": Object {
                       "column": 23,
@@ -5014,7 +4989,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -5033,7 +5007,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -5818,7 +5791,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "key": Object {
               "loc": Object {
@@ -5891,7 +5863,6 @@ Object {
               "params": Array [
                 Object {
                   "accessibility": null,
-                  "decorators": Array [],
                   "export": true,
                   "loc": Object {
                     "end": Object {
@@ -5988,7 +5959,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -6007,7 +5977,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -6303,7 +6272,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -6322,7 +6290,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -6710,7 +6677,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -6729,7 +6695,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -7244,9 +7209,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -7378,7 +7341,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -7397,7 +7359,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -7660,9 +7621,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -7829,7 +7788,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -7848,7 +7806,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -8162,7 +8119,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -8387,7 +8343,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -8721,7 +8676,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -9132,9 +9086,7 @@ Object {
                 ],
                 "type": "ClassBody",
               },
-              "decorators": Array [],
               "id": null,
-              "implements": Array [],
               "loc": Object {
                 "end": Object {
                   "column": 33,
@@ -9456,7 +9408,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -9656,7 +9607,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -9675,7 +9625,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 11,
@@ -11182,7 +11131,6 @@ Object {
           Object {
             "accessibility": "private",
             "computed": true,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -11257,7 +11205,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -11276,7 +11223,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -11539,9 +11485,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -11603,9 +11547,7 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -11703,7 +11645,6 @@ Object {
           Object {
             "accessibility": "private",
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -11815,7 +11756,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -11834,7 +11774,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -12313,9 +12252,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -12356,9 +12293,7 @@ Object {
             "value": null,
           },
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -12434,7 +12369,6 @@ Object {
           Object {
             "accessibility": "private",
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -12524,7 +12458,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -12543,7 +12476,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -12916,7 +12848,6 @@ Object {
           Object {
             "accessibility": "private",
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -12990,7 +12921,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -13009,7 +12939,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -13236,7 +13165,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "key": Object {
               "loc": Object {
@@ -13309,7 +13237,6 @@ Object {
               "params": Array [
                 Object {
                   "accessibility": "private",
-                  "decorators": Array [],
                   "export": false,
                   "loc": Object {
                     "end": Object {
@@ -13383,7 +13310,6 @@ Object {
                 },
                 Object {
                   "accessibility": "private",
-                  "decorators": Array [],
                   "export": false,
                   "loc": Object {
                     "end": Object {
@@ -13457,7 +13383,6 @@ Object {
                 },
                 Object {
                   "accessibility": "private",
-                  "decorators": Array [],
                   "export": false,
                   "loc": Object {
                     "end": Object {
@@ -13567,7 +13492,6 @@ Object {
                 },
                 Object {
                   "accessibility": "private",
-                  "decorators": Array [],
                   "export": false,
                   "loc": Object {
                     "end": Object {
@@ -13700,7 +13624,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -13719,7 +13642,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -14378,7 +14300,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "key": Object {
               "loc": Object {
@@ -14451,7 +14372,6 @@ Object {
               "params": Array [
                 Object {
                   "accessibility": "protected",
-                  "decorators": Array [],
                   "export": false,
                   "loc": Object {
                     "end": Object {
@@ -14525,7 +14445,6 @@ Object {
                 },
                 Object {
                   "accessibility": "protected",
-                  "decorators": Array [],
                   "export": false,
                   "loc": Object {
                     "end": Object {
@@ -14599,7 +14518,6 @@ Object {
                 },
                 Object {
                   "accessibility": "protected",
-                  "decorators": Array [],
                   "export": false,
                   "loc": Object {
                     "end": Object {
@@ -14709,7 +14627,6 @@ Object {
                 },
                 Object {
                   "accessibility": "protected",
-                  "decorators": Array [],
                   "export": false,
                   "loc": Object {
                     "end": Object {
@@ -14842,7 +14759,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -14861,7 +14777,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -15520,7 +15435,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "key": Object {
               "loc": Object {
@@ -15593,7 +15507,6 @@ Object {
               "params": Array [
                 Object {
                   "accessibility": "public",
-                  "decorators": Array [],
                   "export": false,
                   "loc": Object {
                     "end": Object {
@@ -15667,7 +15580,6 @@ Object {
                 },
                 Object {
                   "accessibility": "public",
-                  "decorators": Array [],
                   "export": false,
                   "loc": Object {
                     "end": Object {
@@ -15741,7 +15653,6 @@ Object {
                 },
                 Object {
                   "accessibility": "public",
-                  "decorators": Array [],
                   "export": false,
                   "loc": Object {
                     "end": Object {
@@ -15851,7 +15762,6 @@ Object {
                 },
                 Object {
                   "accessibility": "public",
-                  "decorators": Array [],
                   "export": false,
                   "loc": Object {
                     "end": Object {
@@ -15984,7 +15894,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -16003,7 +15912,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -16662,7 +16570,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "key": Object {
               "loc": Object {
@@ -16735,7 +16642,6 @@ Object {
               "params": Array [
                 Object {
                   "accessibility": null,
-                  "decorators": Array [],
                   "export": false,
                   "loc": Object {
                     "end": Object {
@@ -16809,7 +16715,6 @@ Object {
                 },
                 Object {
                   "accessibility": null,
-                  "decorators": Array [],
                   "export": false,
                   "loc": Object {
                     "end": Object {
@@ -16942,7 +16847,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -16961,7 +16865,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -17370,7 +17273,6 @@ Object {
           Object {
             "accessibility": "public",
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -17444,7 +17346,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -17463,7 +17364,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -17690,7 +17590,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "key": Object {
               "loc": Object {
@@ -17763,7 +17662,6 @@ Object {
               "params": Array [
                 Object {
                   "accessibility": null,
-                  "decorators": Array [],
                   "export": false,
                   "loc": Object {
                     "end": Object {
@@ -17860,7 +17758,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -17879,7 +17776,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -18175,7 +18071,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -18194,7 +18089,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -18420,7 +18314,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -18439,7 +18332,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -18736,7 +18628,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -18755,7 +18646,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 15,
@@ -18966,9 +18856,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -19080,7 +18968,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -19099,7 +18986,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -20247,9 +20133,7 @@ Object {
           ],
           "type": "ClassBody",
         },
-        "decorators": Array [],
         "id": null,
-        "implements": Array [],
         "loc": Object {
           "end": Object {
             "column": 1,
@@ -20510,9 +20394,7 @@ Object {
           ],
           "type": "ClassBody",
         },
-        "decorators": Array [],
         "id": null,
-        "implements": Array [],
         "loc": Object {
           "end": Object {
             "column": 1,
@@ -20828,7 +20710,6 @@ Object {
           ],
           "type": "ClassBody",
         },
-        "decorators": Array [],
         "id": Object {
           "loc": Object {
             "end": Object {
@@ -20847,7 +20728,6 @@ Object {
           ],
           "type": "Identifier",
         },
-        "implements": Array [],
         "loc": Object {
           "end": Object {
             "column": 1,
@@ -21110,7 +20990,6 @@ Object {
           ],
           "type": "ClassBody",
         },
-        "decorators": Array [],
         "id": Object {
           "loc": Object {
             "end": Object {
@@ -21129,7 +21008,6 @@ Object {
           ],
           "type": "Identifier",
         },
-        "implements": Array [],
         "loc": Object {
           "end": Object {
             "column": 1,
@@ -21758,7 +21636,6 @@ Object {
               },
               "members": Array [
                 Object {
-                  "accessibility": null,
                   "computed": false,
                   "export": false,
                   "initializer": null,
@@ -23082,7 +22959,6 @@ Object {
               },
               "members": Array [
                 Object {
-                  "accessibility": null,
                   "computed": false,
                   "export": false,
                   "initializer": null,
@@ -23158,7 +23034,6 @@ Object {
                   },
                 },
                 Object {
-                  "accessibility": null,
                   "computed": false,
                   "export": false,
                   "initializer": null,
@@ -23831,7 +23706,6 @@ Object {
               },
               "members": Array [
                 Object {
-                  "accessibility": null,
                   "computed": false,
                   "export": false,
                   "initializer": null,
@@ -23907,7 +23781,6 @@ Object {
                   },
                 },
                 Object {
-                  "accessibility": null,
                   "computed": false,
                   "export": false,
                   "initializer": null,
@@ -28018,7 +27891,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "export": false,
             "initializer": null,
@@ -28094,7 +27966,6 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": false,
             "export": false,
             "initializer": null,
@@ -28170,7 +28041,6 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": true,
             "export": false,
             "initializer": null,
@@ -28246,7 +28116,6 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": true,
             "export": false,
             "initializer": null,
@@ -28322,7 +28191,6 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "export": false,
             "index": Object {
               "loc": Object {
@@ -28429,7 +28297,6 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "export": false,
             "index": Object {
               "loc": Object {
@@ -28537,7 +28404,6 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": false,
             "export": false,
             "key": Object {
@@ -28613,7 +28479,6 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": false,
             "export": false,
             "key": Object {
@@ -28744,7 +28609,6 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": true,
             "export": false,
             "key": Object {
@@ -28875,7 +28739,6 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": false,
             "export": false,
             "key": Object {
@@ -32441,7 +32304,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "export": false,
             "key": Object {
@@ -32746,7 +32608,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "export": false,
             "initializer": null,
@@ -32789,7 +32650,6 @@ Object {
             "typeAnnotation": null,
           },
           Object {
-            "accessibility": null,
             "computed": false,
             "export": false,
             "initializer": null,
@@ -32865,7 +32725,6 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": false,
             "export": false,
             "key": Object {
@@ -33548,7 +33407,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "export": false,
             "initializer": null,
@@ -35766,9 +35624,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -35843,7 +35699,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -35862,7 +35717,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 23,
@@ -37596,7 +37450,6 @@ Object {
             },
             "members": Array [
               Object {
-                "accessibility": null,
                 "computed": false,
                 "export": false,
                 "initializer": null,
@@ -37672,7 +37525,6 @@ Object {
                 },
               },
               Object {
-                "accessibility": null,
                 "computed": false,
                 "export": false,
                 "initializer": null,
@@ -39464,7 +39316,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "export": false,
             "key": Object {
@@ -41309,7 +41160,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "decorators": Array [
               Object {
@@ -41550,7 +41400,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -41569,7 +41418,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -41976,7 +41824,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "decorators": Array [
               Object {
@@ -42275,7 +42122,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -42294,7 +42140,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -42791,7 +42636,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "decorators": Array [
               Object {
@@ -42994,7 +42838,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -43013,7 +42856,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -43366,7 +43208,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "decorators": Array [
               Object {
@@ -43582,7 +43423,6 @@ Object {
               },
               "params": Array [
                 Object {
-                  "decorators": Array [],
                   "loc": Object {
                     "end": Object {
                       "column": 18,
@@ -43625,7 +43465,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -43644,7 +43483,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -44121,7 +43959,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 12,
@@ -44442,7 +44279,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 21,
@@ -44741,7 +44577,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "decorators": Array [
               Object {
@@ -44911,7 +44746,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -44930,7 +44764,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -45229,7 +45062,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "decorators": Array [
               Object {
@@ -45399,7 +45231,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -45418,7 +45249,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -45735,7 +45565,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "decorators": Array [
               Object {
@@ -45867,7 +45696,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -45886,7 +45714,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -46131,7 +45958,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "decorators": Array [
               Object {
@@ -46263,7 +46089,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -46282,7 +46107,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -46545,7 +46369,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "key": Object {
               "loc": Object {
@@ -46928,7 +46751,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -46947,7 +46769,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -47444,9 +47265,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -47668,7 +47487,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -47687,7 +47505,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -48040,9 +47857,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -48264,7 +48079,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -48283,7 +48097,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -48654,9 +48467,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -48950,7 +48761,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -48969,7 +48779,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -49394,9 +49203,7 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
-            "decorators": Array [],
             "key": Object {
               "loc": Object {
                 "end": Object {
@@ -49690,7 +49497,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -49709,7 +49515,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -50152,7 +49957,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "decorators": Array [
               Object {
@@ -50248,7 +50052,6 @@ Object {
             "value": null,
           },
           Object {
-            "accessibility": null,
             "computed": false,
             "decorators": Array [
               Object {
@@ -50395,7 +50198,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -50414,7 +50216,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -50839,7 +50640,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "decorators": Array [
               Object {
@@ -50955,7 +50755,6 @@ Object {
             "value": null,
           },
           Object {
-            "accessibility": null,
             "computed": false,
             "decorators": Array [
               Object {
@@ -51087,7 +50886,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -51106,7 +50904,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -51513,7 +51310,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "decorators": Array [
               Object {
@@ -51591,7 +51387,6 @@ Object {
             "value": null,
           },
           Object {
-            "accessibility": null,
             "computed": false,
             "decorators": Array [
               Object {
@@ -51685,7 +51480,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -51704,7 +51498,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -51967,7 +51760,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "decorators": Array [
               Object {
@@ -52045,7 +51837,6 @@ Object {
             "value": null,
           },
           Object {
-            "accessibility": null,
             "computed": false,
             "decorators": Array [
               Object {
@@ -52139,7 +51930,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -52158,7 +51948,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -52472,7 +52261,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -52643,7 +52431,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -52850,7 +52637,6 @@ Object {
         ],
         "type": "ClassBody",
       },
-      "decorators": Array [],
       "id": Object {
         "loc": Object {
           "end": Object {
@@ -53436,7 +53222,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "accessibility": null,
             "computed": false,
             "export": false,
             "initializer": Object {
@@ -53758,7 +53543,6 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": false,
             "export": false,
             "initializer": null,
@@ -53834,7 +53618,6 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": false,
             "export": true,
             "initializer": null,
@@ -53910,7 +53693,6 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": false,
             "export": false,
             "initializer": null,
@@ -54307,7 +54089,6 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "export": false,
             "index": Object {
               "loc": Object {
@@ -54414,7 +54195,6 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "export": true,
             "index": Object {
               "loc": Object {
@@ -54521,7 +54301,6 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "export": false,
             "index": Object {
               "loc": Object {
@@ -55015,7 +54794,6 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": false,
             "export": false,
             "key": Object {
@@ -55144,7 +54922,6 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": false,
             "export": true,
             "key": Object {
@@ -55273,7 +55050,6 @@ Object {
             },
           },
           Object {
-            "accessibility": null,
             "computed": false,
             "export": false,
             "key": Object {
@@ -60129,9 +59905,7 @@ Object {
               "body": Object {
                 "body": Array [
                   Object {
-                    "accessibility": null,
                     "computed": false,
-                    "decorators": Array [],
                     "key": Object {
                       "loc": Object {
                         "end": Object {
@@ -60277,7 +60051,6 @@ Object {
                 ],
                 "type": "ClassBody",
               },
-              "decorators": Array [],
               "id": Object {
                 "loc": Object {
                   "end": Object {
@@ -60296,7 +60069,6 @@ Object {
                 ],
                 "type": "Identifier",
               },
-              "implements": Array [],
               "loc": Object {
                 "end": Object {
                   "column": 5,


### PR DESCRIPTION
This changes the way `implements`, `accessibility`  and `decorators` are applied.

When running babylon AST comparison tests, I noticed that babylon only applies the above properties if they are "truthy" (not exactly the right way to describe it but hopefully it's clear what I mean).

For example, if there is at least one decorator on a node, there will be a `decorators` array in the AST, otherwise, there will be no `decorators` property at all.

Currently in `typescript-eslint-parser`, we usually apply an empty array for the `decorators` in that case.

Before reviewing and merging this PR, I would first like to confirm that this is indeed the desired behaviour, @andy-ms?

I am personally pretty ambivalent about which makes more sense and would be keen to hear your thoughts on why you opted from leaving them out of the AST vs empty array/null value.

cc @hzoo @soda0289 