### PR TITLE
Breaking: Infer parsing as JSX from file extension (fixes #399)

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -88,15 +88,14 @@ function generateAST(code, options, additionalParsingContext) {
         }
 
         const hasEcmaFeatures = options.ecmaFeatures && typeof options.ecmaFeatures === "object";
-        const hasFilePath = additionalParsingContext.isParseForESLint ? options.filePath !== DEFAULT_ESLINT_FILEPATH : options.filePath;
-        const hasTsxExtension = hasFilePath && /.tsx$/.test(options.filePath);
 
         // Allows user to parse a string of text passed on the command line in JSX mode.
         if (hasEcmaFeatures) {
-            if (typeof options.ecmaFeatures.jsx !== "undefined") {
-                extra.ecmaFeatures.jsx = options.ecmaFeatures.jsx;
-            }
+            extra.ecmaFeatures.jsx = options.ecmaFeatures.jsx;
         }
+
+        const hasFilePath = additionalParsingContext.isParseForESLint ? options.filePath !== DEFAULT_ESLINT_FILEPATH : options.filePath;
+        const hasTsxExtension = hasFilePath && /.tsx$/.test(options.filePath);
 
         // Infer whether or not the parser should parse in "JSX mode" or not.
         // This will override the parserOptions.ecmaFeatures.jsx config option if a filePath is provided.

--- a/parser.js
+++ b/parser.js
@@ -17,8 +17,12 @@ const SUPPORTED_TYPESCRIPT_VERSIONS = require("./package.json").devDependencies.
 const ACTIVE_TYPESCRIPT_VERSION = ts.version;
 const isRunningSupportedTypeScriptVersion = semver.satisfies(ACTIVE_TYPESCRIPT_VERSION, SUPPORTED_TYPESCRIPT_VERSIONS);
 
+const WARNING_BORDER = "=============";
+const DEFAULT_ESLINT_FILEPATH = "<text>";
+
 let extra;
 let warnedAboutTSVersion = false;
+let warnedAboutJSXOverride = false;
 
 /**
  * Resets the extra config object
@@ -73,17 +77,31 @@ function generateAST(code, options, additionalParsingContext) {
         if (typeof options.tokens === "boolean" && options.tokens) {
             extra.tokens = [];
         }
+
         if (typeof options.comment === "boolean" && options.comment) {
             extra.comment = true;
             extra.comments = [];
         }
+
         if (typeof options.tolerant === "boolean" && options.tolerant) {
             extra.errors = [];
         }
 
-        if (options.ecmaFeatures && typeof options.ecmaFeatures === "object") {
-            // pass through jsx option
-            extra.ecmaFeatures.jsx = options.ecmaFeatures.jsx;
+        const hasEcmaFeatures = options.ecmaFeatures && typeof options.ecmaFeatures === "object";
+        const hasFilePath = additionalParsingContext.isParseForESLint ? options.filePath !== DEFAULT_ESLINT_FILEPATH : options.filePath;
+        const hasTsxExtension = hasFilePath && /.tsx$/.test(options.filePath);
+
+        // Allows user to parse a string of text passed on the command line in JSX mode.
+        if (hasEcmaFeatures) {
+            if (typeof options.ecmaFeatures.jsx !== "undefined") {
+                extra.ecmaFeatures.jsx = options.ecmaFeatures.jsx;
+            }
+        }
+
+        // Infer whether or not the parser should parse in "JSX mode" or not.
+        // This will override the parserOptions.ecmaFeatures.jsx config option if a filePath is provided.
+        if (hasFilePath) {
+            extra.ecmaFeatures.jsx = hasTsxExtension;
         }
 
         /**
@@ -114,18 +132,29 @@ function generateAST(code, options, additionalParsingContext) {
         if (additionalParsingContext.isParseForESLint) {
             extra.parseForESLint = true;
         }
+
+        if (!warnedAboutJSXOverride && hasFilePath && hasEcmaFeatures && typeof options.ecmaFeatures.jsx !== "undefined") {
+            const warning = [
+                WARNING_BORDER,
+                "typescript-eslint-parser will automatically detect whether it should be parsing in JSX mode or not based on file extension.",
+                "Consider removing parserOptions.ecmaFeatures.jsx from your configuration, as it will be overridden by the extension of the file being parsed.",
+                WARNING_BORDER
+            ];
+
+            extra.log(warning.join("\n\n"));
+            warnedAboutJSXOverride = true;
+        }
     }
 
     if (!isRunningSupportedTypeScriptVersion && !warnedAboutTSVersion) {
-        const border = "=============";
         const versionWarning = [
-            border,
+            WARNING_BORDER,
             "WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-eslint-parser.",
             "You may find that it works just fine, or you may not.",
             `SUPPORTED TYPESCRIPT VERSIONS: ${SUPPORTED_TYPESCRIPT_VERSIONS}`,
             `YOUR TYPESCRIPT VERSION: ${ACTIVE_TYPESCRIPT_VERSION}`,
             "Please only submit bug reports when using the officially supported version.",
-            border
+            WARNING_BORDER
         ];
         extra.log(versionWarning.join("\n\n"));
         warnedAboutTSVersion = true;


### PR DESCRIPTION
fixes #399 

This is a WIP implementation of inferring whether the parser should parse in JSX mode or not based on the file extension of the file being parsed. Wanted to have a place to start a discussion, and then when we decide how we want to proceed finish this up.

This is a breaking change for users who are running ESLint on files (and therefore have a filepath). However, I can't think of a reason why you'd ever want the behavior to be different.

That being said, I believe that we do need to keep the behavior to set it manually for when a filepath is not provided, since we don't know whether it should be parsed in JSX mode or not. Example:
```sh
echo 'var foo: number = 1;' | ./node_modules/.bin/eslint --stdin --no-eslintrc --parser-options='ecmaFeatures:{jsx: true}' --parser typescript-eslint-parser
```

A few questions I have:
- I'm not very knowledgable about other downstream consumers of this parser - will this impact them negatively? In other words, should this only happen when `{ isParseForESLint: true }`, or would this be a welcome change for others in the community as well?
- To make it safer, we could have the passed in config always override the inferred value, however, as I mentioned, I can't think of a situation where this would be the desirable behavior. Doing so would also make existing configurations that have this set continue to do the wrong thing.
- I don't see a way around making this a breaking change, since even if we override it the behavior could be different for someone who does not have `parserOptions.ecmaFeatures.jsx` defined in their configuration. How does the team feel about this?
