### PR TITLE
Breaking: Support unique symbol (fixes #426)

### DIFF
--- a/lib/ast-node-types.js
+++ b/lib/ast-node-types.js
@@ -141,6 +141,7 @@ module.exports = {
     TSSymbolKeyword: "TSSymbolKeyword",
     TSTypeAnnotation: "TSTypeAnnotation",
     TSTypeLiteral: "TSTypeLiteral",
+    TSTypeOperator: "TSTypeOperator",
     TSTypeParameter: "TSTypeParameter",
     TSTypeParameterDeclaration: "TSTypeParameterDeclaration",
     TSTypeParameterInstantiation: "TSTypeParameterInstantiation",

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -1571,6 +1571,14 @@ module.exports = function convert(config) {
             });
             break;
 
+        case SyntaxKind.TypeOperator:
+            Object.assign(result, {
+                type: AST_NODE_TYPES.TSTypeOperator,
+                operator: nodeUtils.getTextForTokenKind(node.operator),
+                typeAnnotation: convertChild(node.type)
+            });
+            break;
+
         // Binary Operations
 
         case SyntaxKind.BinaryExpression:

--- a/lib/node-utils.js
+++ b/lib/node-utils.js
@@ -97,6 +97,8 @@ TOKEN_TO_TEXT[SyntaxKind.BarEqualsToken] = "|=";
 TOKEN_TO_TEXT[SyntaxKind.CaretEqualsToken] = "^=";
 TOKEN_TO_TEXT[SyntaxKind.AtToken] = "@";
 TOKEN_TO_TEXT[SyntaxKind.InKeyword] = "in";
+TOKEN_TO_TEXT[SyntaxKind.UniqueKeyword] = "unique";
+TOKEN_TO_TEXT[SyntaxKind.KeyOfKeyword] = "keyof";
 
 /**
  * Find the first matching child based on the given sourceFile and predicate function.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "npm-license": "0.3.3",
     "shelljs": "0.7.8",
     "shelljs-nodecli": "0.1.1",
-    "typescript": "~2.6.1"
+    "typescript": "2.7.0-insiders.20180108"
   },
   "keywords": [
     "ast",

--- a/tests/fixtures/typescript/basics/keyof-operator.src.ts
+++ b/tests/fixtures/typescript/basics/keyof-operator.src.ts
@@ -1,0 +1,1 @@
+type x = keyof foo;

--- a/tests/fixtures/typescript/basics/unique-symbol.src.ts
+++ b/tests/fixtures/typescript/basics/unique-symbol.src.ts
@@ -1,0 +1,1 @@
+type A = unique symbol;

--- a/tests/lib/__snapshots__/typescript.js.snap
+++ b/tests/lib/__snapshots__/typescript.js.snap
@@ -34908,6 +34908,247 @@ Object {
 }
 `;
 
+exports[`typescript fixtures/basics/keyof-operator.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "declarations": Array [
+        Object {
+          "id": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 6,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 5,
+                "line": 1,
+              },
+            },
+            "name": "x",
+            "range": Array [
+              5,
+              6,
+            ],
+            "type": "Identifier",
+          },
+          "init": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 18,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 9,
+                "line": 1,
+              },
+            },
+            "operator": "keyof",
+            "range": Array [
+              9,
+              18,
+            ],
+            "type": "TSTypeOperator",
+            "typeAnnotation": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 18,
+                  "line": 1,
+                },
+                "start": Object {
+                  "column": 15,
+                  "line": 1,
+                },
+              },
+              "range": Array [
+                15,
+                18,
+              ],
+              "type": "TSTypeReference",
+              "typeName": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 18,
+                    "line": 1,
+                  },
+                  "start": Object {
+                    "column": 15,
+                    "line": 1,
+                  },
+                },
+                "name": "foo",
+                "range": Array [
+                  15,
+                  18,
+                ],
+                "type": "Identifier",
+              },
+            },
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 19,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 5,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            5,
+            19,
+          ],
+          "type": "VariableDeclarator",
+        },
+      ],
+      "kind": "type",
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        19,
+      ],
+      "type": "VariableDeclaration",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 2,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    20,
+  ],
+  "sourceType": "script",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 4,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        4,
+      ],
+      "type": "Identifier",
+      "value": "type",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        5,
+        6,
+      ],
+      "type": "Identifier",
+      "value": "x",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        7,
+        8,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        9,
+        14,
+      ],
+      "type": "Identifier",
+      "value": "keyof",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        15,
+        18,
+      ],
+      "type": "Identifier",
+      "value": "foo",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        18,
+        19,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
 exports[`typescript fixtures/basics/nested-type-arguments.src 1`] = `
 Object {
   "body": Array [
@@ -42856,6 +43097,229 @@ Object {
       ],
       "type": "Punctuator",
       "value": "}",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
+exports[`typescript fixtures/basics/unique-symbol.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "declarations": Array [
+        Object {
+          "id": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 6,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 5,
+                "line": 1,
+              },
+            },
+            "name": "A",
+            "range": Array [
+              5,
+              6,
+            ],
+            "type": "Identifier",
+          },
+          "init": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 22,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 9,
+                "line": 1,
+              },
+            },
+            "operator": "unique",
+            "range": Array [
+              9,
+              22,
+            ],
+            "type": "TSTypeOperator",
+            "typeAnnotation": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 22,
+                  "line": 1,
+                },
+                "start": Object {
+                  "column": 16,
+                  "line": 1,
+                },
+              },
+              "range": Array [
+                16,
+                22,
+              ],
+              "type": "TSSymbolKeyword",
+            },
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 23,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 5,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            5,
+            23,
+          ],
+          "type": "VariableDeclarator",
+        },
+      ],
+      "kind": "type",
+      "loc": Object {
+        "end": Object {
+          "column": 23,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        23,
+      ],
+      "type": "VariableDeclaration",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 2,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    24,
+  ],
+  "sourceType": "script",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 4,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        4,
+      ],
+      "type": "Identifier",
+      "value": "type",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        5,
+        6,
+      ],
+      "type": "Identifier",
+      "value": "A",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        7,
+        8,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        9,
+        15,
+      ],
+      "type": "Identifier",
+      "value": "unique",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 22,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        16,
+        22,
+      ],
+      "type": "Identifier",
+      "value": "symbol",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 23,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        22,
+        23,
+      ],
+      "type": "Punctuator",
+      "value": ";",
     },
   ],
   "type": "Program",


### PR DESCRIPTION
This changes captures `TSTypeOperator` and treats it like a unary operator. It breaks `keyof foo` and adds support for `unique symbol`. The `TSTypeOperator` node's `typeAnnotation` parameter is now the `TSTypeReference`, rather than a `TSTypeAnnotation` which has a `TSTypeReference`. (more direct), this is to align with babylon. 

```diff
@@ -30,11 +30,12 @@
                "start": Object {
                  "column": 9,
                  "line": 1,
                },
              },
-             "operator": 140,
+             "operator": "unique",
+             "prefix": true,
              "range": Array [
                9,
                22,
              ],
              "type": "TSTypeOperator",
@@ -43,36 +44,19 @@
                  "end": Object {
                    "column": 22,
                    "line": 1,
                  },
                  "start": Object {
-                   "column": 14,
+                   "column": 16,
                    "line": 1,
                  },
                },
                "range": Array [
-                 14,
+                 16,
                  22,
                ],
-               "type": "TSTypeAnnotation",
-               "typeAnnotation": Object {
-                 "loc": Object {
-                   "end": Object {
-                     "column": 22,
-                     "line": 1,
-                   },
-                   "start": Object {
-                     "column": 16,
-                     "line": 1,
-                   },
-                 },
-                 "range": Array [
-                   16,
-                   22,
-                 ],
-                 "type": "TSSymbolKeyword",
-               },
+               "type": "TSSymbolKeyword",
              },
            },
            "loc": Object {
              "end": Object {
                "column": 23,
```