### PR TITLE
Use TSAbstractFunctionExpression for abstract methods.

### DIFF
--- a/lib/ast-node-types.js
+++ b/lib/ast-node-types.js
@@ -102,6 +102,7 @@ module.exports = {
      * TS-prefixed nodes
      */
     TSAbstractClassProperty: "TSAbstractClassProperty",
+    TSAbstractFunctionExpression: "TSAbstractFunctionExpression",
     TSAbstractKeyword: "TSAbstractKeyword",
     TSAbstractMethodDefinition: "TSAbstractMethodDefinition",
     TSAnyKeyword: "TSAnyKeyword",

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -868,8 +868,9 @@ module.exports = function convert(config) {
 
             const methodLoc = ast.getLineAndCharacterOfPosition(openingParen.getStart()),
                 nodeIsMethod = (node.kind === SyntaxKind.MethodDeclaration),
+                isMethodAbstract = nodeUtils.hasModifier(SyntaxKind.AbstractKeyword, node),
                 method = {
-                    type: AST_NODE_TYPES.FunctionExpression,
+                    type: isMethodAbstract ? AST_NODE_TYPES.TSAbstractFunctionExpression : AST_NODE_TYPES.FunctionExpression,
                     id: null,
                     generator: !!node.asteriskToken,
                     expression: false,
@@ -913,7 +914,7 @@ module.exports = function convert(config) {
                 /**
                  * TypeScript class methods can be defined as "abstract"
                  */
-                const methodDefinitionType = nodeUtils.hasModifier(SyntaxKind.AbstractKeyword, node)
+                const methodDefinitionType = isMethodAbstract
                     ? AST_NODE_TYPES.TSAbstractMethodDefinition
                     : AST_NODE_TYPES.MethodDefinition;
 

--- a/tests/lib/__snapshots__/typescript.js.snap
+++ b/tests/lib/__snapshots__/typescript.js.snap
@@ -1179,7 +1179,7 @@ Object {
                     },
                   },
                 },
-                "type": "FunctionExpression",
+                "type": "TSAbstractFunctionExpression",
               },
             },
           ],


### PR DESCRIPTION
Fixes crash in indent rule. Related to #253.