### PR TITLE
Fix: wrong reference on TSQualifiedName (fixes #550)

### DIFF
--- a/analyze-scope.js
+++ b/analyze-scope.js
@@ -385,6 +385,15 @@ class Referencer extends OriginalReferencer {
     }
 
     /**
+     * Create reference objects for the object part. (This is `obj.prop`)
+     * @param {TSTypeQuery} node The TSTypeQuery node to visit.
+     * @returns {void}
+     */
+    TSQualifiedName(node) {
+        this.visit(node.left);
+    }
+
+    /**
      * Create reference objects for the references in computed keys.
      * @param {TSPropertySignature} node The TSPropertySignature node to visit.
      * @returns {void}

--- a/tests/lib/scope-analysis.js
+++ b/tests/lib/scope-analysis.js
@@ -351,4 +351,23 @@ export default class ListModalStore {
 
         expect(messages).toStrictEqual([]);
     });
+
+    test("https://github.com/eslint/typescript-eslint-parser/issues/550", () => {
+        const code = `
+function test(file: Blob) {
+  const slice: typeof file.slice =
+    file.slice || (file as any).webkitSlice || (file as any).mozSlice
+  return slice
+}
+`;
+        const config = {
+            parser: "typescript-eslint-parser",
+            rules: {
+                "no-use-before-define": "error"
+            }
+        };
+        const messages = linter.verify(code, config, { filename: "issue.ts" });
+
+        expect(messages).toStrictEqual([]);
+    });
 });


### PR DESCRIPTION
This PR fixes #550.

The `typeof file.slice` created two references `file` and `slice`, but it's incorrect. This PR makes the referencer creating only a reference `file`.