### PR TITLE
Chore: Breakout and label TS-specific AST comparison tests

### DIFF
--- a/tests/ast-alignment/spec.js
+++ b/tests/ast-alignment/spec.js
@@ -407,12 +407,140 @@ const fixturePatternsToTest = [
     {
         pattern: "ecma-features/modules/invalid-class.src.js",
         config: { babylonParserOptions: { sourceType: "module" } }
-    }
+    },
+
+    /* ================================================== */
 
     /**
-     * Lots of issues, needs to be broken down
+     * TYPESCRIPT-SPECIFIC FILES
      */
-    // "typescript/**/*.src.ts" // lots and lots of issues...
+
+    /**
+     * No issues
+     */
+    "typescript/basics/async-function-expression.src.ts",
+    "typescript/basics/async-function-with-var-declaration.src.ts",
+    "typescript/basics/function-with-await.src.ts",
+    "typescript/errorRecovery/class-extends-empty-implements.src.ts"
+
+    /**
+     * TypeScript-specific tests taken from "errorRecovery". Babylon is not being as forgiving as the TypeScript compiler here.
+     */
+    // "typescript/errorRecovery/class-empty-extends-implements.src.ts", // babylon parse errors
+    // "typescript/errorRecovery/class-empty-extends.src.ts", // babylon parse errors
+    // "typescript/errorRecovery/decorator-on-enum-declaration.src.ts", // babylon parse errors
+    // "typescript/errorRecovery/interface-property-modifiers.src.ts", // babylon parse errors
+
+    /**
+     * Other babylon parse errors. TODO: Need to coordinate with TS Team.
+     */
+    // "typescript/basics/abstract-class-with-abstract-constructor.src.ts", // babylon parse errors
+    // "typescript/basics/abstract-class-with-abstract-method.src.ts", // babylon parse errors
+    // "typescript/basics/abstract-class-with-optional-method.src.ts", // babylon parse errors
+    // "typescript/basics/abstract-interface.src.ts", // babylon parse errors
+    // "typescript/basics/class-with-export-parameter-properties.src.ts", // babylon parse errors
+    // "typescript/basics/class-with-optional-methods.src.ts", // babylon parse errors
+    // "typescript/basics/class-with-static-parameter-properties.src.ts", // babylon parse errors
+    // "typescript/basics/declare-class-with-optional-method.src.ts", // babylon parse errors
+    // "typescript/basics/export-type-alias-declaration.src.ts", // babylon parse errors
+    // "typescript/basics/export-type-class-declaration.src.ts", // babylon parse errors
+    // "typescript/basics/export-type-function-declaration.src.ts", // babylon parse errors
+    // "typescript/basics/interface-with-all-property-types.src.ts", // babylon parse errors
+    // "typescript/basics/interface-with-construct-signature-with-parameter-accessibility.src.ts", // babylon parse errors
+
+    /**
+     * typescript-eslint-parser erroring, but babylon not.
+     */
+    // "typescript/basics/arrow-function-with-type-parameters.src.ts" // typescript-eslint-parser parse errors
+
+    /**
+     * TypeScript AST differences which need to be resolved
+     */
+    // "typescript/babylon-convergence/type-parameters.src.ts",
+    // "typescript/basics/abstract-class-with-abstract-properties.src.ts",
+    // "typescript/basics/abstract-class-with-abstract-readonly-property.src.ts",
+    // "typescript/basics/class-with-accessibility-modifiers.src.ts",
+    // "typescript/basics/class-with-extends-generic-multiple.src.ts",
+    // "typescript/basics/class-with-extends-generic.src.ts",
+    // "typescript/basics/class-with-generic-method-default.src.ts",
+    // "typescript/basics/class-with-generic-method.src.ts",
+    // "typescript/basics/class-with-implements-generic-multiple.src.ts",
+    // "typescript/basics/class-with-implements-generic.src.ts",
+    // "typescript/basics/class-with-implements.src.ts",
+    // "typescript/basics/class-with-mixin.src.ts",
+    // "typescript/basics/class-with-optional-computed-property.src.ts",
+    // "typescript/basics/class-with-optional-properties.src.ts",
+    // "typescript/basics/class-with-optional-property-undefined.src.ts",
+    // "typescript/basics/class-with-private-parameter-properties.src.ts",
+    // "typescript/basics/class-with-protected-parameter-properties.src.ts",
+    // "typescript/basics/class-with-public-parameter-properties.src.ts",
+    // "typescript/basics/class-with-readonly-parameter-properties.src.ts",
+    // "typescript/basics/class-with-readonly-property.src.ts",
+    // "typescript/basics/class-with-type-parameter-default.src.ts",
+    // "typescript/basics/class-with-type-parameter-underscore.src.ts",
+    // "typescript/basics/class-with-type-parameter.src.ts",
+    // "typescript/basics/declare-function.src.ts",
+    // "typescript/basics/destructuring-assignment.src.ts",
+    // "typescript/basics/export-assignment.src.ts",
+    // "typescript/basics/export-default-class-with-generic.src.ts",
+    // "typescript/basics/export-default-class-with-multiple-generics.src.ts",
+    // "typescript/basics/export-named-class-with-generic.src.ts",
+    // "typescript/basics/export-named-class-with-multiple-generics.src.ts",
+    // "typescript/basics/function-with-object-type-with-optional-properties.src.ts",
+    // "typescript/basics/function-with-object-type-without-annotation.src.ts",
+    // "typescript/basics/function-with-type-parameters-that-have-comments.src.ts",
+    // "typescript/basics/function-with-type-parameters-with-constraint.src.ts",
+    // "typescript/basics/function-with-type-parameters.src.ts",
+    // "typescript/basics/function-with-types-assignation.src.ts",
+    // "typescript/basics/function-with-types.src.ts",
+    // "typescript/basics/interface-extends-multiple.src.ts",
+    // "typescript/basics/interface-extends.src.ts",
+    // "typescript/basics/interface-type-parameters.src.ts",
+    // "typescript/basics/interface-with-extends-type-parameters.src.ts",
+    // "typescript/basics/interface-with-generic.src.ts",
+    // "typescript/basics/interface-with-jsdoc.src.ts",
+    // "typescript/basics/interface-with-optional-properties.src.ts",
+    // "typescript/basics/interface-without-type-annotation.src.ts",
+    // "typescript/basics/nested-type-arguments.src.ts",
+    // "typescript/basics/non-null-assertion-operator.src.ts",
+    // "typescript/basics/null-and-undefined-type-annotations.src.ts",
+    // "typescript/basics/object-with-escaped-properties.src.ts",
+    // "typescript/basics/type-alias-declaration-with-constrained-type-parameter.src.ts",
+    // "typescript/basics/type-alias-declaration.src.ts",
+    // "typescript/basics/type-alias-object-without-annotation.src.ts",
+    // "typescript/basics/type-guard.src.ts",
+    // "typescript/basics/type-parameters-comments.src.ts",
+    // "typescript/basics/typed-this.src.ts",
+    // "typescript/basics/var-with-dotted-type.src.ts",
+    // "typescript/basics/var-with-type.src.ts",
+    // "typescript/basics/variable-declaration-type-annotation-spacing.src.ts",
+    // "typescript/decorators/accessor-decorators/accessor-decorator-factory-instance-member.src.ts",
+    // "typescript/decorators/accessor-decorators/accessor-decorator-factory-static-member.src.ts",
+    // "typescript/decorators/accessor-decorators/accessor-decorator-instance-member.src.ts",
+    // "typescript/decorators/accessor-decorators/accessor-decorator-static-member.src.ts",
+    // "typescript/decorators/class-decorators/class-decorator-factory.src.ts",
+    // "typescript/decorators/class-decorators/class-decorator.src.ts",
+    // "typescript/decorators/method-decorators/method-decorator-factory-instance-member.src.ts",
+    // "typescript/decorators/method-decorators/method-decorator-factory-static-member.src.ts",
+    // "typescript/decorators/method-decorators/method-decorator-instance-member.src.ts",
+    // "typescript/decorators/method-decorators/method-decorator-static-member.src.ts",
+    // "typescript/decorators/parameter-decorators/parameter-decorator-constructor.src.ts",
+    // "typescript/decorators/parameter-decorators/parameter-decorator-decorator-instance-member.src.ts",
+    // "typescript/decorators/parameter-decorators/parameter-decorator-decorator-static-member.src.ts",
+    // "typescript/decorators/parameter-decorators/parameter-decorator-instance-member.src.ts",
+    // "typescript/decorators/parameter-decorators/parameter-decorator-static-member.src.ts",
+    // "typescript/decorators/property-decorators/property-decorator-factory-instance-member.src.ts",
+    // "typescript/decorators/property-decorators/property-decorator-factory-static-member.src.ts",
+    // "typescript/decorators/property-decorators/property-decorator-instance-member.src.ts",
+    // "typescript/decorators/property-decorators/property-decorator-static-member.src.ts",
+    // "typescript/errorRecovery/interface-empty-extends.src.ts",
+    // "typescript/expressions/call-expression-type-arguments.src.ts",
+    // "typescript/expressions/new-expression-type-arguments.src.ts",
+    // "typescript/namespaces-and-modules/ambient-module-declaration-with-import.src.ts",
+    // "typescript/namespaces-and-modules/declare-namespace-with-exported-function.src.ts",
+    // "typescript/namespaces-and-modules/module-with-default-exports.src.ts",
+    // "typescript/namespaces-and-modules/shorthand-ambient-module-declaration.src.ts"
+
 ];
 
 // Either a string of the pattern, or an object containing the pattern and some additional config


### PR DESCRIPTION
Very minor follow up to my last AST comparison PR. This breaks out the typescript fixtures and labels why they currently fail.