### PR TITLE
Test: Add alignment test for visitor-keys

### DIFF
--- a/tests/lib/visitor-keys.js
+++ b/tests/lib/visitor-keys.js
@@ -35,9 +35,7 @@ describe("visitor-keys", () => {
 
     test("check if there is no deprecated TS nodes", () => {
         const TSTypes = Object.keys(visitorKeys).filter(type => type.startsWith("TS"));
-        expect(astTypes).toEqual(
-            expect.arrayContaining(TSTypes),
-        );
+        expect(astTypes).toEqual(expect.arrayContaining(TSTypes));
     });
 
 });

--- a/tests/lib/visitor-keys.js
+++ b/tests/lib/visitor-keys.js
@@ -1,0 +1,43 @@
+/**
+ * @fileoverview Tests for visitor-keys alignment
+ * @author Armano <https://github.com/armano2>
+ * @copyright JS Foundation and other contributors, https://js.foundation//
+ * MIT License
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const { AST_NODE_TYPES } = require("typescript-estree/dist/ast-node-types");
+const visitorKeys = require("../../visitor-keys");
+
+//------------------------------------------------------------------------------
+// Setup
+//------------------------------------------------------------------------------
+
+const astTypes = Object.keys(AST_NODE_TYPES);
+astTypes.push("TSEmptyBodyFunctionExpression"); // node created by parser.js
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("visitor-keys", () => {
+
+    for (const type of astTypes) {
+        test(`type ${type} should be present in visitor-keys`, () => {
+            expect(visitorKeys).toHaveProperty(type);
+        });
+    }
+
+    test("check if there is no deprecated TS nodes", () => {
+        const TSTypes = Object.keys(visitorKeys).filter(type => type.startsWith("TS"));
+        expect(astTypes).toEqual(
+            expect.arrayContaining(TSTypes),
+        );
+    });
+
+});


### PR DESCRIPTION
This PR adds test to check if all nodes provided by typescript-estree are supported.

currently we are not supporting:
- Import
- JSXClosingFragment
- JSXOpeningFragment
- JSXSpreadChild