### PR TITLE
Fix: Re-expose parse method (fixes #519)

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -32,6 +32,10 @@ exports.parseForESLint = function parseForESLint(code, options) {
     return { ast };
 };
 
+exports.parse = function(code, options) {
+    return this.parseForESLint(code, options).ast;
+};
+
 // Deep copy.
 /* istanbul ignore next */
 exports.Syntax = (function() {


### PR DESCRIPTION
Just as a short-term workaround, I figured we could re-expose the `parse` method.

Between this major version and the next, I'd want to work with eslint-plugin-import (and anyone else trying to parse files while linting) to ensure they follow the same algorithm as ESLint. Then maybe we could remove `parse` again.