### PR TITLE
Fix: issue with global augmentation when tokens are not present

### DIFF
--- a/analyze-scope.js
+++ b/analyze-scope.js
@@ -9,38 +9,7 @@ const Reference = require("eslint-scope/lib/reference");
 const OriginalReferencer = require("eslint-scope/lib/referencer");
 const Scope = require("eslint-scope/lib/scope").Scope;
 const fallback = require("eslint-visitor-keys").getKeys;
-const lodash = require("lodash");
 const childVisitorKeys = require("./visitor-keys");
-
-/**
- * Get `.range[0]` of a given object.
- * @param {{range: number[]}} x The object to get.
- * @returns {number} The gotten value.
- */
-function byRange0(x) {
-    return x.range[0];
-}
-
-/**
- * Check the TSModuleDeclaration node is `declare global {}` or not.
- * @param {TSModuleDeclaration} node The TSModuleDeclaration node to check.
- * @param {Token[]} tokens The token list.
- * @returns {boolean} `true` if the node is `declare global {}`.
- */
-function isGlobalAugmentation(node, tokens) {
-    const i = lodash.sortedIndexBy(tokens, node, byRange0);
-    const token1 = tokens[i];
-    const token2 = tokens[i + 1];
-
-    return Boolean(
-        token1 &&
-        token2 &&
-        (token1.type === "Keyword" || token1.type === "Identifier") &&
-        token1.value === "declare" &&
-        (token2.type === "Keyword" || token2.type === "Identifier") &&
-        token2.value === "global"
-    );
-}
 
 /**
  * Define the override function of `Scope#__define` for global augmentation.
@@ -570,12 +539,10 @@ class Referencer extends OriginalReferencer {
      * @returns {void}
      */
     TSModuleDeclaration(node) {
-        const astRoot = this.scopeManager.globalScope.block;
         const scope = this.currentScope();
         const { id, body } = node;
 
-        // https://github.com/JamesHenry/typescript-estree/issues/27
-        if (isGlobalAugmentation(node, astRoot.tokens)) {
+        if (node.global) {
             this.visitGlobalAugmentation(node);
             return;
         }

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
   "dependencies": {
     "eslint-scope": "^4.0.0",
     "eslint-visitor-keys": "^1.0.0",
-    "lodash": "^4.17.11",
-    "typescript-estree": "5.0.0"
+    "typescript-estree": "5.3.0"
   },
   "devDependencies": {
     "eslint": "^4.19.1",

--- a/parser.js
+++ b/parser.js
@@ -41,7 +41,7 @@ exports.parseForESLint = function parseForESLint(code, options) {
     traverser.traverse(ast, {
         enter: node => {
             switch (node.type) {
-                // Just for backword compatibility.
+                // Just for backward compatibility.
                 case "DeclareFunction":
                     if (!node.body) {
                         node.type = `TSEmptyBody${node.type}`;
@@ -58,7 +58,7 @@ exports.parseForESLint = function parseForESLint(code, options) {
 
                 // Import/Export declarations cannot appear in script.
                 // But if those appear only in namespace/module blocks, `ast.sourceType` was `"script"`.
-                // This doesn't modify `ast.sourceType` directly for backrard compatibility.
+                // This doesn't modify `ast.sourceType` directly for backward compatibility.
                 case "ImportDeclaration":
                 case "ExportAllDeclaration":
                 case "ExportDefaultDeclaration":


### PR DESCRIPTION
This PR solves issue with: https://github.com/eslint/typescript-eslint-parser/issues/570

i had to upgrade `typescript-estree` to latest version with solution for https://github.com/JamesHenry/typescript-estree/issues/27

additionally lodash is no longer used in project