### PR TITLE
Breaking: Explicitly handle TSEnumDeclaration (fixes #345)

### DIFF
--- a/lib/ast-node-types.js
+++ b/lib/ast-node-types.js
@@ -109,6 +109,7 @@ module.exports = {
     TSConstructSignature: "TSConstructSignature",
     TSDeclareKeyword: "TSDeclareKeyword",
     TSEnumDeclaration: "TSEnumDeclaration",
+    TSEnumMember: "TSEnumMember",
     TSExportAssignment: "TSExportAssigment",
     TSIndexSignature: "TSIndexSignature",
     TSInterfaceBody: "TSInterfaceBody",

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -1994,6 +1994,36 @@ module.exports = function convert(config) {
             });
             break;
 
+        case SyntaxKind.EnumDeclaration: {
+            Object.assign(result, {
+                type: AST_NODE_TYPES.TSEnumDeclaration,
+                id: convertChild(node.name),
+                members: node.members.map(convertChild)
+            });
+            // check for exports
+            result = nodeUtils.fixExports(node, result, ast);
+            /**
+             * Semantically, decorators are not allowed on enum declarations,
+             * but the TypeScript compiler will parse them and produce a valid AST,
+             * so we handle them here too.
+             */
+            if (node.decorators) {
+                result.decorators = convertDecorators(node.decorators);
+            }
+            break;
+        }
+
+        case SyntaxKind.EnumMember: {
+            Object.assign(result, {
+                type: AST_NODE_TYPES.TSEnumMember,
+                id: convertChild(node.name)
+            });
+            if (node.initializer) {
+                result.initializer = convertChild(node.initializer);
+            }
+            break;
+        }
+
         default:
             deeplyCopy();
     }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "BSD-2-Clause",
   "devDependencies": {
     "babel-code-frame": "^6.22.0",
-    "babylon": "^7.0.0-beta.19",
+    "babylon": "^7.0.0-beta.20",
     "eslint": "3.19.0",
     "eslint-config-eslint": "4.0.0",
     "eslint-plugin-node": "4.2.2",

--- a/tests/ast-alignment/spec.js
+++ b/tests/ast-alignment/spec.js
@@ -421,7 +421,12 @@ const fixturePatternsToTest = [
     "typescript/basics/async-function-expression.src.ts",
     "typescript/basics/async-function-with-var-declaration.src.ts",
     "typescript/basics/function-with-await.src.ts",
-    "typescript/errorRecovery/class-extends-empty-implements.src.ts"
+    "typescript/errorRecovery/class-extends-empty-implements.src.ts",
+
+    {
+        pattern: "typescript/basics/export-named-enum.src.ts",
+        config: { babylonParserOptions: { sourceType: "module" } }
+    }
 
     /**
      * TypeScript-specific tests taken from "errorRecovery". Babylon is not being as forgiving as the TypeScript compiler here.

--- a/tests/fixtures/typescript/basics/export-named-enum.src.ts
+++ b/tests/fixtures/typescript/basics/export-named-enum.src.ts
@@ -1,0 +1,4 @@
+export enum Foo {
+    foo = 1,
+    bar
+}

--- a/tests/lib/__snapshots__/typescript.js.snap
+++ b/tests/lib/__snapshots__/typescript.js.snap
@@ -21856,6 +21856,356 @@ Object {
 }
 `;
 
+exports[`typescript fixtures/basics/export-named-enum.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "declaration": Object {
+        "id": Object {
+          "loc": Object {
+            "end": Object {
+              "column": 15,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 12,
+              "line": 1,
+            },
+          },
+          "name": "Foo",
+          "range": Array [
+            12,
+            15,
+          ],
+          "type": "Identifier",
+        },
+        "loc": Object {
+          "end": Object {
+            "column": 1,
+            "line": 4,
+          },
+          "start": Object {
+            "column": 7,
+            "line": 1,
+          },
+        },
+        "members": Array [
+          Object {
+            "id": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 7,
+                  "line": 2,
+                },
+                "start": Object {
+                  "column": 4,
+                  "line": 2,
+                },
+              },
+              "name": "foo",
+              "range": Array [
+                22,
+                25,
+              ],
+              "type": "Identifier",
+            },
+            "initializer": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 11,
+                  "line": 2,
+                },
+                "start": Object {
+                  "column": 10,
+                  "line": 2,
+                },
+              },
+              "range": Array [
+                28,
+                29,
+              ],
+              "raw": "1",
+              "type": "Literal",
+              "value": 1,
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 11,
+                "line": 2,
+              },
+              "start": Object {
+                "column": 4,
+                "line": 2,
+              },
+            },
+            "range": Array [
+              22,
+              29,
+            ],
+            "type": "TSEnumMember",
+          },
+          Object {
+            "id": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 7,
+                  "line": 3,
+                },
+                "start": Object {
+                  "column": 4,
+                  "line": 3,
+                },
+              },
+              "name": "bar",
+              "range": Array [
+                35,
+                38,
+              ],
+              "type": "Identifier",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 7,
+                "line": 3,
+              },
+              "start": Object {
+                "column": 4,
+                "line": 3,
+              },
+            },
+            "range": Array [
+              35,
+              38,
+            ],
+            "type": "TSEnumMember",
+          },
+        ],
+        "range": Array [
+          7,
+          40,
+        ],
+        "type": "TSEnumDeclaration",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        40,
+      ],
+      "source": null,
+      "specifiers": Array [],
+      "type": "ExportNamedDeclaration",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 1,
+      "line": 4,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    40,
+  ],
+  "sourceType": "module",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        6,
+      ],
+      "type": "Keyword",
+      "value": "export",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        7,
+        11,
+      ],
+      "type": "Keyword",
+      "value": "enum",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        12,
+        15,
+      ],
+      "type": "Identifier",
+      "value": "Foo",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        16,
+        17,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 4,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        22,
+        25,
+      ],
+      "type": "Identifier",
+      "value": "foo",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        26,
+        27,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        28,
+        29,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        29,
+        30,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        35,
+        38,
+      ],
+      "type": "Identifier",
+      "value": "bar",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        39,
+        40,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
 exports[`typescript fixtures/basics/export-type-alias-declaration.src 1`] = `
 Object {
   "body": Array [
@@ -53468,18 +53818,7 @@ Object {
           "type": "Decorator",
         },
       ],
-      "loc": Object {
-        "end": Object {
-          "column": 14,
-          "line": 1,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 1,
-        },
-      },
-      "members": Array [],
-      "name": Object {
+      "id": Object {
         "loc": Object {
           "end": Object {
             "column": 11,
@@ -53497,6 +53836,17 @@ Object {
         ],
         "type": "Identifier",
       },
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "members": Array [],
       "range": Array [
         0,
         14,


### PR DESCRIPTION
cc @j-f1, as per my comments on the other PR, for this solution I opted for explicitly handling the `TSEnumDeclaration`, and I also wanted to make sure that we (typescript-eslint-parser and babylon) were aligned on the structure of `members`, so I have also handled `TSEnumMember`s and verified this is the case.

I don't believe the other elements from that PR were necessary to fix #345 in the end, so I left them out, but please let me know if you think I am missing something!