### PR TITLE
Chore: Allow dependencies to dedupe with eslint dependencies

### DIFF
--- a/lib/node-utils.js
+++ b/lib/node-utils.js
@@ -12,7 +12,7 @@
 //------------------------------------------------------------------------------
 
 const ts = require("typescript"),
-    unescape = require("lodash.unescape");
+    unescape = require("lodash/unescape");
 
 //------------------------------------------------------------------------------
 // Private

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "betarelease": "eslint-prerelease beta"
   },
   "dependencies": {
-    "lodash.unescape": "4.0.1",
-    "semver": "5.5.0"
+    "lodash.unescape": "^4.0.1",
+    "semver": "^5.5.0"
   },
   "peerDependencies": {
     "typescript": "*"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "eslint-release": "0.11.1",
     "glob": "7.1.2",
     "jest": "23.1.0",
-    "lodash.isplainobject": "4.0.6",
     "npm-license": "0.3.3",
     "shelljs": "0.8.2",
     "shelljs-nodecli": "0.1.1",
@@ -55,7 +54,7 @@
     "betarelease": "eslint-prerelease beta"
   },
   "dependencies": {
-    "lodash.unescape": "^4.0.1",
+    "lodash": "^4.17.10",
     "semver": "^5.5.0"
   },
   "peerDependencies": {

--- a/tests/ast-alignment/utils.js
+++ b/tests/ast-alignment/utils.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const isPlainObject = require("lodash.isplainobject");
+const isPlainObject = require("lodash/isPlainObject");
 
 /**
  * By default, pretty-format (within Jest matchers) retains the names/types of nodes from the babylon AST,


### PR DESCRIPTION
Two parts to this PR:

- Allow semver range for dependencies. This matches eslint
- Use the full lodash package (as used by eslint) instead of just the unescape module