### PR TITLE
Breaking: Support TypeScript 2.6 (fixes #394)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ node_js:
     - "6"
     - "7"
     - "8"
+    - "9"
 after_success:
     - npm run coveralls

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A parser that converts TypeScript into an [ESTree](https://github.com/estree/est
 
 We will always endeavor to support the latest stable version of TypeScript.
 
-The version of TypeScript currently supported by this parser is `~2.5.1`. This is reflected in the `devDependency` requirement within the package.json file, and it is what the tests will be run against. We have an open `peerDependency` requirement in order to allow for experimentation on newer/beta versions of TypeScript.
+The version of TypeScript currently supported by this parser is `~2.6.1`. This is reflected in the `devDependency` requirement within the package.json file, and it is what the tests will be run against. We have an open `peerDependency` requirement in order to allow for experimentation on newer/beta versions of TypeScript.
 
 If you use a non-supported version of TypeScript, the parser will log a warning to the console.
 

--- a/package.json
+++ b/package.json
@@ -18,19 +18,19 @@
   },
   "license": "BSD-2-Clause",
   "devDependencies": {
-    "babel-code-frame": "^6.26.0",
+    "babel-code-frame": "6.26.0",
     "babylon": "7.0.0-beta.24",
-    "eslint": "4.6.1",
+    "eslint": "4.10.0",
     "eslint-config-eslint": "4.0.0",
-    "eslint-plugin-node": "5.1.1",
+    "eslint-plugin-node": "5.2.1",
     "eslint-release": "0.10.3",
-    "glob": "^7.1.2",
-    "jest": "21.0.1",
-    "lodash.isplainobject": "^4.0.6",
+    "glob": "7.1.2",
+    "jest": "21.2.1",
+    "lodash.isplainobject": "4.0.6",
     "npm-license": "0.3.3",
     "shelljs": "0.7.8",
     "shelljs-nodecli": "0.1.1",
-    "typescript": "~2.6.0-rc"
+    "typescript": "~2.6.1"
   },
   "keywords": [
     "ast",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "npm-license": "0.3.3",
     "shelljs": "0.7.8",
     "shelljs-nodecli": "0.1.1",
-    "typescript": "~2.5.1"
+    "typescript": "~2.6.0-rc"
   },
   "keywords": [
     "ast",


### PR DESCRIPTION
This will be merged once TypeScript 2.6 is the stable version, as usual.

This branch is protected, any changes that go into master before this PR gets merged will need to be merged into the `ts-2.6` branch - it cannot be rebased.

This is our usual policy with these TypeScript upgrades, because it allows users to rely on commit hashes as installable versions.

Also, as usual, we are classifying this as a breaking change (to trigger our release tool to increment the major version number) if though there are no breaking code changes in the parser, as there is no downside to doing so and it better signals intentions to users.

**Note:** The build is currently failing on Node 4 as for some reason the corresponding version of NPM is saying that `~2.6.0-rc` does not satisfy a `peerDependency` requirement of `*` 🙄 