### PR TITLE
Fix: Location data for methods and constructors

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -744,8 +744,9 @@ module.exports = function convert(config) {
         case SyntaxKind.SetAccessor:
         case SyntaxKind.MethodDeclaration: {
 
-            // TODO: double-check that these positions are correct
-            const methodLoc = ast.getLineAndCharacterOfPosition(node.name.end + 1),
+            const openingParen = nodeUtils.findNextToken(node.name, ast);
+
+            const methodLoc = ast.getLineAndCharacterOfPosition(openingParen.getStart()),
                 nodeIsMethod = (node.kind === SyntaxKind.MethodDeclaration),
                 method = {
                     type: AST_NODE_TYPES.FunctionExpression,
@@ -758,7 +759,7 @@ module.exports = function convert(config) {
                     loc: {
                         start: {
                             line: methodLoc.line + 1,
-                            column: methodLoc.character - 1
+                            column: methodLoc.character
                         },
                         end: result.loc.end
                     }
@@ -865,7 +866,8 @@ module.exports = function convert(config) {
                     }
                 };
 
-            const constructorIdentifierLoc = ast.getLineAndCharacterOfPosition(firstConstructorToken.getStart()),
+            const constructorIdentifierLocStart = ast.getLineAndCharacterOfPosition(firstConstructorToken.getStart()),
+                constructorIdentifierLocEnd = ast.getLineAndCharacterOfPosition(firstConstructorToken.getEnd()),
                 constructorIsComputed = !!node.name && nodeUtils.isComputedProperty(node.name);
 
             let constructorKey;
@@ -878,12 +880,12 @@ module.exports = function convert(config) {
                     range: [firstConstructorToken.getStart(), firstConstructorToken.end],
                     loc: {
                         start: {
-                            line: constructorIdentifierLoc.line + 1,
-                            column: constructorIdentifierLoc.character
+                            line: constructorIdentifierLocStart.line + 1,
+                            column: constructorIdentifierLocStart.character
                         },
                         end: {
-                            line: constructor.loc.start.line,
-                            column: constructor.loc.start.column
+                            line: constructorIdentifierLocEnd.line + 1,
+                            column: constructorIdentifierLocEnd.character
                         }
                     }
                 };
@@ -894,12 +896,12 @@ module.exports = function convert(config) {
                     range: [firstConstructorToken.getStart(), firstConstructorToken.end],
                     loc: {
                         start: {
-                            line: constructorIdentifierLoc.line + 1,
-                            column: constructorIdentifierLoc.character
+                            line: constructorIdentifierLocStart.line + 1,
+                            column: constructorIdentifierLocStart.character
                         },
                         end: {
-                            line: constructor.loc.start.line,
-                            column: constructor.loc.start.column
+                            line: constructorIdentifierLocEnd.line + 1,
+                            column: constructorIdentifierLocEnd.character
                         }
                     }
                 };

--- a/tests/lib/__snapshots__/ecma-features.js.snap
+++ b/tests/lib/__snapshots__/ecma-features.js.snap
@@ -10441,7 +10441,7 @@ Object {
                   "line": 1,
                 },
                 "start": Object {
-                  "column": 18,
+                  "column": 19,
                   "line": 1,
                 },
               },
@@ -18360,7 +18360,7 @@ Object {
             "key": Object {
               "loc": Object {
                 "end": Object {
-                  "column": 21,
+                  "column": 20,
                   "line": 1,
                 },
                 "start": Object {

--- a/tests/lib/__snapshots__/typescript.js.snap
+++ b/tests/lib/__snapshots__/typescript.js.snap
@@ -400,7 +400,7 @@ Object {
               "key": Object {
                 "loc": Object {
                   "end": Object {
-                    "column": 24,
+                    "column": 12,
                     "line": 2,
                   },
                   "start": Object {
@@ -4744,7 +4744,7 @@ Object {
                   "line": 6,
                 },
                 "start": Object {
-                  "column": 15,
+                  "column": 16,
                   "line": 4,
                 },
               },
@@ -4931,7 +4931,7 @@ Object {
                   "line": 9,
                 },
                 "start": Object {
-                  "column": 18,
+                  "column": 19,
                   "line": 7,
                 },
               },


### PR DESCRIPTION
Found, developed and tested by comparing against Babylon (+ESTree plugin) AST and cross-referenced with espree results from the same code.