### PR TITLE
Fix: decorators removed on interface declarations (fixes #478)

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -2101,7 +2101,14 @@ module.exports = function convert(config) {
                 id: convertChild(node.name),
                 heritage: hasImplementsClause ? interfaceHeritageClauses[0].types.map(convertInterfaceHeritageClause) : []
             });
-
+            /**
+             * Semantically, decorators are not allowed on interface declarations,
+             * but the TypeScript compiler will parse them and produce a valid AST,
+             * so we handle them here too.
+             */
+            if (node.decorators) {
+                result.decorators = convertDecorators(node.decorators);
+            }
             // check for exports
             result = nodeUtils.fixExports(node, result, ast);
 

--- a/tests/ast-alignment/fixtures-to-test.js
+++ b/tests/ast-alignment/fixtures-to-test.js
@@ -454,6 +454,7 @@ let fixturePatternConfigsToTest = [
             "class-empty-extends-implements", // babylon parse errors
             "class-empty-extends", // babylon parse errors
             "decorator-on-enum-declaration", // babylon parse errors
+            "decorator-on-interface-declaration", // babylon parse errors
             "interface-property-modifiers", // babylon parse errors
             "enum-with-keywords" // babylon parse errors
         ]

--- a/tests/fixtures/typescript/errorRecovery/decorator-on-interface-declaration.src.ts
+++ b/tests/fixtures/typescript/errorRecovery/decorator-on-interface-declaration.src.ts
@@ -1,0 +1,2 @@
+@deco()
+interface M {}

--- a/tests/lib/__snapshots__/typescript.js.snap
+++ b/tests/lib/__snapshots__/typescript.js.snap
@@ -57236,6 +57236,285 @@ Object {
 }
 `;
 
+exports[`typescript fixtures/errorRecovery/decorator-on-interface-declaration.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "abstract": false,
+      "body": Object {
+        "body": Array [],
+        "loc": Object {
+          "end": Object {
+            "column": 14,
+            "line": 2,
+          },
+          "start": Object {
+            "column": 12,
+            "line": 2,
+          },
+        },
+        "range": Array [
+          20,
+          22,
+        ],
+        "type": "TSInterfaceBody",
+      },
+      "decorators": Array [
+        Object {
+          "expression": Object {
+            "arguments": Array [],
+            "callee": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 5,
+                  "line": 1,
+                },
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                },
+              },
+              "name": "deco",
+              "range": Array [
+                1,
+                5,
+              ],
+              "type": "Identifier",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 7,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 1,
+                "line": 1,
+              },
+            },
+            "range": Array [
+              1,
+              7,
+            ],
+            "type": "CallExpression",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 7,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 0,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            0,
+            7,
+          ],
+          "type": "Decorator",
+        },
+      ],
+      "heritage": Array [],
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 11,
+            "line": 2,
+          },
+          "start": Object {
+            "column": 10,
+            "line": 2,
+          },
+        },
+        "name": "M",
+        "range": Array [
+          18,
+          19,
+        ],
+        "type": "Identifier",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        22,
+      ],
+      "type": "TSInterfaceDeclaration",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 14,
+      "line": 2,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    22,
+  ],
+  "sourceType": "script",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        1,
+      ],
+      "type": "Punctuator",
+      "value": "@",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        1,
+        5,
+      ],
+      "type": "Identifier",
+      "value": "deco",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        5,
+        6,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        6,
+        7,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        8,
+        17,
+      ],
+      "type": "Keyword",
+      "value": "interface",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        18,
+        19,
+      ],
+      "type": "Identifier",
+      "value": "M",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        20,
+        21,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        21,
+        22,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
 exports[`typescript fixtures/errorRecovery/empty-type-arguments.src 1`] = `
 Object {
   "body": Array [


### PR DESCRIPTION
This pull request fixes a bug that where decorators(invalid) on interface declarations are removed from the AST.

There was already a case where semantically invalid decorators are kept for enum declarations, so I followed the same logic for this case as well.

Looking forward to hearing your feedback.

Regards,

Related issues
https://github.com/prettier/prettier/issues/4552
