### PR TITLE
Fix: Allow to visit typeParameters in VariableDeclarator

### DIFF
--- a/tests/fixtures/scope-analysis/type-generic.ts
+++ b/tests/fixtures/scope-analysis/type-generic.ts
@@ -1,0 +1,1 @@
+type foo<A> = Foo<A>

--- a/tests/lib/__snapshots__/scope-analysis.js.snap
+++ b/tests/lib/__snapshots__/scope-analysis.js.snap
@@ -5690,6 +5690,31 @@ Object {
 }
 `;
 
+exports[`TypeScript scope analysis tests/fixtures/scope-analysis/type-generic.ts 1`] = `
+Object {
+  "$id": 0,
+  "block": Object {
+    "range": Array [
+      0,
+      21,
+    ],
+    "type": "Program",
+  },
+  "childScopes": Array [],
+  "functionExpressionScope": false,
+  "isStrict": false,
+  "references": Array [],
+  "throughReferences": Array [],
+  "type": "global",
+  "upperScope": null,
+  "variableMap": Object {},
+  "variableScope": Object {
+    "$ref": 0,
+  },
+  "variables": Array [],
+}
+`;
+
 exports[`TypeScript scope analysis tests/fixtures/scope-analysis/typeof.ts 1`] = `
 Object {
   "$id": 3,

--- a/visitor-keys.js
+++ b/visitor-keys.js
@@ -21,6 +21,8 @@ module.exports = Evk.unionWith({
     ObjectPattern: ["properties", "typeAnnotation"],
     NewExpression: ["callee", "typeParameters", "arguments"],
     CallExpression: ["callee", "typeParameters", "arguments"],
+    // typeParameters are preset only when kind='type'
+    VariableDeclarator: ["id", "typeParameters", "init"],
 
     // Additional Nodes.
     ClassProperty: ["decorators", "key", "typeAnnotation", "value"],

--- a/visitor-keys.js
+++ b/visitor-keys.js
@@ -21,7 +21,7 @@ module.exports = Evk.unionWith({
     ObjectPattern: ["properties", "typeAnnotation"],
     NewExpression: ["callee", "typeParameters", "arguments"],
     CallExpression: ["callee", "typeParameters", "arguments"],
-    // typeParameters are preset only when kind='type'
+    // typeParameters are present only when kind='type'
     VariableDeclarator: ["id", "typeParameters", "init"],
 
     // Additional Nodes.


### PR DESCRIPTION
This PR adds `typeParameters` to VariableDeclarator

`typeParameters` can be only present if `kind=type`