### PR TITLE
Breaking: switch 'jsx' option by filename (fixes #517)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,12 @@ By far the most common case will be installing the [eslint-plugin-typescript](ht
 
 The following additional configuration options are available by specifying them in [`parserOptions`](https://eslint.org/docs/user-guide/configuring#specifying-parser-options) in your ESLint configuration file.
 
-**`jsx`** - default `false`. It's `true` on `*.tsx` files automatically. Enable parsing JSX when `true`. More details can be found [here](https://www.typescriptlang.org/docs/handbook/jsx.html).
+- **`jsx`** - default `false`. Enable parsing JSX when `true`. More details can be found [here](https://www.typescriptlang.org/docs/handbook/jsx.html).
+    - It's `false` on `*.ts` files regardless of this option.
+    - It's `true` on `*.tsx` files regardless of this option.
+    - Otherwise, it respects this option.
 
-**`useJSXTextNode`** - default `false`. The JSX AST changed the node type for string literals inside a JSX Element from `Literal` to `JSXText`. When value is `true`, these nodes will be parsed as type `JSXText`. When value is `false`, these nodes will be parsed as type `Literal`.
+- **`useJSXTextNode`** - default `false`. The JSX AST changed the node type for string literals inside a JSX Element from `Literal` to `JSXText`. When value is `true`, these nodes will be parsed as type `JSXText`. When value is `false`, these nodes will be parsed as type `Literal`.
 
 ### .eslintrc.json
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ By far the most common case will be installing the [eslint-plugin-typescript](ht
 
 The following additional configuration options are available by specifying them in [`parserOptions`](https://eslint.org/docs/user-guide/configuring#specifying-parser-options) in your ESLint configuration file.
 
-**`jsx`** - default `false`. Enable parsing JSX when `true`. More details can be found [here](https://www.typescriptlang.org/docs/handbook/jsx.html).
+**`jsx`** - default `false`. It's `true` on `*.tsx` files automatically. Enable parsing JSX when `true`. More details can be found [here](https://www.typescriptlang.org/docs/handbook/jsx.html).
 
 **`useJSXTextNode`** - default `false`. The JSX AST changed the node type for string literals inside a JSX Element from `Literal` to `JSXText`. When value is `true`, these nodes will be parsed as type `JSXText`. When value is `false`, these nodes will be parsed as type `Literal`.
 

--- a/parser.js
+++ b/parser.js
@@ -20,8 +20,11 @@ const visitorKeys = require("./visitor-keys");
 exports.version = require("./package.json").version;
 
 exports.parseForESLint = function parseForESLint(code, options) {
-    if (options && typeof options.filePath === "string" && options.filePath.endsWith(".tsx")) {
-        options = Object.assign({}, options, { jsx: true });
+    if (options && typeof options.filePath === "string") {
+        const tsx = options.filePath.endsWith(".tsx");
+        if (tsx || options.filePath.endsWith(".ts")) {
+            options = Object.assign({}, options, { jsx: tsx });
+        }
     }
 
     const ast = parse(code, options);

--- a/parser.js
+++ b/parser.js
@@ -21,7 +21,7 @@ exports.version = require("./package.json").version;
 
 exports.parseForESLint = function parseForESLint(code, options) {
     if (options && typeof options.filePath === "string" && options.filePath.endsWith(".tsx")) {
-        options.jsx = true;
+        options = Object.assign({}, options, { jsx: true });
     }
 
     const ast = parse(code, options);

--- a/parser.js
+++ b/parser.js
@@ -20,6 +20,10 @@ const visitorKeys = require("./visitor-keys");
 exports.version = require("./package.json").version;
 
 exports.parseForESLint = function parseForESLint(code, options) {
+    if (options && typeof options.filePath === "string" && options.filePath.endsWith(".tsx")) {
+        options.jsx = true;
+    }
+
     const ast = parse(code, options);
     traverser.traverse(ast, {
         enter: node => {

--- a/tests/lib/tsx.js
+++ b/tests/lib/tsx.js
@@ -48,7 +48,7 @@ describe("TSX", () => {
         const linter = new Linter();
         linter.defineParser("typescript-eslint-parser", parser);
 
-        test("anonymous", () => {
+        test("filePath was not provided", () => {
             const code = "const element = <T/>";
             const config = {
                 parser: "typescript-eslint-parser"
@@ -67,6 +67,19 @@ describe("TSX", () => {
                     source: "const element = <T/>"
                 }]
             );
+        });
+
+        test("filePath was not provided and 'jsx:true' option", () => {
+            const code = "const element = <T/>";
+            const config = {
+                parser: "typescript-eslint-parser",
+                parserOptions: {
+                    jsx: true
+                }
+            };
+            const messages = linter.verify(code, config);
+
+            assert.deepStrictEqual(messages, []);
         });
 
         test("test.ts", () => {
@@ -90,7 +103,7 @@ describe("TSX", () => {
             );
         });
 
-        test("test.ts with 'jsx' option", () => {
+        test("test.ts with 'jsx:true' option", () => {
             const code = "const element = <T/>";
             const config = {
                 parser: "typescript-eslint-parser",
@@ -100,13 +113,37 @@ describe("TSX", () => {
             };
             const messages = linter.verify(code, config, { filename: "test.ts" });
 
-            assert.deepStrictEqual(messages, []);
+            assert.deepStrictEqual(
+                messages,
+                [{
+                    column: 18,
+                    fatal: true,
+                    line: 1,
+                    message: "Parsing error: '>' expected.",
+                    ruleId: null,
+                    severity: 2,
+                    source: "const element = <T/>"
+                }]
+            );
         });
 
         test("test.tsx", () => {
             const code = "const element = <T/>";
             const config = {
                 parser: "typescript-eslint-parser"
+            };
+            const messages = linter.verify(code, config, { filename: "test.tsx" });
+
+            assert.deepStrictEqual(messages, []);
+        });
+
+        test("test.tsx with 'jsx:false' option", () => {
+            const code = "const element = <T/>";
+            const config = {
+                parser: "typescript-eslint-parser",
+                parserOptions: {
+                    jsx: false
+                }
             };
             const messages = linter.verify(code, config, { filename: "test.tsx" });
 

--- a/tests/lib/tsx.js
+++ b/tests/lib/tsx.js
@@ -12,7 +12,6 @@
 //------------------------------------------------------------------------------
 
 const
-    assert = require("assert"),
     path = require("path"),
     { Linter } = require("eslint"),
     shelljs = require("shelljs"),
@@ -55,18 +54,15 @@ describe("TSX", () => {
             };
             const messages = linter.verify(code, config);
 
-            assert.deepStrictEqual(
-                messages,
-                [{
-                    column: 18,
-                    fatal: true,
-                    line: 1,
-                    message: "Parsing error: '>' expected.",
-                    ruleId: null,
-                    severity: 2,
-                    source: "const element = <T/>"
-                }]
-            );
+            expect(messages).toStrictEqual([{
+                column: 18,
+                fatal: true,
+                line: 1,
+                message: "Parsing error: '>' expected.",
+                ruleId: null,
+                severity: 2,
+                source: "const element = <T/>"
+            }]);
         });
 
         test("filePath was not provided and 'jsx:true' option", () => {
@@ -79,7 +75,7 @@ describe("TSX", () => {
             };
             const messages = linter.verify(code, config);
 
-            assert.deepStrictEqual(messages, []);
+            expect(messages).toStrictEqual([]);
         });
 
         test("test.ts", () => {
@@ -89,18 +85,15 @@ describe("TSX", () => {
             };
             const messages = linter.verify(code, config, { filename: "test.ts" });
 
-            assert.deepStrictEqual(
-                messages,
-                [{
-                    column: 18,
-                    fatal: true,
-                    line: 1,
-                    message: "Parsing error: '>' expected.",
-                    ruleId: null,
-                    severity: 2,
-                    source: "const element = <T/>"
-                }]
-            );
+            expect(messages).toStrictEqual([{
+                column: 18,
+                fatal: true,
+                line: 1,
+                message: "Parsing error: '>' expected.",
+                ruleId: null,
+                severity: 2,
+                source: "const element = <T/>"
+            }]);
         });
 
         test("test.ts with 'jsx:true' option", () => {
@@ -113,18 +106,15 @@ describe("TSX", () => {
             };
             const messages = linter.verify(code, config, { filename: "test.ts" });
 
-            assert.deepStrictEqual(
-                messages,
-                [{
-                    column: 18,
-                    fatal: true,
-                    line: 1,
-                    message: "Parsing error: '>' expected.",
-                    ruleId: null,
-                    severity: 2,
-                    source: "const element = <T/>"
-                }]
-            );
+            expect(messages).toStrictEqual([{
+                column: 18,
+                fatal: true,
+                line: 1,
+                message: "Parsing error: '>' expected.",
+                ruleId: null,
+                severity: 2,
+                source: "const element = <T/>"
+            }]);
         });
 
         test("test.tsx", () => {
@@ -134,7 +124,7 @@ describe("TSX", () => {
             };
             const messages = linter.verify(code, config, { filename: "test.tsx" });
 
-            assert.deepStrictEqual(messages, []);
+            expect(messages).toStrictEqual([]);
         });
 
         test("test.tsx with 'jsx:false' option", () => {
@@ -147,7 +137,7 @@ describe("TSX", () => {
             };
             const messages = linter.verify(code, config, { filename: "test.tsx" });
 
-            assert.deepStrictEqual(messages, []);
+            expect(messages).toStrictEqual([]);
         });
     });
 });

--- a/tests/lib/tsx.js
+++ b/tests/lib/tsx.js
@@ -11,8 +11,12 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const path = require("path"),
+const
+    assert = require("assert"),
+    path = require("path"),
+    { Linter } = require("eslint"),
     shelljs = require("shelljs"),
+    parser = require("../../"),
     testUtils = require("../../tools/test-utils");
 
 //------------------------------------------------------------------------------
@@ -38,5 +42,75 @@ describe("TSX", () => {
             jsx: true
         };
         test(`fixtures/${filename}.src`, testUtils.createSnapshotTestBlock(code, config));
+    });
+
+    describe("if the filename ends with '.tsx', enable jsx option automatically.", () => {
+        const linter = new Linter();
+        linter.defineParser("typescript-eslint-parser", parser);
+
+        test("anonymous", () => {
+            const code = "const element = <T/>";
+            const config = {
+                parser: "typescript-eslint-parser"
+            };
+            const messages = linter.verify(code, config);
+
+            assert.deepStrictEqual(
+                messages,
+                [{
+                    column: 18,
+                    fatal: true,
+                    line: 1,
+                    message: "Parsing error: '>' expected.",
+                    ruleId: null,
+                    severity: 2,
+                    source: "const element = <T/>"
+                }]
+            );
+        });
+
+        test("test.ts", () => {
+            const code = "const element = <T/>";
+            const config = {
+                parser: "typescript-eslint-parser"
+            };
+            const messages = linter.verify(code, config, { filename: "test.ts" });
+
+            assert.deepStrictEqual(
+                messages,
+                [{
+                    column: 18,
+                    fatal: true,
+                    line: 1,
+                    message: "Parsing error: '>' expected.",
+                    ruleId: null,
+                    severity: 2,
+                    source: "const element = <T/>"
+                }]
+            );
+        });
+
+        test("test.ts with 'jsx' option", () => {
+            const code = "const element = <T/>";
+            const config = {
+                parser: "typescript-eslint-parser",
+                parserOptions: {
+                    jsx: true
+                }
+            };
+            const messages = linter.verify(code, config, { filename: "test.ts" });
+
+            assert.deepStrictEqual(messages, []);
+        });
+
+        test("test.tsx", () => {
+            const code = "const element = <T/>";
+            const config = {
+                parser: "typescript-eslint-parser"
+            };
+            const messages = linter.verify(code, config, { filename: "test.tsx" });
+
+            assert.deepStrictEqual(messages, []);
+        });
     });
 });


### PR DESCRIPTION
This PR makes the parser setting `jsx` option by filename automatically.

- `*.ts` ... it sets `jsx: false`.
- `*.tsx` ... it sets `jsx: true`.
- Otherwise (E.g., `*.js`, not provided, etc...) ... respects the given `jsx` option.

(Edited at `2018-11-08 20:52Z`)

Fixes #517.