### PR TITLE
Breaking: typescript-estree v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ npm install --save-dev typescript-eslint-parser
 In your ESLint configuration file, set the `parser` property:
 
 ```json
-"parser": "typescript-eslint-parser"
+{
+    "parser": "typescript-eslint-parser"
+}
 ```
 
 There is sometimes an incorrect assumption that the parser itself is what does everything necessary to facilitate the use of ESLint with TypeScript. In actuality, it is the combination of the parser _and_ one or more plugins which allow you to maximize your usage of ESLint with TypeScript.
@@ -30,14 +32,19 @@ Instead, you also need to make use of one more plugins which will add or extend 
 
 By far the most common case will be installing the [eslint-plugin-typescript](https://github.com/nzakas/eslint-plugin-typescript) plugin, but there are also other relevant options available such a [eslint-plugin-tslint](https://github.com/JamesHenry/eslint-plugin-tslint).
 
-## Options
+## Configuration
+
+The following additional configuration options are available by specifying them in [`parserOptions`](https://eslint.org/docs/user-guide/configuring#specifying-parser-options) in your ESLint configuration file.
 
 **`jsx`** - default `false`. Enable parsing JSX when `true`. More details can be found [here](https://www.typescriptlang.org/docs/handbook/jsx.html).
 
 **`useJSXTextNode`** - default `false`. The JSX AST changed the node type for string literals inside a JSX Element from `Literal` to `JSXText`. When value is `true`, these nodes will be parsed as type `JSXText`. When value is `false`, these nodes will be parsed as type `Literal`.
 
+### .eslintrc.json
+
 ```json
 {
+    "parser": "typescript-eslint-parser",
     "parserOptions": {
         "jsx": true,
         "useJSXTextNode": true

--- a/README.md
+++ b/README.md
@@ -32,13 +32,16 @@ By far the most common case will be installing the [eslint-plugin-typescript](ht
 
 ## Options
 
-The full list of options can be found in the [typescript-estree README](https://github.com/JamesHenry/typescript-estree#parsecode-options). Use them like this in your eslintrc:
+**`jsx`** - default `false`. Enable parsing JSX when `true`. More details can be found [here](https://www.typescriptlang.org/docs/handbook/jsx.html).
 
-```js
-parserOptions: {
-  ecmaFeatures: {
-    jsx: true,
-  }
+**`useJSXTextNode`** - default `false`. The JSX AST changed the node type for string literals inside a JSX Element from `Literal` to `JSXText`. When value is `true`, these nodes will be parsed as type `JSXText`. When value is `false`, these nodes will be parsed as type `Literal`.
+
+```json
+{
+    "parserOptions": {
+        "jsx": true,
+        "useJSXTextNode": true
+    }
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "eslint": "4.19.1",
     "eslint-visitor-keys": "^1.0.0",
-    "typescript-estree": "2.1.0"
+    "typescript-estree": "5.0.0"
   },
   "peerDependencies": {
     "typescript": "*"

--- a/parser.js
+++ b/parser.js
@@ -13,6 +13,25 @@ const astNodeTypes = require("typescript-estree").AST_NODE_TYPES;
 const traverser = require("eslint/lib/util/traverser");
 const visitorKeys = require("./visitor-keys");
 
+/**
+ * Formats the parser options object for typescript-estree
+ * @param {Object} options - ESLint parser options object
+ * @returns {Object} formatted typescript-estree options object
+ */
+function formatOptions(options) {
+    const formattedOptions = Object.assign({}, options);
+
+    if (options.ecmaFeatures) {
+        delete formattedOptions.ecmaFeatures;
+
+        if (options.ecmaFeatures.jsx) {
+            formattedOptions.jsx = options.ecmaFeatures.jsx;
+        }
+    }
+
+    return formattedOptions;
+}
+
 //------------------------------------------------------------------------------
 // Public
 //------------------------------------------------------------------------------
@@ -20,7 +39,7 @@ const visitorKeys = require("./visitor-keys");
 exports.version = require("./package.json").version;
 
 exports.parseForESLint = function parseForESLint(code, options) {
-    const ast = parse(code, options);
+    const ast = parse(code, formatOptions(options));
     traverser.traverse(ast, {
         enter: node => {
             if (node.type === "DeclareFunction" || node.type === "FunctionExpression" || node.type === "FunctionDeclaration") {
@@ -34,7 +53,7 @@ exports.parseForESLint = function parseForESLint(code, options) {
 };
 
 exports.parse = function(code, options) {
-    return this.parseForESLint(code, options).ast;
+    return this.parseForESLint(code, formatOptions(options)).ast;
 };
 
 // Deep copy.

--- a/parser.js
+++ b/parser.js
@@ -13,25 +13,6 @@ const astNodeTypes = require("typescript-estree").AST_NODE_TYPES;
 const traverser = require("eslint/lib/util/traverser");
 const visitorKeys = require("./visitor-keys");
 
-/**
- * Formats the parser options object for typescript-estree
- * @param {Object} options - ESLint parser options object
- * @returns {Object} formatted typescript-estree options object
- */
-function formatOptions(options) {
-    const formattedOptions = Object.assign({}, options);
-
-    if (options.ecmaFeatures) {
-        delete formattedOptions.ecmaFeatures;
-
-        if (options.ecmaFeatures.jsx) {
-            formattedOptions.jsx = options.ecmaFeatures.jsx;
-        }
-    }
-
-    return formattedOptions;
-}
-
 //------------------------------------------------------------------------------
 // Public
 //------------------------------------------------------------------------------
@@ -39,7 +20,7 @@ function formatOptions(options) {
 exports.version = require("./package.json").version;
 
 exports.parseForESLint = function parseForESLint(code, options) {
-    const ast = parse(code, formatOptions(options));
+    const ast = parse(code, options);
     traverser.traverse(ast, {
         enter: node => {
             if (node.type === "DeclareFunction" || node.type === "FunctionExpression" || node.type === "FunctionDeclaration") {
@@ -53,7 +34,7 @@ exports.parseForESLint = function parseForESLint(code, options) {
 };
 
 exports.parse = function(code, options) {
-    return this.parseForESLint(code, formatOptions(options)).ast;
+    return this.parseForESLint(code, options).ast;
 };
 
 // Deep copy.

--- a/tests/lib/__snapshots__/basics.js.snap
+++ b/tests/lib/__snapshots__/basics.js.snap
@@ -94,6 +94,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -499,6 +500,7 @@ Object {
       "type": "DoWhileStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -1177,6 +1179,7 @@ Object {
       "type": "FunctionDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -1544,6 +1547,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 17,
@@ -1712,6 +1716,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -1973,6 +1978,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 6,
@@ -2215,6 +2221,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -2515,6 +2522,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 4,
@@ -2974,6 +2982,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,

--- a/tests/lib/__snapshots__/ecma-features.js.snap
+++ b/tests/lib/__snapshots__/ecma-features.js.snap
@@ -98,6 +98,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 14,
@@ -416,6 +417,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 18,
@@ -715,6 +717,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 13,
@@ -1056,6 +1059,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -1626,6 +1630,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 13,
@@ -1925,6 +1930,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 19,
@@ -2189,6 +2195,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 13,
@@ -2517,6 +2524,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 32,
@@ -2853,6 +2861,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 27,
@@ -3207,6 +3216,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 30,
@@ -3507,6 +3517,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 26,
@@ -3771,6 +3782,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 24,
@@ -4071,6 +4083,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 35,
@@ -4407,6 +4420,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 30,
@@ -4743,6 +4757,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 30,
@@ -5061,6 +5076,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 30,
@@ -5307,6 +5323,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 25,
@@ -5536,6 +5553,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 6,
@@ -5783,6 +5801,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 9,
@@ -6051,6 +6070,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 24,
@@ -6351,6 +6371,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 17,
@@ -6651,6 +6672,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 18,
@@ -6951,6 +6973,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 16,
@@ -7125,6 +7148,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 11,
@@ -7317,6 +7341,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 16,
@@ -7563,6 +7588,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 10,
@@ -7814,6 +7840,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 13,
@@ -8137,6 +8164,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 29,
@@ -8599,6 +8627,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 12,
@@ -8773,6 +8802,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 14,
@@ -8982,6 +9012,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 15,
@@ -9153,6 +9184,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -9250,6 +9282,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -9384,6 +9417,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -9572,6 +9606,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -9854,6 +9889,7 @@ Object {
       "type": "SwitchStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -10414,6 +10450,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 32,
@@ -10931,6 +10968,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 26,
@@ -11262,6 +11300,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 11,
@@ -11545,6 +11584,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 24,
@@ -11900,6 +11940,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 22,
@@ -12256,6 +12297,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -12593,6 +12635,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 2,
@@ -13001,6 +13044,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -13428,6 +13472,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 24,
@@ -13820,6 +13865,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 35,
@@ -14229,6 +14275,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 29,
@@ -14795,6 +14842,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 59,
@@ -15516,6 +15564,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 39,
@@ -16165,6 +16214,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 21,
@@ -16690,6 +16740,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 48,
@@ -17249,6 +17300,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 22,
@@ -17790,6 +17842,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 24,
@@ -18367,6 +18420,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 23,
@@ -18926,6 +18980,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 56,
@@ -19407,6 +19462,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 26,
@@ -19782,6 +19838,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -20173,6 +20230,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -20505,6 +20563,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 28,
@@ -20782,6 +20841,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 20,
@@ -21022,6 +21082,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 11,
@@ -21208,6 +21269,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 11,
@@ -21394,6 +21456,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 12,
@@ -21616,6 +21679,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 21,
@@ -21821,6 +21885,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -22068,6 +22133,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -22364,6 +22430,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 13,
@@ -22604,6 +22671,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 22,
@@ -22979,6 +23047,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -23408,6 +23477,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -23761,6 +23831,7 @@ Object {
       "type": "FunctionDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 20,
@@ -24096,6 +24167,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 22,
@@ -24507,6 +24579,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 27,
@@ -24970,6 +25043,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 36,
@@ -25410,6 +25484,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 12,
@@ -25724,6 +25799,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 16,
@@ -26057,6 +26133,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 13,
@@ -26415,6 +26492,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -26953,6 +27031,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -27641,6 +27720,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -28257,6 +28337,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -28723,6 +28804,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -29261,6 +29343,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -29949,6 +30032,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -30565,6 +30649,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -30968,6 +31053,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 10,
@@ -31355,6 +31441,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 31,
@@ -32025,6 +32112,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 39,
@@ -32628,6 +32716,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 23,
@@ -33088,6 +33177,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 28,
@@ -33548,6 +33638,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 24,
@@ -33974,6 +34065,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 16,
@@ -34496,6 +34588,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 31,
@@ -34994,6 +35087,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 22,
@@ -35570,6 +35664,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 42,
@@ -36290,6 +36385,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 32,
@@ -36938,6 +37034,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 26,
@@ -37514,6 +37611,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 23,
@@ -38091,6 +38189,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 31,
@@ -38704,6 +38803,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 27,
@@ -39391,6 +39491,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 2,
@@ -40351,6 +40452,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 2,
@@ -41138,6 +41240,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -41544,6 +41647,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 31,
@@ -41976,6 +42080,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 31,
@@ -42836,6 +42941,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 53,
@@ -43514,6 +43620,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 15,
@@ -43850,6 +43957,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 13,
@@ -44150,6 +44258,7 @@ Object {
       "type": "FunctionDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 23,
@@ -44543,6 +44652,7 @@ Object {
       "type": "FunctionDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 23,
@@ -45104,6 +45214,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 39,
@@ -45619,6 +45730,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 23,
@@ -45990,6 +46102,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 25,
@@ -46436,6 +46549,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -46828,6 +46942,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 28,
@@ -47407,6 +47522,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 36,
@@ -48000,6 +48116,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 23,
@@ -48449,6 +48566,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 25,
@@ -48835,6 +48953,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 15,
@@ -49117,6 +49236,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 11,
@@ -49418,6 +49538,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 16,
@@ -49908,6 +50029,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 18,
@@ -50434,6 +50556,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 28,
@@ -50917,6 +51040,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 11,
@@ -51217,6 +51341,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 15,
@@ -51574,6 +51699,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 15,
@@ -52119,6 +52245,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 35,
@@ -52614,6 +52741,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 15,
@@ -52875,6 +53003,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 13,
@@ -53175,6 +53304,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 17,
@@ -53511,6 +53641,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 15,
@@ -53811,6 +53942,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 15,
@@ -54147,6 +54279,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 13,
@@ -54483,6 +54616,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 25,
@@ -55024,6 +55158,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 31,
@@ -55641,6 +55776,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 24,
@@ -56098,6 +56234,7 @@ Object {
       "type": "ForOfStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -56525,6 +56662,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 21,
@@ -56946,6 +57084,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -57389,6 +57528,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 31,
@@ -57960,6 +58100,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -58344,6 +58485,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 14,
@@ -58638,6 +58780,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 11,
@@ -59031,6 +59174,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 25,
@@ -59472,6 +59616,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 23,
@@ -59876,6 +60021,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 18,
@@ -60190,6 +60336,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 15,
@@ -60416,6 +60563,7 @@ Object {
       "type": "FunctionDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -60753,6 +60901,7 @@ Object {
       "type": "FunctionDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -61229,6 +61378,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -61603,6 +61753,7 @@ Object {
       "type": "FunctionDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -62101,6 +62252,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -62508,6 +62660,7 @@ Object {
       "type": "FunctionDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -62938,6 +63091,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -63653,6 +63807,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -64569,6 +64724,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -65328,6 +65484,26 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 45,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        61,
+        98,
+      ],
+      "type": "Line",
+      "value": " ... do some stuff with options ...",
+    },
+  ],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -65997,6 +66173,26 @@ Object {
         114,
       ],
       "type": "VariableDeclaration",
+    },
+  ],
+  "comments": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 45,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        68,
+        105,
+      ],
+      "type": "Line",
+      "value": " ... do some stuff with options ...",
     },
   ],
   "loc": Object {
@@ -66717,6 +66913,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -67435,6 +67632,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -68059,6 +68257,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -68611,6 +68810,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -69104,6 +69304,7 @@ Object {
       "type": "TryStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -69326,6 +69527,7 @@ Object {
       "type": "TryStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -69696,6 +69898,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -70195,6 +70398,7 @@ Object {
       "type": "ForOfStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -70798,6 +71002,7 @@ Object {
       "type": "ForOfStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -71202,6 +71407,7 @@ Object {
       "type": "ForOfStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -71570,6 +71776,7 @@ Object {
       "type": "ForOfStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -71938,6 +72145,7 @@ Object {
       "type": "ForOfStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -72272,6 +72480,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 27,
@@ -72552,6 +72761,7 @@ Object {
       "type": "FunctionDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -72964,6 +73174,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -73479,6 +73690,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 34,
@@ -73794,6 +74006,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 17,
@@ -74091,6 +74304,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 31,
@@ -74425,6 +74639,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 28,
@@ -74760,6 +74975,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -75114,6 +75330,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -75485,6 +75702,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -75725,6 +75943,7 @@ Object {
       "type": "ReturnStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -75822,6 +76041,7 @@ Object {
       "type": "ReturnStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -75919,6 +76139,7 @@ Object {
       "type": "ReturnStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -76104,6 +76325,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -76364,6 +76586,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -76626,6 +76849,7 @@ Object {
       "type": "FunctionDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -77066,6 +77290,7 @@ Object {
       "type": "WithStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -77450,6 +77675,7 @@ Object {
       "type": "ExportDefaultDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -77619,6 +77845,7 @@ Object {
       "type": "ExportDefaultDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -77807,6 +78034,7 @@ Object {
       "type": "ExportDefaultDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -78033,6 +78261,7 @@ Object {
       "type": "ExportDefaultDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -78255,6 +78484,7 @@ Object {
       "type": "ExportDefaultDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -78462,6 +78692,7 @@ Object {
       "type": "ExportDefaultDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -78667,6 +78898,7 @@ Object {
       "type": "ExportDefaultDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -78858,6 +79090,7 @@ Object {
       "type": "ExportDefaultDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -79062,6 +79295,7 @@ Object {
       "type": "ExportDefaultDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -79195,6 +79429,7 @@ Object {
       "type": "ExportAllDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -79402,6 +79637,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -79645,6 +79881,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -79924,6 +80161,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -80256,6 +80494,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -80571,6 +80810,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -80867,6 +81107,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -81130,6 +81371,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -81355,6 +81597,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -81580,6 +81823,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -81858,6 +82102,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -82118,6 +82363,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -82253,6 +82499,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -82424,6 +82671,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -82666,6 +82914,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -82944,6 +83193,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -83188,6 +83438,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -83399,6 +83650,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -83697,6 +83949,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -83903,6 +84156,7 @@ Object {
       "type": "ImportDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -84144,6 +84398,7 @@ Object {
       "type": "ImportDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -84439,6 +84694,7 @@ Object {
       "type": "ImportDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -84717,6 +84973,7 @@ Object {
       "type": "ImportDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -84977,6 +85234,7 @@ Object {
       "type": "ImportDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -85111,6 +85369,7 @@ Object {
       "type": "ImportDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -85281,6 +85540,7 @@ Object {
       "type": "ImportDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -85612,6 +85872,7 @@ Object {
       "type": "ImportDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -85872,6 +86133,7 @@ Object {
       "type": "ImportDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -86096,6 +86358,7 @@ Object {
       "type": "ImportDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -86391,6 +86654,7 @@ Object {
       "type": "ImportDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -86722,6 +86986,7 @@ Object {
       "type": "ImportDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -87000,6 +87265,7 @@ Object {
       "type": "ImportDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -87242,6 +87508,7 @@ Object {
       "type": "ImportDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -87486,6 +87753,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -87637,6 +87905,7 @@ Object {
       "type": "ExportDefaultDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -87836,6 +88105,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -88017,6 +88287,7 @@ Object {
       "type": "ImportDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -88225,6 +88496,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -88480,6 +88752,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -88797,6 +89070,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -89204,6 +89478,7 @@ Object {
       "type": "FunctionDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -89632,6 +89907,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -90043,6 +90319,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 19,
@@ -90533,6 +90810,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 32,
@@ -91104,6 +91382,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -91458,6 +91737,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -91779,6 +92059,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -92116,6 +92397,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -92472,6 +92754,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -93046,6 +93329,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 2,
@@ -93748,6 +94032,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 2,
@@ -94377,6 +94662,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 2,
@@ -94900,6 +95186,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 2,
@@ -95386,6 +95673,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -95831,6 +96119,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 3,
@@ -96222,6 +96511,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 3,
@@ -96613,6 +96903,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 3,
@@ -97023,6 +97314,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 3,
@@ -97433,6 +97725,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 3,
@@ -97846,6 +98139,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -98496,6 +98790,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -98883,6 +99178,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -99016,6 +99312,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -99149,6 +99446,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -99288,6 +99586,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -99485,6 +99784,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -99682,6 +99982,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -99879,6 +100180,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -100076,6 +100378,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -100323,6 +100626,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 23,
@@ -100715,6 +101019,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -101107,6 +101412,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -101424,6 +101730,7 @@ Object {
       "type": "TSEmptyBodyFunctionDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 24,
@@ -101759,6 +102066,7 @@ Object {
       "type": "TSEmptyBodyFunctionDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 23,
@@ -102113,6 +102421,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 27,
@@ -102485,6 +102794,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 29,
@@ -102912,6 +103222,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 23,
@@ -103245,6 +103556,7 @@ Object {
       "type": "EmptyStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 20,
@@ -103543,6 +103855,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 13,
@@ -103819,6 +104132,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 14,
@@ -104077,6 +104391,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 10,
@@ -104470,6 +104785,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -104734,6 +105050,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -104894,6 +105211,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 40,
@@ -105334,6 +105652,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 31,
@@ -105752,6 +106071,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 13,
@@ -105877,6 +106197,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 5,
@@ -106035,6 +106356,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 13,
@@ -106244,6 +106566,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -106664,6 +106987,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 32,
@@ -107085,6 +107409,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 19,
@@ -107182,6 +107507,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 27,

--- a/tests/lib/__snapshots__/jsx.js.snap
+++ b/tests/lib/__snapshots__/jsx.js.snap
@@ -291,6 +291,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 45,
@@ -1036,6 +1037,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -1621,6 +1623,26 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 27,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        4,
+        27,
+      ],
+      "type": "Block",
+      "value": " this is a comment ",
+    },
+  ],
   "loc": Object {
     "end": Object {
       "column": 33,
@@ -2099,6 +2121,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 28,
@@ -2667,6 +2690,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 42,
@@ -3068,6 +3092,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 10,
@@ -3742,6 +3767,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 84,
@@ -4426,6 +4452,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 12,
@@ -4704,6 +4731,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 14,
@@ -5068,6 +5096,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -5542,6 +5571,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -5982,6 +6012,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 12,
@@ -6244,6 +6275,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 6,
@@ -6565,6 +6597,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -6991,6 +7024,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -7413,6 +7447,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 36,
@@ -7763,6 +7798,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 19,
@@ -8127,6 +8163,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 12,
@@ -8615,6 +8652,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 16,
@@ -9055,6 +9093,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 25,
@@ -9493,6 +9532,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 54,
@@ -9970,6 +10010,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 24,
@@ -10345,6 +10386,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -10733,6 +10775,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 25,

--- a/tests/lib/__snapshots__/tsx.js.snap
+++ b/tests/lib/__snapshots__/tsx.js.snap
@@ -185,6 +185,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -1010,6 +1011,7 @@ Object {
       "type": "ExportDefaultDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,

--- a/tests/lib/__snapshots__/typescript.js.snap
+++ b/tests/lib/__snapshots__/typescript.js.snap
@@ -98,6 +98,7 @@ Object {
       },
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 24,
@@ -413,6 +414,7 @@ Object {
       },
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 42,
@@ -807,6 +809,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,
@@ -1253,6 +1256,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,
@@ -1715,6 +1719,7 @@ Object {
       "type": "TSAbstractClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -2087,6 +2092,7 @@ Object {
       "type": "TSAbstractClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -2552,6 +2558,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,
@@ -2939,6 +2946,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,
@@ -3325,6 +3333,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,
@@ -3730,6 +3739,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 5,
@@ -4251,6 +4261,7 @@ Object {
       "type": "FunctionDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -5262,6 +5273,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -6153,6 +6165,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -6544,6 +6557,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -6911,6 +6925,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -7242,6 +7257,7 @@ Object {
       },
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -7715,6 +7731,7 @@ Object {
       },
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -8198,6 +8215,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -8644,6 +8662,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -9012,6 +9031,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -9253,6 +9273,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -9567,6 +9588,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -9934,6 +9956,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -11023,6 +11046,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -12313,6 +12337,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -12864,6 +12889,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -13562,6 +13588,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -14023,6 +14050,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -14716,6 +14744,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,
@@ -15841,6 +15870,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,
@@ -16966,6 +16996,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,
@@ -17913,6 +17944,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,
@@ -18411,6 +18443,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -18820,6 +18853,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -19170,6 +19204,7 @@ Object {
       },
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -19447,6 +19482,7 @@ Object {
       },
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -19725,6 +19761,7 @@ Object {
       },
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -20003,6 +20040,7 @@ Object {
       "type": "TSEnumDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,
@@ -20359,6 +20397,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,
@@ -20727,6 +20766,7 @@ Object {
       "type": "TSEmptyBodyDeclareFunction",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 42,
@@ -21114,6 +21154,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 21,
@@ -21372,6 +21413,7 @@ Object {
       "type": "TSExportAssignment",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -21560,6 +21602,7 @@ Object {
       "type": "ExportDefaultDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -21838,6 +21881,7 @@ Object {
       "type": "ExportDefaultDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -22153,6 +22197,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -22450,6 +22495,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -22800,6 +22846,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,
@@ -23132,6 +23179,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 40,
@@ -23464,6 +23512,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 2,
@@ -23849,6 +23898,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 47,
@@ -24219,6 +24269,7 @@ Object {
       "type": "FunctionDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -24777,6 +24828,7 @@ Object {
       "type": "FunctionDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -25513,6 +25565,7 @@ Object {
       "type": "FunctionDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -26133,6 +26186,7 @@ Object {
       },
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -26556,6 +26610,26 @@ Object {
         ],
         "type": "TSTypeParameterDeclaration",
       },
+    },
+  ],
+  "comments": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 28,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        17,
+        28,
+      ],
+      "type": "Block",
+      "value": "comment",
     },
   ],
   "loc": Object {
@@ -27016,6 +27090,7 @@ Object {
       },
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -27581,6 +27656,7 @@ Object {
       "type": "FunctionDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -28249,6 +28325,7 @@ Object {
       "type": "FunctionDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -29070,6 +29147,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -29708,6 +29786,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -30112,6 +30191,7 @@ Object {
       "type": "TSInterfaceDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -30371,6 +30451,7 @@ Object {
       "type": "TSInterfaceDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -30632,6 +30713,7 @@ Object {
       },
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -32041,6 +32123,7 @@ Object {
       "type": "TSInterfaceDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -34230,6 +34313,7 @@ Object {
       "type": "TSInterfaceDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -34671,6 +34755,7 @@ Object {
       },
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -35004,6 +35089,7 @@ Object {
       },
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -35268,6 +35354,29 @@ Object {
         87,
       ],
       "type": "TSInterfaceDeclaration",
+    },
+  ],
+  "comments": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 4,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        21,
+        71,
+      ],
+      "type": "Block",
+      "value": "*
+     * Comment Line 1
+     * @baz bar 
+     ",
     },
   ],
   "loc": Object {
@@ -35752,6 +35861,7 @@ Object {
       "type": "TSInterfaceDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -36337,6 +36447,7 @@ Object {
       "type": "TSInterfaceDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -36578,6 +36689,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -36963,6 +37075,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 44,
@@ -37491,6 +37604,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -38150,6 +38264,7 @@ Object {
       "type": "FunctionDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,
@@ -38769,6 +38884,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 17,
@@ -39392,6 +39508,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -40228,6 +40345,7 @@ Object {
       "type": "FunctionDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 42,
@@ -40740,6 +40858,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 37,
@@ -41234,6 +41353,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 48,
@@ -41709,6 +41829,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -42220,6 +42341,7 @@ Object {
       "type": "FunctionDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,
@@ -42897,6 +43019,116 @@ Object {
         ],
         "type": "TSTypeParameterDeclaration",
       },
+    },
+  ],
+  "comments": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 20,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        5,
+        20,
+      ],
+      "type": "Block",
+      "value": " comment 1 ",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 38,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        23,
+        38,
+      ],
+      "type": "Block",
+      "value": " comment 2 ",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 23,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        58,
+        67,
+      ],
+      "type": "Block",
+      "value": " aaa ",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 35,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 26,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        70,
+        79,
+      ],
+      "type": "Block",
+      "value": " bbb ",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 23,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        102,
+        111,
+      ],
+      "type": "Block",
+      "value": " aaa ",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 35,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 26,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        114,
+        123,
+      ],
+      "type": "Block",
+      "value": " bbb ",
     },
   ],
   "loc": Object {
@@ -43626,6 +43858,26 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 49,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 34,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        58,
+        73,
+      ],
+      "type": "Block",
+      "value": "AudioBuffer",
+    },
+  ],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -44226,6 +44478,7 @@ Object {
       "type": "TSInterfaceDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -44755,6 +45008,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -45161,6 +45415,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -45688,6 +45943,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -46091,6 +46347,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -46458,6 +46715,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 22,
@@ -46852,6 +47110,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,
@@ -47574,6 +47833,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,
@@ -48290,6 +48550,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,
@@ -48917,6 +49178,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,
@@ -49393,6 +49655,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 12,
@@ -49713,6 +49976,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 21,
@@ -50198,6 +50462,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -50683,6 +50948,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -51148,6 +51414,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -51541,6 +51808,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -52203,6 +52471,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -52939,6 +53208,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -53531,6 +53801,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -54213,6 +54484,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -54949,6 +55221,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -55646,6 +55919,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,
@@ -56330,6 +56604,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,
@@ -56920,6 +57195,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,
@@ -57366,6 +57642,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -57697,6 +57974,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -57903,6 +58181,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -58126,6 +58405,7 @@ Object {
       "type": "ClassDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -58350,6 +58630,7 @@ Object {
       "type": "TSEnumDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 14,
@@ -58593,6 +58874,7 @@ Object {
       "type": "TSInterfaceDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 14,
@@ -58888,6 +59170,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 16,
@@ -59197,6 +59480,7 @@ Object {
       "type": "ExportNamedDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 72,
@@ -59493,6 +59777,7 @@ Object {
       "type": "TSInterfaceDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -61569,6 +61854,7 @@ Object {
       "type": "TSInterfaceDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -64562,6 +64848,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 14,
@@ -64984,6 +65271,7 @@ Object {
       "type": "VariableDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 21,
@@ -65355,6 +65643,7 @@ Object {
       "type": "ExpressionStatement",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 14,
@@ -65617,6 +65906,7 @@ Object {
       "type": "TSModuleDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -66077,6 +66367,7 @@ Object {
       "type": "TSModuleDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,
@@ -66775,6 +67066,7 @@ Object {
       "type": "TSModuleDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,
@@ -67926,6 +68218,7 @@ Object {
       "type": "TSModuleDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 1,
@@ -68744,6 +69037,7 @@ Object {
       "type": "TSModuleDeclaration",
     },
   ],
+  "comments": Array [],
   "loc": Object {
     "end": Object {
       "column": 0,

--- a/tests/lib/basics.js
+++ b/tests/lib/basics.js
@@ -37,14 +37,8 @@ describe("basics", () => {
         // Uncomment and fill in filename to focus on a single file
         // var filename = "jsx/invalid-matching-placeholder-in-closing-tag";
         const code = shelljs.cat(`${path.resolve(FIXTURES_DIR, filename)}.src.js`);
-        const config = {
-            loc: true,
-            range: true,
-            tokens: true,
-            ecmaFeatures: {},
-            errorOnUnknownASTType: true
-        };
-        test(`fixtures/${filename}.src`, testUtils.createSnapshotTestBlock(code, config));
+
+        test(`fixtures/${filename}.src`, testUtils.createSnapshotTestBlock(code));
     });
 
 });

--- a/tests/lib/basics.js
+++ b/tests/lib/basics.js
@@ -32,13 +32,8 @@ const testFiles = shelljs.find(FIXTURES_DIR)
 //------------------------------------------------------------------------------
 
 describe("basics", () => {
-
     testFiles.forEach(filename => {
-        // Uncomment and fill in filename to focus on a single file
-        // var filename = "jsx/invalid-matching-placeholder-in-closing-tag";
         const code = shelljs.cat(`${path.resolve(FIXTURES_DIR, filename)}.src.js`);
-
         test(`fixtures/${filename}.src`, testUtils.createSnapshotTestBlock(code));
     });
-
 });

--- a/tests/lib/comments.js
+++ b/tests/lib/comments.js
@@ -32,7 +32,6 @@ const testFiles = shelljs.find(FIXTURES_DIR)
 //------------------------------------------------------------------------------
 
 describe("Comments", () => {
-
     testFiles.forEach(filename => {
         const code = shelljs.cat(`${path.resolve(FIXTURES_DIR, filename)}.src.js`);
         const config = {
@@ -40,5 +39,4 @@ describe("Comments", () => {
         };
         test(`fixtures/${filename}.src`, testUtils.createSnapshotTestBlock(code, config));
     });
-
 });

--- a/tests/lib/comments.js
+++ b/tests/lib/comments.js
@@ -36,13 +36,7 @@ describe("Comments", () => {
     testFiles.forEach(filename => {
         const code = shelljs.cat(`${path.resolve(FIXTURES_DIR, filename)}.src.js`);
         const config = {
-            loc: true,
-            range: true,
-            tokens: true,
-            comment: true,
-            ecmaFeatures: {
-                jsx: true
-            }
+            jsx: true
         };
         test(`fixtures/${filename}.src`, testUtils.createSnapshotTestBlock(code, config));
     });

--- a/tests/lib/ecma-features.js
+++ b/tests/lib/ecma-features.js
@@ -32,15 +32,8 @@ const testFiles = shelljs.find(FIXTURES_DIR)
 //------------------------------------------------------------------------------
 
 describe("ecmaFeatures", () => {
-
     testFiles.forEach(filename => {
-
-        // Uncomment and fill in filename to focus on a single file
-        // var filename = "jsx/invalid-matching-placeholder-in-closing-tag";
         const code = shelljs.cat(`${path.resolve(FIXTURES_DIR, filename)}.src.js`);
-
-        test(`fixtures/${filename}.src`, () => {
-            testUtils.createSnapshotTestBlock(code)();
-        });
+        test(`fixtures/${filename}.src`, testUtils.createSnapshotTestBlock(code));
     });
 });

--- a/tests/lib/ecma-features.js
+++ b/tests/lib/ecma-features.js
@@ -37,19 +37,10 @@ describe("ecmaFeatures", () => {
 
         // Uncomment and fill in filename to focus on a single file
         // var filename = "jsx/invalid-matching-placeholder-in-closing-tag";
-        const feature = path.dirname(filename),
-            code = shelljs.cat(`${path.resolve(FIXTURES_DIR, filename)}.src.js`),
-            config = {
-                loc: true,
-                range: true,
-                tokens: true,
-                ecmaFeatures: {},
-                errorOnUnknownASTType: true
-            };
+        const code = shelljs.cat(`${path.resolve(FIXTURES_DIR, filename)}.src.js`);
 
         test(`fixtures/${filename}.src`, () => {
-            config.ecmaFeatures[feature] = true;
-            testUtils.createSnapshotTestBlock(code, config)();
+            testUtils.createSnapshotTestBlock(code)();
         });
     });
 });

--- a/tests/lib/jsx.js
+++ b/tests/lib/jsx.js
@@ -56,14 +56,8 @@ describe("JSX", () => {
             const code = shelljs.cat(`${path.resolve(fixturesDir, filename)}.src.js`);
 
             const config = {
-                loc: true,
-                range: true,
-                tokens: true,
-                errorOnUnknownASTType: true,
                 useJSXTextNode,
-                ecmaFeatures: {
-                    jsx: true
-                }
+                jsx: true
             };
 
             test(`fixtures/${filename}.src`, testUtils.createSnapshotTestBlock(code, config));

--- a/tests/lib/jsx.js
+++ b/tests/lib/jsx.js
@@ -51,15 +51,11 @@ describe("JSX", () => {
     function testFixture(fixturesDir, useJSXTextNode) {
 
         return filename => {
-            // Uncomment and fill in filename to focus on a single file
-            // var filename = "jsx/invalid-matching-placeholder-in-closing-tag";
             const code = shelljs.cat(`${path.resolve(fixturesDir, filename)}.src.js`);
-
             const config = {
                 useJSXTextNode,
                 jsx: true
             };
-
             test(`fixtures/${filename}.src`, testUtils.createSnapshotTestBlock(code, config));
         };
     }

--- a/tests/lib/tsx.js
+++ b/tests/lib/tsx.js
@@ -36,14 +36,8 @@ describe("TSX", () => {
         // var filename = "jsx/invalid-matching-placeholder-in-closing-tag";
         const code = shelljs.cat(`${path.resolve(TSX_FIXTURES_DIR, filename)}.src.tsx`);
         const config = {
-            loc: true,
-            range: true,
-            tokens: true,
-            errorOnUnknownASTType: true,
             useJSXTextNode: true,
-            ecmaFeatures: {
-                jsx: true
-            }
+            jsx: true
         };
         test(`fixtures/${filename}.src`, testUtils.createSnapshotTestBlock(code, config));
     });

--- a/tests/lib/tsx.js
+++ b/tests/lib/tsx.js
@@ -32,8 +32,6 @@ const testFiles = shelljs.find(TSX_FIXTURES_DIR)
 
 describe("TSX", () => {
     testFiles.forEach(filename => {
-        // Uncomment and fill in filename to focus on a single file
-        // var filename = "jsx/invalid-matching-placeholder-in-closing-tag";
         const code = shelljs.cat(`${path.resolve(TSX_FIXTURES_DIR, filename)}.src.tsx`);
         const config = {
             useJSXTextNode: true,

--- a/tests/lib/typescript.js
+++ b/tests/lib/typescript.js
@@ -37,14 +37,7 @@ describe("typescript", () => {
         // Uncomment and fill in filename to focus on a single file
         // var filename = "jsx/invalid-matching-placeholder-in-closing-tag";
         const code = shelljs.cat(`${path.resolve(FIXTURES_DIR, filename)}.src.ts`);
-        const config = {
-            loc: true,
-            range: true,
-            tokens: true,
-            ecmaFeatures: {},
-            errorOnUnknownASTType: true
-        };
-        test(`fixtures/${filename}.src`, testUtils.createSnapshotTestBlock(code, config));
+        test(`fixtures/${filename}.src`, testUtils.createSnapshotTestBlock(code));
     });
 
 });

--- a/tests/lib/typescript.js
+++ b/tests/lib/typescript.js
@@ -34,8 +34,6 @@ const testFiles = shelljs.find(FIXTURES_DIR)
 describe("typescript", () => {
 
     testFiles.forEach(filename => {
-        // Uncomment and fill in filename to focus on a single file
-        // var filename = "jsx/invalid-matching-placeholder-in-closing-tag";
         const code = shelljs.cat(`${path.resolve(FIXTURES_DIR, filename)}.src.ts`);
         test(`fixtures/${filename}.src`, testUtils.createSnapshotTestBlock(code));
     });

--- a/tools/test-utils.js
+++ b/tools/test-utils.js
@@ -41,7 +41,16 @@ function getRaw(ast) {
  * @param {*} config the parser configuration
  * @returns {Function} callback for Jest test() block
  */
-function createSnapshotTestBlock(code, config) {
+function createSnapshotTestBlock(code, config = {}) {
+    const defaultConfig = {
+        loc: true,
+        range: true,
+        raw: true,
+        tokens: true,
+        comment: true,
+        errorOnUnknownASTType: true
+    };
+    config = Object.assign({}, defaultConfig, config);
 
     /**
      * @returns {Object} the AST object


### PR DESCRIPTION
Following up on https://github.com/JamesHenry/typescript-estree/pull/22, this updates to the latest version of typescript-estree.

Looks like it might also fix https://github.com/eslint/typescript-eslint-parser/issues/503.

I think we should remove support for `ecmaFeatures` in the options and add individual feature flags if we need them in the future (which seems unlikely). Thoughts?