### PR TITLE
Fix: Remove all tokens inside comments from tokens array (fixes #422)

### DIFF
--- a/lib/node-utils.js
+++ b/lib/node-utils.js
@@ -245,6 +245,32 @@ function isComma(token) {
 }
 
 /**
+ * Returns true if the given TSToken is a comment
+ * @param  {TSToken}  token the TypeScript token
+ * @returns {boolean}       is commment
+ */
+function isComment(token) {
+    return (token.kind === SyntaxKind.SingleLineCommentTrivia || token.kind === SyntaxKind.MultiLineCommentTrivia) || (token.kind >= SyntaxKind.JSDocTypeExpression && token.kind <= SyntaxKind.JSDocTypeLiteral);
+}
+
+/**
+ * Returns true if the given TSToken is inside a comment
+ * Non-comment type tokens are generated for types in JSDoc Blocks
+ * @param  {TSToken}  token the TypeScript token
+ * @returns {boolean}       is inside a commment
+ */
+function isInsideComment(token) {
+    if (token.kind === SyntaxKind.SourceFile) {
+        return false;
+    }
+    if (isComment(token)) {
+        return true;
+    }
+    return isInsideComment(token.parent);
+}
+
+
+/**
  * Returns the binary expression type of the given TSToken
  * @param  {TSToken} operator the operator token
  * @returns {string}          the binary expression type
@@ -693,7 +719,7 @@ function convertTokens(ast) {
      * @returns {undefined}
      */
     function walk(node) {
-        if (isToken(node) && node.kind !== SyntaxKind.EndOfFileToken) {
+        if (isToken(node) && !isInsideComment(node) && node.kind !== SyntaxKind.EndOfFileToken) {
             const converted = convertToken(node, ast);
 
             if (converted) {

--- a/lib/node-utils.js
+++ b/lib/node-utils.js
@@ -185,7 +185,9 @@ module.exports = {
     convertTokens,
     getNodeContainer,
     isWithinTypeAnnotation,
-    isTypeKeyword
+    isTypeKeyword,
+    isComment,
+    isJSDocComment
 };
 /* eslint-enable no-use-before-define */
 
@@ -245,30 +247,22 @@ function isComma(token) {
 }
 
 /**
- * Returns true if the given TSToken is a comment
- * @param  {TSToken}  token the TypeScript token
- * @returns {boolean}       is commment
+ * Returns true if the given TSNode is a comment
+ * @param {TSNode} node the TypeScript node
+ * @returns {boolean} is commment
  */
-function isComment(token) {
-    return (token.kind === SyntaxKind.SingleLineCommentTrivia || token.kind === SyntaxKind.MultiLineCommentTrivia) || (token.kind >= SyntaxKind.JSDocTypeExpression && token.kind <= SyntaxKind.JSDocTypeLiteral);
+function isComment(node) {
+    return node.kind === SyntaxKind.SingleLineCommentTrivia || node.kind === SyntaxKind.MultiLineCommentTrivia;
 }
 
 /**
- * Returns true if the given TSToken is inside a comment
- * Non-comment type tokens are generated for types in JSDoc Blocks
- * @param  {TSToken}  token the TypeScript token
- * @returns {boolean}       is inside a commment
+ * Returns true if the given TSNode is a JSDoc comment
+ * @param {TSNode} node the TypeScript node
+ * @returns {boolean} is JSDoc comment
  */
-function isInsideComment(token) {
-    if (token.kind === SyntaxKind.SourceFile) {
-        return false;
-    }
-    if (isComment(token)) {
-        return true;
-    }
-    return isInsideComment(token.parent);
+function isJSDocComment(node) {
+    return node.kind === SyntaxKind.JSDocComment;
 }
-
 
 /**
  * Returns the binary expression type of the given TSToken
@@ -282,7 +276,6 @@ function getBinaryExpressionType(operator) {
         return "LogicalExpression";
     }
     return "BinaryExpression";
-
 }
 
 /**
@@ -719,7 +712,13 @@ function convertTokens(ast) {
      * @returns {undefined}
      */
     function walk(node) {
-        if (isToken(node) && !isInsideComment(node) && node.kind !== SyntaxKind.EndOfFileToken) {
+        // TypeScript generates tokens for types in JSDoc blocks. Comment tokens
+        // and their children should not be walked or added to the resulting tokens list.
+        if (isComment(node) || isJSDocComment(node)) {
+            return;
+        }
+
+        if (isToken(node) && node.kind !== SyntaxKind.EndOfFileToken) {
             const converted = convertToken(node, ast);
 
             if (converted) {

--- a/tests/fixtures/comments/jsdoc-comment.src.js
+++ b/tests/fixtures/comments/jsdoc-comment.src.js
@@ -1,17 +1,4 @@
 /**
- * @a
- */
-foo;
-
-/**
- * @a
- */
-/**
- * a
- */
-foo;
-
-/**
  * This is a function.
  * @param {String} bar some string
  * @returns {String} returns bar

--- a/tests/integration/external-fixtures/jsdoc-indent.js
+++ b/tests/integration/external-fixtures/jsdoc-indent.js
@@ -10,3 +10,12 @@ foo;
  * a
  */
 foo;
+
+/**
+ * This is a function.
+ * @param {String} bar
+ * @returns {String} returns bar
+ */
+function foo(bar) {
+    return bar;
+}

--- a/tests/integration/typescript.spec.js
+++ b/tests/integration/typescript.spec.js
@@ -80,7 +80,7 @@ describe("TypeScript", () => {
         );
     });
 
-    it("should not produce any lint errors on valid JSDoc indentation (#344)", () => {
+    it("should not produce any lint errors on valid JSDoc indentation (#344 & #422)", () => {
         verifyAndAssertMessages(
             loadExternalFixture("jsdoc-indent"),
             {

--- a/tests/lib/__snapshots__/comments.js.snap
+++ b/tests/lib/__snapshots__/comments.js.snap
@@ -830,6 +830,347 @@ Object {
 }
 `;
 
+exports[`Comments fixtures/jsdoc-comment.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "async": false,
+      "body": Object {
+        "body": Array [
+          Object {
+            "argument": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 14,
+                  "line": 7,
+                },
+                "start": Object {
+                  "column": 11,
+                  "line": 7,
+                },
+              },
+              "name": "bar",
+              "range": Array [
+                130,
+                133,
+              ],
+              "type": "Identifier",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 15,
+                "line": 7,
+              },
+              "start": Object {
+                "column": 4,
+                "line": 7,
+              },
+            },
+            "range": Array [
+              123,
+              134,
+            ],
+            "type": "ReturnStatement",
+          },
+        ],
+        "loc": Object {
+          "end": Object {
+            "column": 1,
+            "line": 8,
+          },
+          "start": Object {
+            "column": 18,
+            "line": 6,
+          },
+        },
+        "range": Array [
+          117,
+          136,
+        ],
+        "type": "BlockStatement",
+      },
+      "expression": false,
+      "generator": false,
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 12,
+            "line": 6,
+          },
+          "start": Object {
+            "column": 9,
+            "line": 6,
+          },
+        },
+        "name": "foo",
+        "range": Array [
+          108,
+          111,
+        ],
+        "type": "Identifier",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 6,
+        },
+      },
+      "params": Array [
+        Object {
+          "loc": Object {
+            "end": Object {
+              "column": 16,
+              "line": 6,
+            },
+            "start": Object {
+              "column": 13,
+              "line": 6,
+            },
+          },
+          "name": "bar",
+          "range": Array [
+            112,
+            115,
+          ],
+          "type": "Identifier",
+        },
+      ],
+      "range": Array [
+        99,
+        136,
+      ],
+      "type": "FunctionDeclaration",
+    },
+  ],
+  "comments": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        98,
+      ],
+      "type": "Block",
+      "value": "*
+ * This is a function.
+ * @param {String} bar some string
+ * @returns {String} returns bar
+ ",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 9,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 6,
+    },
+  },
+  "range": Array [
+    99,
+    137,
+  ],
+  "sourceType": "script",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        99,
+        107,
+      ],
+      "type": "Keyword",
+      "value": "function",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        108,
+        111,
+      ],
+      "type": "Identifier",
+      "value": "foo",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        111,
+        112,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        112,
+        115,
+      ],
+      "type": "Identifier",
+      "value": "bar",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        115,
+        116,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        117,
+        118,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 4,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        123,
+        129,
+      ],
+      "type": "Keyword",
+      "value": "return",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        130,
+        133,
+      ],
+      "type": "Identifier",
+      "value": "bar",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        133,
+        134,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        135,
+        136,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
 exports[`Comments fixtures/jsx-block-comment.src 1`] = `
 Object {
   "body": Array [


### PR DESCRIPTION
This fixes an issue where TypeScript generates tokens for `{Type}` (for both the brackets and the Identifier `Type`), causing the indent rule in core to have some false positives. I'm assuming these tokens are generated as part of TypeScript's JS file checking and type hinting from doc blocks.

@eslint/eslint-team As an aside, could we potentially leverage this behavior for our own JSDoc parsing and validation in ESLint core? Would be nice if we could rely on a well-maintained project like TypeScript instead of doctrine, since we've been struggling to maintain that.

Maybe @JamesHenry has some idea of the feasibility of this, given your experience!

This is my first time working with this codebase or really anything TypeScript related, so please do let me know if there are better ways to achieve this or if any assumptions I've made are incorrect.

To illustrate the change, here's a before and after of the tokens and comments arrays generated for the following code:

```js
/**
 * This is a function.
 * @param {String} text
 * @returns {String}
 */
