### PR TITLE
Fix: Remove lib from package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "main": "parser.js",
   "version": "19.0.0",
   "files": [
-    "lib",
     "parser.js"
   ],
   "engines": {


### PR DESCRIPTION
This prevented eslint-release from running correctly for v19