### PR TITLE
Chore: test Node v11 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ node_js:
     - "8"
     - "9"
     - "10"
+    - "11"
 
 script: npm test && npm run integration-tests
 


### PR DESCRIPTION
Now that Node v11 is officially in development, we should probably start testing it.