### PR TITLE
Upgrade: eslint-release@1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _test.js
 .DS_Store
 .vscode
 yarn.lock
+.eslint-release-info.json

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "eslint-config-eslint": "4.0.0",
     "eslint-plugin-node": "6.0.1",
-    "eslint-release": "0.11.1",
+    "eslint-release": "1.1.0",
     "jest": "23.1.0",
     "npm-license": "0.3.3",
     "shelljs": "0.8.2",
@@ -41,11 +41,11 @@
     "integration-tests": "docker-compose -f tests/integration/docker-compose.yml up",
     "kill-integration-test-containers": "docker-compose -f tests/integration/docker-compose.yml down -v --rmi local",
     "lint": "node Makefile.js lint",
-    "release": "eslint-release",
-    "ci-release": "eslint-ci-release",
-    "gh-release": "eslint-gh-release",
-    "alpharelease": "eslint-prerelease alpha",
-    "betarelease": "eslint-prerelease beta"
+    "generate-release": "eslint-generate-release",
+    "generate-alpharelease": "eslint-generate-prerelease alpha",
+    "generate-betarelease": "eslint-generate-prerelease beta",
+    "generate-rcrelease": "eslint-generate-prerelease rc",
+    "publish-release": "eslint-publish-release"
   },
   "dependencies": {
     "eslint": "4.19.1",


### PR DESCRIPTION
(refs https://github.com/eslint/eslint/issues/10631)

This updates `eslint-release` to allow the package to still be published from the Jenkins server now that we have 2FA enabled on the bot account.

Some changes are also needed on the Jenkins server -- I plan to make those changes after this is merged.

@JamesHenry We've enabled 2FA for the bot npm account on the Jenkins server, so from now on you'll need to be able to generate 2FA codes in order to publish with the ESLint Jenkins server. Do you have a [Keybase](https://keybase.io/) account or PGP key that I can use to encrypt the QR code and send it to you? I'm also happy to answer any questions here/on Gitter/somewhere else.