### PR TITLE
Docs: add options to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ By far the most common case will be installing the [eslint-plugin-typescript](ht
 
 ## Options
 
-The following are the available options and their default values:
+The full list of options can be found in the [typescript-estree README](https://github.com/JamesHenry/typescript-estree#parsecode-options). Use them like this in your eslintrc:
 
 ```js
 parserOptions: {
   ecmaFeatures: {
-    jsx: false,
+    jsx: true,
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ Instead, you also need to make use of one more plugins which will add or extend 
 
 By far the most common case will be installing the [eslint-plugin-typescript](https://github.com/nzakas/eslint-plugin-typescript) plugin, but there are also other relevant options available such a [eslint-plugin-tslint](https://github.com/JamesHenry/eslint-plugin-tslint).
 
+## Options
+
+The following are the available options and their default values:
+
+```js
+parserOptions: {
+  ecmaFeatures: {
+    jsx: false,
+  }
+}
+```
+
 ## Supported TypeScript Version
 
 We will always endeavor to support the latest stable version of TypeScript.


### PR DESCRIPTION
Are these options inherited from somewhere? If so, then maybe we should just mention that, and only list ones that are specific to this parser.