### PR TITLE
Breaking: Properly categorize constructors with no body

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -1050,6 +1050,8 @@ module.exports = function convert(config) {
                 result.accessibility = accessibility;
             }
 
+            namespaceEmptyBodyFunctionForESLint(result.value);
+
             break;
 
         }

--- a/tests/lib/__snapshots__/typescript.js.snap
+++ b/tests/lib/__snapshots__/typescript.js.snap
@@ -733,7 +733,7 @@ Object {
                   63,
                   66,
                 ],
-                "type": "FunctionExpression",
+                "type": "TSEmptyBodyFunctionExpression",
               },
             },
           ],


### PR DESCRIPTION
I think this is a breaking change, but feel free to correct me if I’m wrong.

Error this fixes:

```
.../node_modules/eslint/lib/rules/strict.js:220
            const isBlock = node.body.type === "BlockStatement",
                                      ^
TypeError: Cannot read property 'type' of null
    at enterFunction (.../node_modules/eslint/lib/rules/strict.js:220:39)
    at listeners.(anonymous function).forEach.listener (.../node_modules/eslint/lib/util/safe-emitter.js:47:58)
    at Array.forEach (<anonymous>)
    at Object.emit (.../node_modules/eslint/lib/util/safe-emitter.js:47:38)
    at NodeEventGenerator.applySelector (.../node_modules/eslint/lib/util/node-event-generator.js:251:26)
    at NodeEventGenerator.applySelectors (.../node_modules/eslint/lib/util/node-event-generator.js:280:22)
    at NodeEventGenerator.enterNode (.../node_modules/eslint/lib/util/node-event-generator.js:294:14)
    at CodePathAnalyzer.enterNode (.../node_modules/eslint/lib/code-path-analysis/code-path-analyzer.js:608:23)
    at Traverser.enter (.../node_modules/eslint/lib/linter.js:956:32)
    at Traverser.__execute (.../node_modules/estraverse/estraverse.js:397:31)
    at Traverser.traverse (.../node_modules/estraverse/estraverse.js:501:28)
    at Traverser.traverse (.../node_modules/eslint/lib/util/traverser.js:31:22)
    at Linter._verifyWithoutProcessors (.../node_modules/eslint/lib/linter.js:953:19)
    at preprocess.map.textBlock (.../node_modules/eslint/lib/linter.js:994:35)
    at Array.map (<anonymous>)
    at Linter.verify (.../node_modules/eslint/lib/linter.js:993:42)
```
  