function foo(text) {}
```
Before this patch:
```
Tokens:  [ { type: 'Punctuator',
    value: '{',
    range: [ 37, 38 ],
    loc: { start: [Object], end: [Object] } },
  { type: 'Identifier',
    value: 'String',
    range: [ 38, 44 ],
    loc: { start: [Object], end: [Object] } },
  { type: 'Punctuator',
    value: '}',
    range: [ 44, 45 ],
    loc: { start: [Object], end: [Object] } },
  { type: 'Identifier',
    value: 'text',
    range: [ 46, 50 ],
    loc: { start: [Object], end: [Object] } },
  { type: 'Punctuator',
    value: '{',
    range: [ 63, 64 ],
    loc: { start: [Object], end: [Object] } },
  { type: 'Identifier',
    value: 'String',
    range: [ 64, 70 ],
    loc: { start: [Object], end: [Object] } },
  { type: 'Punctuator',
    value: '}',
    range: [ 70, 71 ],
    loc: { start: [Object], end: [Object] } },
  { type: 'Keyword',
    value: 'function',
    range: [ 76, 84 ],
    loc: { start: [Object], end: [Object] } },
  { type: 'Identifier',
    value: 'foo',
    range: [ 85, 88 ],
    loc: { start: [Object], end: [Object] } },
  { type: 'Punctuator',
    value: '(',
    range: [ 88, 89 ],
    loc: { start: [Object], end: [Object] } },
  { type: 'Identifier',
    value: 'text',
    range: [ 89, 93 ],
    loc: { start: [Object], end: [Object] } },
  { type: 'Punctuator',
    value: ')',
    range: [ 93, 94 ],
    loc: { start: [Object], end: [Object] } },
  { type: 'Punctuator',
    value: '{',
    range: [ 95, 96 ],
    loc: { start: [Object], end: [Object] } },
  { type: 'Punctuator',
    value: '}',
    range: [ 96, 97 ],
    loc: { start: [Object], end: [Object] } } ]

