### PR TITLE
Revert "Chore: Make ESLint a devDependency/peerDependency (fixes #523)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "license": "BSD-2-Clause",
   "devDependencies": {
-    "eslint": "^4.19.0",
     "eslint-config-eslint": "4.0.0",
     "eslint-plugin-node": "6.0.1",
     "eslint-release": "1.1.0",
@@ -50,11 +49,11 @@
     "publish-release": "eslint-publish-release"
   },
   "dependencies": {
+    "eslint": "4.19.1",
     "eslint-visitor-keys": "^1.0.0",
     "typescript-estree": "2.1.0"
   },
   "peerDependencies": {
-    "eslint": ">=4.19.0 <6.0.0",
     "typescript": "*"
   },
   "jest": {


### PR DESCRIPTION
Reverts eslint/typescript-eslint-parser#526

Adding a peer dependency requirement is a breaking change. So the plan is to revert the chore commit (this PR), cut a patch release, then re-apply the changes in a breaking commit and cut a major release.

Refs #534.