### PR TITLE
New: Improve enum handling

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -595,6 +595,37 @@ module.exports = function convert(config) {
             });
             break;
 
+        case SyntaxKind.EnumDeclaration:
+            // Sets the enum's `id` property to its `name`
+            // for compatibility with class declarations
+            node.id = node.name;
+            if (node.modifiers && node.modifiers.length) {
+                const mods = node.modifiers;
+                delete node.modifiers;
+                let foundUsefulModifier = false;
+                for (const modifier of mods) {
+                    if (modifier.kind === SyntaxKind.ExportKeyword) {
+                        Object.assign(result, {
+                            type: AST_NODE_TYPES.ExportNamedDeclaration,
+                            declaration: deeplyCopy({
+                                range: [mods.end + 1, node.end],
+                                loc: nodeUtils.getLocFor(mods.end + 1, node.end, ast)
+                            }),
+                            specifiers: [],
+                            source: null
+                        });
+                        foundUsefulModifier = true;
+                        break;
+                    }
+                }
+                if (!foundUsefulModifier) {
+                    deeplyCopy();
+                }
+            } else {
+                deeplyCopy();
+            }
+            break;
+
         // Expressions
 
         case SyntaxKind.ExpressionStatement:

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -253,9 +253,13 @@ module.exports = function convert(config) {
      * For nodes that are copied directly from the TypeScript AST into
      * ESTree mostly as-is. The only difference is the addition of a type
      * property instead of a kind property. Recursively copies all children.
+     * @param   {Object} object=result The object to copy into
      * @returns {void}
      */
-    function deeplyCopy() {
+    function deeplyCopy(object) {
+        if (!object) {
+            object = result;
+        }
         const customType = `TS${SyntaxKind[node.kind]}`;
         /**
          * If the "errorOnUnknownASTType" option is set to true, throw an error,
@@ -264,36 +268,37 @@ module.exports = function convert(config) {
         if (additionalOptions.errorOnUnknownASTType && !AST_NODE_TYPES[customType]) {
             throw new Error(`Unknown AST_NODE_TYPE: "${customType}"`);
         }
-        result.type = customType;
+        object.type = customType;
         Object
             .keys(node)
             .filter(key => !(/^(?:kind|parent|pos|end|flags|modifierFlagsCache|jsDoc)$/.test(key)))
             .forEach(key => {
                 if (key === "type") {
-                    result.typeAnnotation = (node.type) ? convertTypeAnnotation(node.type) : null;
+                    object.typeAnnotation = (node.type) ? convertTypeAnnotation(node.type) : null;
                 } else if (key === "typeArguments") {
-                    result.typeParameters = (node.typeArguments)
+                    object.typeParameters = (node.typeArguments)
                         ? convertTypeArgumentsToTypeParameters(node.typeArguments)
                         : null;
                 } else if (key === "typeParameters") {
-                    result.typeParameters = (node.typeParameters)
+                    object.typeParameters = (node.typeParameters)
                         ? convertTSTypeParametersToTypeParametersDeclaration(node.typeParameters)
                         : null;
                 } else if (key === "decorators") {
                     const decorators = convertDecorators(node.decorators);
                     if (decorators && decorators.length) {
-                        result.decorators = decorators;
+                        object.decorators = decorators;
                     }
                 } else {
                     if (Array.isArray(node[key])) {
-                        result[key] = node[key].map(convertChild);
+                        object[key] = node[key].map(convertChild);
                     } else if (node[key] && typeof node[key] === "object") {
-                        result[key] = convertChild(node[key]);
+                        object[key] = convertChild(node[key]);
                     } else {
-                        result[key] = node[key];
+                        object[key] = node[key];
                     }
                 }
             });
+        return object;
     }
 
     /**

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -271,7 +271,7 @@ module.exports = function convert(config) {
         object.type = customType;
         Object
             .keys(node)
-            .filter(key => !(/^(?:kind|parent|pos|end|flags|modifierFlagsCache|jsDoc)$/.test(key)))
+            .filter(key => !(/^(?:_.+|kind|parent|pos|end|flags|modifierFlagsCache|jsDoc)$/.test(key)))
             .forEach(key => {
                 if (key === "type") {
                     object.typeAnnotation = (node.type) ? convertTypeAnnotation(node.type) : null;

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -595,36 +595,16 @@ module.exports = function convert(config) {
             });
             break;
 
-        case SyntaxKind.EnumDeclaration:
+        case SyntaxKind.EnumDeclaration: {
             // Sets the enum's `id` property to its `name`
             // for compatibility with class declarations
             node.id = node.name;
-            if (node.modifiers && node.modifiers.length) {
-                const mods = node.modifiers;
-                delete node.modifiers;
-                let foundUsefulModifier = false;
-                for (const modifier of mods) {
-                    if (modifier.kind === SyntaxKind.ExportKeyword) {
-                        Object.assign(result, {
-                            type: AST_NODE_TYPES.ExportNamedDeclaration,
-                            declaration: deeplyCopy({
-                                range: [mods.end + 1, node.end],
-                                loc: nodeUtils.getLocFor(mods.end + 1, node.end, ast)
-                            }),
-                            specifiers: [],
-                            source: null
-                        });
-                        foundUsefulModifier = true;
-                        break;
-                    }
-                }
-                if (!foundUsefulModifier) {
-                    deeplyCopy();
-                }
-            } else {
-                deeplyCopy();
-            }
+            // check for exports
+            const newResult = nodeUtils.fixExports(node, result, ast); // drops the export keyword
+            deeplyCopy();
+            result = newResult;
             break;
+        }
 
         // Expressions
 

--- a/lib/node-utils.js
+++ b/lib/node-utils.js
@@ -518,6 +518,11 @@ function fixExports(node, result, ast) {
             newResult.source = null;
         }
 
+        node.modifiers.shift(); // remove `export`
+        if (declarationIsDefault) {
+            node.modifiers.shift(); // remove `default`
+        }
+
         return newResult;
 
     }

--- a/tests/fixtures/typescript/basics/export-named-enum.src.ts
+++ b/tests/fixtures/typescript/basics/export-named-enum.src.ts
@@ -1,0 +1,1 @@
+export enum Foo {}

--- a/tests/lib/__snapshots__/typescript.js.snap
+++ b/tests/lib/__snapshots__/typescript.js.snap
@@ -21336,6 +21336,7 @@ Object {
           },
         },
         "members": Array [],
+        "modifiers": Array [],
         "name": Object {
           "loc": Object {
             "end": Object {

--- a/tests/lib/__snapshots__/typescript.js.snap
+++ b/tests/lib/__snapshots__/typescript.js.snap
@@ -52879,6 +52879,24 @@ Object {
           "type": "Decorator",
         },
       ],
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 11,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 10,
+            "line": 1,
+          },
+        },
+        "name": "E",
+        "range": Array [
+          10,
+          11,
+        ],
+        "type": "Identifier",
+      },
       "loc": Object {
         "end": Object {
           "column": 14,

--- a/tests/lib/__snapshots__/typescript.js.snap
+++ b/tests/lib/__snapshots__/typescript.js.snap
@@ -21302,6 +21302,194 @@ Object {
 }
 `;
 
+exports[`typescript fixtures/basics/export-named-enum.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "declaration": Object {
+        "id": Object {
+          "loc": Object {
+            "end": Object {
+              "column": 15,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 12,
+              "line": 1,
+            },
+          },
+          "name": "Foo",
+          "range": Array [
+            12,
+            15,
+          ],
+          "type": "Identifier",
+        },
+        "loc": Object {
+          "end": Object {
+            "column": 18,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 7,
+            "line": 1,
+          },
+        },
+        "members": Array [],
+        "name": Object {
+          "loc": Object {
+            "end": Object {
+              "column": 15,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 12,
+              "line": 1,
+            },
+          },
+          "name": "Foo",
+          "range": Array [
+            12,
+            15,
+          ],
+          "type": "Identifier",
+        },
+        "range": Array [
+          7,
+          18,
+        ],
+        "type": "TSEnumDeclaration",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        18,
+      ],
+      "source": null,
+      "specifiers": Array [],
+      "type": "ExportNamedDeclaration",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 2,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    19,
+  ],
+  "sourceType": "module",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        6,
+      ],
+      "type": "Keyword",
+      "value": "export",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        7,
+        11,
+      ],
+      "type": "Keyword",
+      "value": "enum",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        12,
+        15,
+      ],
+      "type": "Identifier",
+      "value": "Foo",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        16,
+        17,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        17,
+        18,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
 exports[`typescript fixtures/basics/export-type-alias-declaration.src 1`] = `
 Object {
   "body": Array [

--- a/tools/test-utils.js
+++ b/tools/test-utils.js
@@ -61,7 +61,8 @@ function createSnapshotTestBlock(code, config) {
              * AST_NODE_TYPE, we rethrow to cause the test to fail
              */
             if (e.message.match("Unknown AST_NODE_TYPE")) {
-                throw new Error(e);
+                e.stack += `\n\nRethrown\n${new Error().stack.split("\n").slice(1).join("\n")}`;
+                throw e;
             }
             expect(parse).toThrowErrorMatchingSnapshot();
         }


### PR DESCRIPTION
* Add an `id` property to the generated AST that makes the node more compatible with a `ClassDeclaration` node
* Wrap the `EnumDeclaration` in an `ExportNamedDeclaration` if the enum is exported

Also:

* Show the full stack when a test gets an error about an unknown AST type
* Allow calling `deeplyCopy` with a destination object to copy the data into instead of `result`

Fixes #345.