### PR TITLE
New: Allow other orderings of implements/extends clauses (fixes #361)

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -1277,19 +1277,13 @@ module.exports = function convert(config) {
             }
 
             const openBrace = nodeUtils.findNextToken(lastClassToken, ast);
-            const hasExtends = (heritageClauses.length && node.heritageClauses[0].token === SyntaxKind.ExtendsKeyword);
+            const superClass = heritageClauses.find(clause => clause.token === SyntaxKind.ExtendsKeyword);
 
-            let hasImplements = false;
-            let superClass;
-
-            if (hasExtends && heritageClauses[0].types.length > 0) {
-                superClass = heritageClauses.shift();
-                if (superClass.types[0] && superClass.types[0].typeArguments) {
-                    result.superTypeParameters = convertTypeArgumentsToTypeParameters(superClass.types[0].typeArguments);
-                }
+            if (superClass && superClass.types[0] && superClass.types[0].typeArguments) {
+                result.superTypeParameters = convertTypeArgumentsToTypeParameters(superClass.types[0].typeArguments);
             }
 
-            hasImplements = heritageClauses.length > 0;
+            const implementsClause = heritageClauses.find(clause => clause.token === SyntaxKind.ImplementsKeyword);
 
             Object.assign(result, {
                 type: classNodeType,
@@ -1302,11 +1296,11 @@ module.exports = function convert(config) {
                     range: [openBrace.getStart(), result.range[1]],
                     loc: nodeUtils.getLocFor(openBrace.getStart(), node.end, ast)
                 },
-                superClass: (superClass ? convertChild(superClass.types[0].expression) : null)
+                superClass: (superClass && superClass.types[0] ? convertChild(superClass.types[0].expression) : null)
             });
 
-            if (hasImplements) {
-                result.implements = heritageClauses[0].types.map(convertClassImplements);
+            if (implementsClause) {
+                result.implements = implementsClause.types.map(convertClassImplements);
             }
 
             if (node.decorators) {

--- a/tests/fixtures/typescript/basics/class-with-extends-and-implements.src.ts
+++ b/tests/fixtures/typescript/basics/class-with-extends-and-implements.src.ts
@@ -1,0 +1,1 @@
+class ClassWithParentAndInterface extends MyOtherClass implements MyInterface {}

--- a/tests/fixtures/typescript/basics/class-with-implements-and-extends.src.ts
+++ b/tests/fixtures/typescript/basics/class-with-implements-and-extends.src.ts
@@ -1,0 +1,1 @@
+class ClassWithParentAndInterface implements MyInterface extends MyOtherClass {}

--- a/tests/lib/__snapshots__/typescript.js.snap
+++ b/tests/lib/__snapshots__/typescript.js.snap
@@ -6250,6 +6250,283 @@ Object {
 }
 `;
 
+exports[`typescript fixtures/basics/class-with-extends-and-implements.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "body": Object {
+        "body": Array [],
+        "loc": Object {
+          "end": Object {
+            "column": 80,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 78,
+            "line": 1,
+          },
+        },
+        "range": Array [
+          78,
+          80,
+        ],
+        "type": "ClassBody",
+      },
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 33,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 6,
+            "line": 1,
+          },
+        },
+        "name": "ClassWithParentAndInterface",
+        "range": Array [
+          6,
+          33,
+        ],
+        "type": "Identifier",
+      },
+      "implements": Array [
+        Object {
+          "id": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 77,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 66,
+                "line": 1,
+              },
+            },
+            "name": "MyInterface",
+            "range": Array [
+              66,
+              77,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 77,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 66,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            66,
+            77,
+          ],
+          "type": "ClassImplements",
+        },
+      ],
+      "loc": Object {
+        "end": Object {
+          "column": 80,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        80,
+      ],
+      "superClass": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 54,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 42,
+            "line": 1,
+          },
+        },
+        "name": "MyOtherClass",
+        "range": Array [
+          42,
+          54,
+        ],
+        "type": "Identifier",
+      },
+      "type": "ClassDeclaration",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 2,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    81,
+  ],
+  "sourceType": "script",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        5,
+      ],
+      "type": "Keyword",
+      "value": "class",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 33,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        6,
+        33,
+      ],
+      "type": "Identifier",
+      "value": "ClassWithParentAndInterface",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 41,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        34,
+        41,
+      ],
+      "type": "Keyword",
+      "value": "extends",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 54,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 42,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        42,
+        54,
+      ],
+      "type": "Identifier",
+      "value": "MyOtherClass",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 65,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 55,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        55,
+        65,
+      ],
+      "type": "Keyword",
+      "value": "implements",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 77,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 66,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        66,
+        77,
+      ],
+      "type": "Identifier",
+      "value": "MyInterface",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 79,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 78,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        78,
+        79,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 80,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 79,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        79,
+        80,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
 exports[`typescript fixtures/basics/class-with-extends-generic.src 1`] = `
 Object {
   "body": Array [
@@ -8312,6 +8589,283 @@ Object {
       "range": Array [
         28,
         29,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
+exports[`typescript fixtures/basics/class-with-implements-and-extends.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "body": Object {
+        "body": Array [],
+        "loc": Object {
+          "end": Object {
+            "column": 80,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 78,
+            "line": 1,
+          },
+        },
+        "range": Array [
+          78,
+          80,
+        ],
+        "type": "ClassBody",
+      },
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 33,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 6,
+            "line": 1,
+          },
+        },
+        "name": "ClassWithParentAndInterface",
+        "range": Array [
+          6,
+          33,
+        ],
+        "type": "Identifier",
+      },
+      "implements": Array [
+        Object {
+          "id": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 56,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 45,
+                "line": 1,
+              },
+            },
+            "name": "MyInterface",
+            "range": Array [
+              45,
+              56,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 56,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 45,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            45,
+            56,
+          ],
+          "type": "ClassImplements",
+        },
+      ],
+      "loc": Object {
+        "end": Object {
+          "column": 80,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        80,
+      ],
+      "superClass": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 77,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 65,
+            "line": 1,
+          },
+        },
+        "name": "MyOtherClass",
+        "range": Array [
+          65,
+          77,
+        ],
+        "type": "Identifier",
+      },
+      "type": "ClassDeclaration",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 2,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    81,
+  ],
+  "sourceType": "script",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        5,
+      ],
+      "type": "Keyword",
+      "value": "class",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 33,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        6,
+        33,
+      ],
+      "type": "Identifier",
+      "value": "ClassWithParentAndInterface",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 44,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        34,
+        44,
+      ],
+      "type": "Keyword",
+      "value": "implements",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 56,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 45,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        45,
+        56,
+      ],
+      "type": "Identifier",
+      "value": "MyInterface",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 64,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 57,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        57,
+        64,
+      ],
+      "type": "Keyword",
+      "value": "extends",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 77,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 65,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        65,
+        77,
+      ],
+      "type": "Identifier",
+      "value": "MyOtherClass",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 79,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 78,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        78,
+        79,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 80,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 79,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        79,
+        80,
       ],
       "type": "Punctuator",
       "value": "}",
@@ -52279,7 +52833,6 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
       "loc": Object {
         "end": Object {
           "column": 1,
@@ -52449,7 +53002,43 @@ Object {
         ],
         "type": "Identifier",
       },
-      "implements": Array [],
+      "implements": Array [
+        Object {
+          "id": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 32,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 29,
+                "line": 1,
+              },
+            },
+            "name": "Bar",
+            "range": Array [
+              29,
+              32,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 32,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 29,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            29,
+            32,
+          ],
+          "type": "ClassImplements",
+        },
+      ],
       "loc": Object {
         "end": Object {
           "column": 1,


### PR DESCRIPTION
This allows for classes like

```ts
class ClassWithParentAndInterface implements MyInterface extends MyOtherClass {}
```

which currently do not parse the `extends` clause.

Fixes #361.