### PR TITLE
Upgrade: typescript-estree ^5.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "eslint-scope": "^4.0.0",
     "eslint-visitor-keys": "^1.0.0",
-    "typescript-estree": "5.3.0"
+    "typescript-estree": "^5.3.0"
   },
   "devDependencies": {
     "eslint": "^4.19.1",


### PR DESCRIPTION
This PR updates typescript-estree to the most recent release. Of note is this addition: https://github.com/JamesHenry/typescript-estree/commit/8787f16b92ba1bf890c4a52cba3ffec625b6d4ba

Is there a reason we want to lock the version? It seems like we should be able to use `^`, as the project follows semver.
