### PR TITLE
Breaking: make 'useJSXTextNode:true' by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The following additional configuration options are available by specifying them 
 
 **`jsx`** - default `false`. Enable parsing JSX when `true`. More details can be found [here](https://www.typescriptlang.org/docs/handbook/jsx.html).
 
-**`useJSXTextNode`** - default `true`. The JSX AST changed the node type for string literals inside a JSX Element from `Literal` to `JSXText`. When value is `true`, these nodes will be parsed as type `JSXText`. When value is `false`, these nodes will be parsed as type `Literal`. Please set `false` if you use this parser on ESLint v4.
+**`useJSXTextNode`** - default `true`. Please set `false` if you use this parser on ESLint v4. If this is `false`, the parser creates the AST of JSX texts as the legacy style.
 
 ### .eslintrc.json
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The following additional configuration options are available by specifying them 
 
 **`jsx`** - default `false`. Enable parsing JSX when `true`. More details can be found [here](https://www.typescriptlang.org/docs/handbook/jsx.html).
 
-**`useJSXTextNode`** - default `false`. The JSX AST changed the node type for string literals inside a JSX Element from `Literal` to `JSXText`. When value is `true`, these nodes will be parsed as type `JSXText`. When value is `false`, these nodes will be parsed as type `Literal`.
+**`useJSXTextNode`** - default `true`. The JSX AST changed the node type for string literals inside a JSX Element from `Literal` to `JSXText`. When value is `true`, these nodes will be parsed as type `JSXText`. When value is `false`, these nodes will be parsed as type `Literal`. Please set `false` if you use this parser on ESLint v4.
 
 ### .eslintrc.json
 

--- a/parser.js
+++ b/parser.js
@@ -20,6 +20,12 @@ const visitorKeys = require("./visitor-keys");
 exports.version = require("./package.json").version;
 
 exports.parseForESLint = function parseForESLint(code, options) {
+    if (typeof options !== "object" || options === null) {
+        options = { useJSXTextNode: true };
+    } else if (typeof options.useJSXTextNode !== "boolean") {
+        options = Object.assign({}, options, { useJSXTextNode: true });
+    }
+
     const ast = parse(code, options);
     traverser.traverse(ast, {
         enter: node => {

--- a/tests/lib/__snapshots__/comments.js.snap
+++ b/tests/lib/__snapshots__/comments.js.snap
@@ -1219,7 +1219,7 @@ Object {
                         ],
                         "raw": "
             ",
-                        "type": "Literal",
+                        "type": "JSXText",
                         "value": "
             ",
                       },
@@ -1274,7 +1274,7 @@ Object {
                         ],
                         "raw": "
         ",
-                        "type": "Literal",
+                        "type": "JSXText",
                         "value": "
         ",
                       },
@@ -1960,7 +1960,7 @@ Object {
                         ],
                         "raw": "
         ",
-                        "type": "Literal",
+                        "type": "JSXText",
                         "value": "
         ",
                       },


### PR DESCRIPTION
This PR makes the parser `useJSXTextNode: true` by default because the current ESLint assumes so.

And add a note to README.md: "Please set `false` if you use this parser on ESLint v4."