### PR TITLE
Breaking: Support TypeScript 2.8 (fixes #453)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A parser that converts TypeScript source code into an [ESTree](https://github.co
 
 We will always endeavor to support the latest stable version of TypeScript.
 
-The version of TypeScript currently supported by this parser is `~2.7.1`. This is reflected in the `devDependency` requirement within the package.json file, and it is what the tests will be run against. We have an open `peerDependency` requirement in order to allow for experimentation on newer/beta versions of TypeScript.
+The version of TypeScript currently supported by this parser is `~2.8.1`. This is reflected in the `devDependency` requirement within the package.json file, and it is what the tests will be run against. We have an open `peerDependency` requirement in order to allow for experimentation on newer/beta versions of TypeScript.
 
 If you use a non-supported version of TypeScript, the parser will log a warning to the console.
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "npm-license": "0.3.3",
     "shelljs": "0.8.1",
     "shelljs-nodecli": "0.1.1",
-    "typescript": "~2.7.1"
+    "typescript": "~2.8.1"
   },
   "keywords": [
     "ast",


### PR DESCRIPTION
No changes were required to support the existing tests.

We should look to add coverage for new features introduced in 2.8 before this gets merged and check we are aligned with Babylon.