Comments:  [ { type: 'Block',
    value: '*\n * This is a function.\n * @param {String} text\n * @returns {String}\n ',
    range: [ 0, 75 ],
    loc: { start: [Object], end: [Object] } } ]
```

After this patch:
```
Tokens:  [ { type: 'Keyword',
    value: 'function',
    range: [ 76, 84 ],
    loc: { start: [Object], end: [Object] } },
  { type: 'Identifier',
    value: 'foo',
    range: [ 85, 88 ],
    loc: { start: [Object], end: [Object] } },
  { type: 'Punctuator',
    value: '(',
    range: [ 88, 89 ],
    loc: { start: [Object], end: [Object] } },
  { type: 'Identifier',
    value: 'text',
    range: [ 89, 93 ],
    loc: { start: [Object], end: [Object] } },
  { type: 'Punctuator',
    value: ')',
    range: [ 93, 94 ],
    loc: { start: [Object], end: [Object] } },
  { type: 'Punctuator',
    value: '{',
    range: [ 95, 96 ],
    loc: { start: [Object], end: [Object] } },
  { type: 'Punctuator',
    value: '}',
    range: [ 96, 97 ],
    loc: { start: [Object], end: [Object] } } ]

Comments:  [ { type: 'Block',
    value: '*\n * This is a function.\n * @param {String} text\n * @returns {String}\n ',
    range: [ 0, 75 ],
    loc: { start: [Object], end: [Object] } } ]
```