### PR TITLE
Fix: make no-unused-vars not reporting enum members

### DIFF
--- a/analyze-scope.js
+++ b/analyze-scope.js
@@ -498,6 +498,11 @@ class Referencer extends OriginalReferencer {
         const scope = this.currentScope();
 
         scope.__define(id, new Definition("EnumMemberName", id, node));
+
+        // Set `eslintUsed` flag to the defined variable because the enum member is obviously exported.
+        const variable = scope.set.get(id.name);
+        variable.eslintUsed = true;
+
         if (initializer) {
             scope.__referencing(
                 id,

--- a/tests/lib/__snapshots__/scope-analysis.js.snap
+++ b/tests/lib/__snapshots__/scope-analysis.js.snap
@@ -2441,7 +2441,7 @@ Object {
               "type": "EnumMemberName",
             },
           ],
-          "eslintUsed": undefined,
+          "eslintUsed": true,
           "identifiers": Array [
             Object {
               "name": "A",
@@ -2488,7 +2488,7 @@ Object {
               "type": "EnumMemberName",
             },
           ],
-          "eslintUsed": undefined,
+          "eslintUsed": true,
           "identifiers": Array [
             Object {
               "name": "B",
@@ -2535,7 +2535,7 @@ Object {
               "type": "EnumMemberName",
             },
           ],
-          "eslintUsed": undefined,
+          "eslintUsed": true,
           "identifiers": Array [
             Object {
               "name": "C",
@@ -2790,7 +2790,7 @@ Object {
               "type": "EnumMemberName",
             },
           ],
-          "eslintUsed": undefined,
+          "eslintUsed": true,
           "identifiers": Array [
             Object {
               "name": "BAR",

--- a/tests/lib/scope-analysis.js
+++ b/tests/lib/scope-analysis.js
@@ -370,4 +370,22 @@ function test(file: Blob) {
 
         expect(messages).toStrictEqual([]);
     });
+
+    test("https://github.com/eslint/typescript-eslint-parser/issues/553", () => {
+        const code = `
+enum Foo {
+    BAR = 'bar'
+}
+Foo
+`;
+        const config = {
+            parser: "typescript-eslint-parser",
+            rules: {
+                "no-unused-vars": "error"
+            }
+        };
+        const messages = linter.verify(code, config, { filename: "issue.ts" });
+
+        expect(messages).toStrictEqual([]);
+    });
 });


### PR DESCRIPTION
This is a small followup for #553.

Currently, `no-unused-vars` rule reports enum members.

```ts
enum E {
    FOO //→ 'FOO' is assigned a value but never used.
}
```

This behavior is not nice.

This PR makes to set `eslintUsed` flag to the enum member variables, as similar to `/* exported */` directive comments. As a result, `no-unused-vars` knows the enum members are exported (used on other places).